### PR TITLE
Added simplified chinese language

### DIFF
--- a/bookworm/resources/locale/zh_CN/LC_MESSAGES/bookworm.po
+++ b/bookworm/resources/locale/zh_CN/LC_MESSAGES/bookworm.po
@@ -1,0 +1,2042 @@
+# Arabic translations for Bookworm.
+# Copyright (C) 2019 Musharraf Omer
+# This file is distributed under the same license as the Bookworm project.
+# Musharraf Omer <ibnomer2011@hotmail.com>, 2019.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: 0.1\n"
+"Report-Msgid-Bugs-To: ibnomer2011@hotmail.com\n"
+"POT-Creation-Date: 2020-08-08 18:02+0200\n"
+"PO-Revision-Date: 2020-08-24 15:36+0800\n"
+"Last-Translator: Musharraf Omer <ibnomer2011@hotmail.com>\n"
+"Language-Team: Rowen <manchen_0528@outlook.com>\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.7.0\n"
+"X-Generator: Poedit 2.4\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+#. Translators: the content of a message indicating a connection error
+#: bookworm/otau.py:97
+msgid "We couldn't access the internet right now. Please try again later."
+msgstr "当前无法连接网络，请稍后再试。"
+
+#. Translators: the title of a message indicating a connection error
+#. Translators: the title of a message indicating a failure in downloading an
+#. update
+#: bookworm/otau.py:99 bookworm/otau.py:173
+msgid "Network Error"
+msgstr "网络错误"
+
+#. Translators: the content of a message indicating an error while updating the
+#. app
+#: bookworm/otau.py:111
+msgid ""
+"We have faced a technical problem while checking for updates. Please try "
+"again later."
+msgstr "在检查更新时遇到了问题。请稍后再试。"
+
+#. Translators: the title of a message indicating an error while updating the
+#. app
+#: bookworm/otau.py:115
+msgid "Error Checking For Updates"
+msgstr "检查更新出错"
+
+#. Translators: the content of a message indicating that there is no new
+#. version
+#: bookworm/otau.py:128
+msgid ""
+"Congratulations, you have already got the latest version of Bookworm.\n"
+"We are working day and night on making Bookworm better. The next version of "
+"Bookworm is on its way, so wait for it. Rest assured, we will notify you "
+"when it is released."
+msgstr ""
+"恭喜，您的Bookworm已更新到最新版。\n"
+"\n"
+"我们正在不停地努力使Bookworm变得更好。下一个版本的Bookworm即将推出，请耐心等"
+"待。我们会在发布新版时通知您。"
+
+#. Translators: the title of a message indicating that there is no new version
+#: bookworm/otau.py:135
+msgid "No Update"
+msgstr "当前已是最新版"
+
+#. Translators: the content of a message indicating the availability of an
+#. update
+#: bookworm/otau.py:143
+msgid ""
+"A new update for Bookworm has been released.\n"
+"Would you like to download and install it?\n"
+"\tInstalled Version: {current}\n"
+"\tNew Version: {new}\n"
+msgstr ""
+"Bookworm的新版本已发布。\n"
+"您要下载并安装吗？\n"
+"\t已安装的版本：{current}\n"
+"\t新版本：{new}\n"
+
+#. Translators: the title of a message indicating the availability of an update
+#: bookworm/otau.py:150
+msgid "Update Available"
+msgstr "有可用更新"
+
+#. Translators: the content of a message indicating a failure in downloading an
+#. update
+#: bookworm/otau.py:167
+msgid ""
+"A network error was occured when trying to download the update.\n"
+"Make sure you are connected to the internet, or try again at a later time."
+msgstr ""
+"尝试下载更新时发生网络错误。\n"
+"请确保您已连接到网络，或稍后再试。"
+
+#. Translators: the title of a message indicating the progress of downloading
+#. an update
+#: bookworm/otau.py:180
+msgid "Downloading Update"
+msgstr "更新下载中"
+
+#. Translators: a message indicating the progress of downloading an update
+#. bundle
+#: bookworm/otau.py:182
+msgid "Downloading {url}:"
+msgstr "下载中 {url}:"
+
+#. Translators: a message indicating the progress of downloading an update
+#. bundle
+#: bookworm/otau.py:191
+msgid "Downloading. {downloaded} MB of {total} MB"
+msgstr "正在下载. {downloaded} MB 共 {total} MB"
+
+#. Translators: the content of a message indicating a corrupted file
+#: bookworm/otau.py:207
+msgid ""
+"The update file has been downloaded, but it has been corrupted during "
+"download.\n"
+"Would you like to download the update file again?"
+msgstr ""
+"更新文件已下载，但在下载过程中已损坏。\n"
+"您要重新下载吗？"
+
+#. Translators: the title of a message indicating a corrupted file
+#: bookworm/otau.py:212
+msgid "Download Error"
+msgstr "下载错误"
+
+#. Translators: the content of a message indicating successful download of the
+#. update bundle
+#: bookworm/otau.py:223
+msgid ""
+"The update has been downloaded successfully, and it is ready to be "
+"installed.\n"
+"The application will be restarted in order to complete the update process.\n"
+"Click the OK button to continue."
+msgstr ""
+"更新已成功下载，可以安装了。\n"
+"软件将重新启动以完成此更新过程。\n"
+"单击“确定”按钮继续。"
+
+#. Translators: the title of a message indicating successful download of the
+#. update bundle
+#: bookworm/otau.py:229
+msgid "Download Completed"
+msgstr "下载完成"
+
+#. Translators: the title of a message shown when extracting an update bundle
+#: bookworm/otau.py:234
+msgid "Extracting Update Bundle"
+msgstr "解压更新包"
+
+#. Translators: a message shown when extracting an update bundle
+#: bookworm/otau.py:236
+msgid "Please wait..."
+msgstr "请稍候..."
+
+#. Translators: the title of a message shown
+#. when the format of the e-book is not supported
+#: bookworm/reader.py:66
+msgid "Unsupported Document Format"
+msgstr "不支持的文件格式"
+
+#. Translators: the content of a message shown
+#. when the format of the e-book is not supported
+#: bookworm/reader.py:69
+msgid "The format of the given document is not supported by Bookworm."
+msgstr "Bookworm不支持该文档格式。"
+
+#. Translators: the title of an error message
+#: bookworm/reader.py:80
+msgid "Error Openning Document"
+msgstr "打开文档时出错"
+
+#. Translators: the content of an error message
+#: bookworm/reader.py:82
+msgid ""
+"Could not open file {file}\n"
+".Either the file  has been damaged during download, or it has been corrupted "
+"in some other way."
+msgstr ""
+"无法打开文件{file} \n"
+"\n"
+"。文件在下载过程中已损坏，或已通过其他方式损坏。"
+
+#. Translators: the label of the page content text area
+#: bookworm/reader.py:160
+msgid "Page {page} | {chapter}"
+msgstr "第 {page} 页 | {chapter}"
+
+#. Translators: a message that is announced after navigating to a page
+#. Translators: a message to announce when navigating to another page
+#: bookworm/reader.py:164 bookworm/text_to_speech/__init__.py:183
+msgid "Page {page} of {total}"
+msgstr "第{page}页，共{total}页。"
+
+#. Translators: the title of the window when an e-book is open
+#: bookworm/reader.py:241
+msgid "{title} â€” by {author}"
+msgstr "{title} — by {author}"
+
+#: bookworm/annotation/__init__.py:51
+msgid "&Bookmark...\tCtrl-B"
+msgstr "书签(&B)... \tCtrl-B"
+
+#: bookworm/annotation/__init__.py:52
+msgid "Bookmark the current location"
+msgstr "在当前位置添加书签"
+
+#: bookworm/annotation/__init__.py:57
+msgid "Co&mment...\tCtrl-m"
+msgstr "注释... \tCtrl-m"
+
+#: bookworm/annotation/__init__.py:58
+msgid "Add a comment at the current location"
+msgstr "在当前位置添加注释"
+
+#: bookworm/annotation/__init__.py:68
+msgid "Highlight Selection\tCtrl-Shift-H"
+msgstr "高亮显示选择 \tCtrl-Shift-H"
+
+#: bookworm/annotation/__init__.py:69
+msgid "Highlight and save selected text."
+msgstr "高亮显示并保存所选文本。"
+
+#. Translators: the label of a button in the application toolbar
+#: bookworm/annotation/__init__.py:78
+msgid "Bookmark"
+msgstr "书签"
+
+#. Translators: the label of a button in the application toolbar
+#: bookworm/annotation/__init__.py:80
+msgid "Comment"
+msgstr "注释"
+
+#. Translators: the label of a page in the settings dialog
+#: bookworm/annotation/__init__.py:90
+#: bookworm/annotation/annotation_dialogs.py:414
+msgid "Annotation"
+msgstr "注解(&A)"
+
+#. Translators: the label of the text area which shows the
+#. content of the current page
+#: bookworm/annotation/annotation_dialogs.py:61
+#: bookworm/annotation/annotation_dialogs.py:249
+#: bookworm/gui/book_viewer/__init__.py:82
+msgid "Content"
+msgstr "内容"
+
+#: bookworm/annotation/annotation_dialogs.py:64
+msgid "Metadata"
+msgstr "元数据"
+
+#: bookworm/annotation/annotation_dialogs.py:66
+#: bookworm/annotation/annotation_dialogs.py:466
+msgid "Tags"
+msgstr "标签"
+
+#: bookworm/annotation/annotation_dialogs.py:70
+msgid "Date Created"
+msgstr "创建日期"
+
+#: bookworm/annotation/annotation_dialogs.py:75
+msgid "Last updated"
+msgstr "最近更新时间"
+
+#. Translators: the label of a button to close the dialog
+#: bookworm/annotation/annotation_dialogs.py:89
+#: bookworm/annotation/annotation_dialogs.py:144 bookworm/gui/settings.py:86
+#: bookworm/text_to_speech/tts_gui.py:324
+msgid "&Close"
+msgstr "关闭(&C)"
+
+#. Translators: label for unnamed bookmarks
+#: bookworm/annotation/annotation_dialogs.py:123
+msgid "(Unnamed)"
+msgstr "(未命名)"
+
+#: bookworm/annotation/annotation_dialogs.py:127
+msgid "Saved Bookmarks"
+msgstr "保存书签"
+
+#. Translators: the label of a button to remove a voice profile
+#: bookworm/annotation/annotation_dialogs.py:129
+#: bookworm/text_to_speech/tts_gui.py:318
+msgid "&Remove"
+msgstr "删除(&R)"
+
+#. Translators: the title of a column in the bookmarks list
+#. Translators: the content of a message asking the user to delete a bookmark
+#: bookworm/annotation/annotation_dialogs.py:205
+msgid ""
+"This action can not be reverted.\r\n"
+"Are you sure you want to remove this bookmark?"
+msgstr ""
+"此操作无法还原。\n"
+"您确定要删除该书签吗？"
+
+#. Translators: the title of a message asking the user to delete a bookmark
+#: bookworm/annotation/annotation_dialogs.py:209
+msgid "Remove Bookmark?"
+msgstr "删除书签？"
+
+#. Translators: the header of the filtering controls in the annotations viewer
+#: bookworm/annotation/annotation_dialogs.py:236
+#: bookworm/annotation/annotation_dialogs.py:330
+msgid "Book"
+msgstr "书籍"
+
+#: bookworm/annotation/annotation_dialogs.py:240
+msgid "Tag"
+msgstr "标签"
+
+#. Translators: the title of a column in the search results list
+#. showing the title of the chapter in which this occurrence was found
+#: bookworm/annotation/annotation_dialogs.py:245
+#: bookworm/gui/book_viewer/core_dialogs.py:52
+msgid "Section"
+msgstr "章节"
+
+#: bookworm/annotation/annotation_dialogs.py:253
+msgid "&Apply"
+msgstr "应用(&A)"
+
+#: bookworm/annotation/annotation_dialogs.py:313
+msgid "Filter By"
+msgstr "过滤"
+
+#: bookworm/annotation/annotation_dialogs.py:321
+msgid "Sort By"
+msgstr "排序方式"
+
+#: bookworm/annotation/annotation_dialogs.py:326
+msgid "Date"
+msgstr "日期"
+
+#. Translators: the title of a column in the search results list
+#. Translators: the label of the image of a page in a dialog to render the
+#. current page
+#: bookworm/annotation/annotation_dialogs.py:327
+#: bookworm/gui/book_viewer/core_dialogs.py:38
+#: bookworm/gui/book_viewer/render_view.py:54
+msgid "Page"
+msgstr "页"
+
+#: bookworm/annotation/annotation_dialogs.py:335
+msgid "Ascending"
+msgstr "上升"
+
+#: bookworm/annotation/annotation_dialogs.py:343
+msgid "&View..."
+msgstr "查看(&V)"
+
+#. Translators: the label of a button to edit a voice profile
+#: bookworm/annotation/annotation_dialogs.py:345
+#: bookworm/text_to_speech/tts_gui.py:316
+msgid "&Edit..."
+msgstr "编辑(&E)"
+
+#: bookworm/annotation/annotation_dialogs.py:347
+msgid "&Delete..."
+msgstr "删除(&D)..."
+
+#: bookworm/annotation/annotation_dialogs.py:348
+msgid "E&xport..."
+msgstr "导出(&E)"
+
+#: bookworm/annotation/annotation_dialogs.py:428
+msgid ""
+"This action can not be reverted.\r\n"
+"Are you sure you want to remove this item?"
+msgstr ""
+"此操作无法还原。\n"
+"您确定要删除该项吗？"
+
+#: bookworm/annotation/annotation_dialogs.py:431
+msgid "Delete Annotation?"
+msgstr "删除注释？"
+
+#: bookworm/annotation/annotation_dialogs.py:466
+msgid "Edit Tags"
+msgstr "编辑标签"
+
+#: bookworm/annotation/annotation_dialogs.py:474
+msgid "Export Options"
+msgstr "导出选项"
+
+#: bookworm/annotation/annotation_dialogs.py:513
+msgid ""
+"Could not find eBook file. The file has been renamed, moved, or deleted."
+msgstr "找不到电子书文件。该文件可能已被重命名，移动或删除。"
+
+#: bookworm/annotation/annotation_dialogs.py:516
+msgid "Could not open eBook"
+msgstr "无法打开电子书"
+
+#: bookworm/annotation/annotation_dialogs.py:538
+msgid "Include book title"
+msgstr "包含书名"
+
+#: bookworm/annotation/annotation_dialogs.py:540
+msgid "Include section title"
+msgstr "包括章节标题"
+
+#: bookworm/annotation/annotation_dialogs.py:543
+msgid "Include  page number"
+msgstr "包含页码"
+
+#: bookworm/annotation/annotation_dialogs.py:545
+msgid "Include tags"
+msgstr "包含标签"
+
+#: bookworm/annotation/annotation_dialogs.py:546
+msgid "Output format:"
+msgstr "输出格式："
+
+#: bookworm/annotation/annotation_dialogs.py:550
+msgid "Output File"
+msgstr "输出文件"
+
+#: bookworm/annotation/annotation_dialogs.py:554
+msgid "&Browse"
+msgstr "浏览(&B)"
+
+#. Translators: the label of a checkbox
+#: bookworm/annotation/annotation_dialogs.py:559
+msgid "Open file after exporting"
+msgstr "导出后打开文件"
+
+#. Translators: the title of a save file dialog asking the user for a filename
+#. to export notes to
+#. Translators: the title of a dialog to save the exported book
+#: bookworm/annotation/annotation_dialogs.py:586
+#: bookworm/gui/book_viewer/menubar.py:159
+msgid "Save As"
+msgstr "另存为"
+
+#. Translators: the title of a group of controls in the
+#: bookworm/annotation/annotation_gui.py:30
+msgid "Annotations"
+msgstr "注解"
+
+#. Translators: the label of a checkbox
+#: bookworm/annotation/annotation_gui.py:35
+msgid "Use visual styles to indicate annotations"
+msgstr "使用视觉样式显示注释"
+
+#. Translators: the label of a checkbox
+#: bookworm/annotation/annotation_gui.py:42
+msgid "Use sounds to indicate the presence of comments"
+msgstr "使用音效提示包含注释"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/annotation/annotation_gui.py:93
+msgid "Add &Bookmark\tCtrl-B"
+msgstr "添加书签(&B)... \tCtrl-B"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/annotation/annotation_gui.py:95
+msgid "Add a bookmark at the current position"
+msgstr "在当前位置添加书签"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/annotation/annotation_gui.py:100
+msgid "Add &Named Bookmark...\tCtrl-Shift-B"
+msgstr "查看书签(&V)... \tCtrl-Shift-B"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/annotation/annotation_gui.py:102
+msgid "Add a named bookmark at the current position"
+msgstr "在当前位置添加并命名书签"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/annotation/annotation_gui.py:107
+msgid "Add Co&mment...\tCtrl-M"
+msgstr "添加注释(&M)... \tCtrl-M"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/annotation/annotation_gui.py:109
+msgid "Add a comment at the current position"
+msgstr "在当前位置添加注释"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/annotation/annotation_gui.py:114
+msgid "&Highlight Selection\tCtrl-H"
+msgstr "高亮显示选择 \tCtrl-H"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/annotation/annotation_gui.py:116
+msgid "Highlight selected text and save it."
+msgstr "高亮显示所选文本并保存。"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/annotation/annotation_gui.py:121
+msgid "Saved &Bookmarks..."
+msgstr "已保存的书签..."
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/annotation/annotation_gui.py:123
+msgid "View added bookmarks"
+msgstr "查看已添加的书签"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/annotation/annotation_gui.py:128
+msgid "Saved Co&mments..."
+msgstr "保存注释..."
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/annotation/annotation_gui.py:130
+msgid "View, edit, and remove comments."
+msgstr "查看，编辑和删除笔记。"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/annotation/annotation_gui.py:135
+msgid "Saved &Highlights..."
+msgstr "保存高亮显示..."
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/annotation/annotation_gui.py:137
+msgid "View saved highlights."
+msgstr "查看已保存的高亮显示。"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/annotation/annotation_gui.py:141
+msgid "&Annotations"
+msgstr "注解(&A)"
+
+#. Translators: spoken message
+#: bookworm/annotation/annotation_gui.py:179
+msgid "Bookmark Added"
+msgstr "书签已添加"
+
+#. Translators: title of a dialog
+#: bookworm/annotation/annotation_gui.py:188
+msgid "Add Named Bookmark"
+msgstr "命名书签"
+
+#. Translators: label of a text entry
+#: bookworm/annotation/annotation_gui.py:190
+msgid "Bookmark name:"
+msgstr "书签名称"
+
+#. Translators: the title of a dialog to add a comment
+#: bookworm/annotation/annotation_gui.py:200
+msgid "New Comment"
+msgstr "添加注释"
+
+#. Translators: the label of an edit field to enter a comment
+#: bookworm/annotation/annotation_gui.py:202
+msgid "Comment:"
+msgstr "注释"
+
+#. Translators: title of a dialog
+#: bookworm/annotation/annotation_gui.py:215
+msgid "Tag Comment"
+msgstr "标签注释"
+
+#. Translators: label of a text entry
+#: bookworm/annotation/annotation_gui.py:217
+#: bookworm/annotation/annotation_gui.py:264
+msgid "Tags:"
+msgstr "标签："
+
+#: bookworm/annotation/annotation_gui.py:229
+msgid "No selection"
+msgstr "无章节"
+
+#. Translators: spoken message
+#: bookworm/annotation/annotation_gui.py:237
+msgid "Highlight removed"
+msgstr "高亮显示已删除"
+
+#. Translators: spoken message
+#: bookworm/annotation/annotation_gui.py:240
+msgid "Already highlighted"
+msgstr "已高亮显示"
+
+#. Translators: spoken message
+#: bookworm/annotation/annotation_gui.py:247
+#: bookworm/annotation/annotation_gui.py:253
+msgid "Highlight extended"
+msgstr "高亮扩展"
+
+#. Translators: spoken message
+#. Translators: title of a dialog
+#: bookworm/annotation/annotation_gui.py:262
+msgid "Tag Highlight"
+msgstr "标签高亮"
+
+#. Translators: the title of a dialog to view bookmarks
+#: bookworm/annotation/annotation_gui.py:277
+msgid "Bookmarks | {book}"
+msgstr "书签 | {book}"
+
+#: bookworm/annotation/annotation_gui.py:287
+msgid "Comments"
+msgstr "注释"
+
+#: bookworm/annotation/annotation_gui.py:300
+msgid "Highlights"
+msgstr "高亮"
+
+#. Translators: the name of a document file format
+#. Translators: a name of a file format
+#: bookworm/annotation/exporters/core_renderers.py:14
+#: bookworm/gui/book_viewer/menubar.py:163
+msgid "Plain Text"
+msgstr "纯文本"
+
+#: bookworm/annotation/exporters/core_renderers.py:25
+msgid "Section: {}"
+msgstr "章节： {}"
+
+#: bookworm/annotation/exporters/core_renderers.py:28
+msgid "Tagged: {}"
+msgstr "标记为：{}"
+
+#. Translators: written to the end of the plain-text file when exporting
+#. comments or highlights
+#: bookworm/annotation/exporters/core_renderers.py:38
+msgid "End of File"
+msgstr "文件结束"
+
+#. Translators: page number as shown when exporting comments or highlights
+#: bookworm/annotation/exporters/core_renderers.py:48
+#: bookworm/annotation/exporters/core_renderers.py:121
+#: bookworm/gui/book_viewer/render_view.py:120
+msgid "Page {}"
+msgstr "页{}"
+
+#. Translators: the name of a document file format
+#: bookworm/annotation/exporters/core_renderers.py:70
+msgid "Markdown"
+msgstr "Markdown"
+
+#. Translators: written to output file when exporting comments or highlights
+#: bookworm/annotation/exporters/core_renderers.py:78
+msgid "Notes For {}"
+msgstr "笔记 | {book}"
+
+#: bookworm/annotation/exporters/core_renderers.py:87
+msgid "**Page {}**"
+msgstr "**第{}页**"
+
+#. Translators: the name of a document file format
+#: bookworm/annotation/exporters/core_renderers.py:98
+msgid "HTML"
+msgstr "HTML"
+
+#. Translators: used as a title for an html file when exporting comments or
+#. highlights
+#: bookworm/annotation/exporters/core_renderers.py:104
+msgid "Annotations â€” {}"
+msgstr "注释– {}"
+
+#. Translators: the name of a document file format
+#: bookworm/document_formats/mupdf.py:53
+msgid "Portable Document (PDF)"
+msgstr "便携式文件（PDF）"
+
+#. Translators: the name of a document file format
+#: bookworm/document_formats/mupdf.py:159
+msgid "Electronic Publication (EPUB)"
+msgstr "电子出版物（EPUB）"
+
+#. Translators: the name of a document file format
+#: bookworm/document_formats/plain_text.py:34
+msgid "Plain Text File"
+msgstr "纯文本"
+
+#. Translators: the title of a group of controls in the search dialog
+#: bookworm/gui/components.py:72
+msgid "Search Range"
+msgstr "搜索范围"
+
+#. Translators: the label of a radio button in the search dialog
+#: bookworm/gui/components.py:74
+msgid "Page Range"
+msgstr "页码范围"
+
+#. Translators: the label of an edit field in the search dialog
+#. to enter the page from which the search will start
+#: bookworm/gui/components.py:80
+msgid "From:"
+msgstr "从："
+
+#. Translators: the label of an edit field in the search dialog
+#. to enter the page number at which the search will stop
+#: bookworm/gui/components.py:86
+msgid "To:"
+msgstr "到："
+
+#. Translators: the label of a radio button in the search dialog
+#: bookworm/gui/components.py:91
+msgid "Specific section"
+msgstr "指定章节"
+
+#. Translators: the label of a combobox in the search dialog
+#. to choose the section to which the search will be confined
+#: bookworm/gui/components.py:94
+msgid "Select section:"
+msgstr "所选章节"
+
+#. Translators: the lable of the OK button in a dialog
+#: bookworm/gui/components.py:177 bookworm/gui/components.py:217
+#: bookworm/gui/settings.py:343
+msgid "OK"
+msgstr "确定(&O)"
+
+#. Translators: the lable of the cancel button in a dialog
+#: bookworm/gui/components.py:180 bookworm/gui/components.py:220
+#: bookworm/gui/settings.py:346
+msgid "Cancel"
+msgstr "取消(&C)"
+
+#. Translators: the title of the file associations dialog
+#: bookworm/gui/settings.py:35
+msgid "Bookworm File Associations"
+msgstr "Bookworm文件关联"
+
+#: bookworm/gui/settings.py:47
+msgid ""
+"This dialog will help you to setup file associations.\n"
+"Associating files with Bookworm means that when you click on a file in "
+"windows explorer, it will be opend in Bookworm by default "
+msgstr ""
+"此对话框可以帮助您设置文件关联。\n"
+"设置文件关联后，您在Windows资源管理器中单击文件时，默认将在Bookworm中直接打开"
+"该文件"
+
+#. Translators: the main label of a button
+#: bookworm/gui/settings.py:56
+msgid "Associate all"
+msgstr "全部关联"
+
+#. Translators: the note of a button
+#: bookworm/gui/settings.py:58
+msgid "Use Bookworm to open all supported ebook formats"
+msgstr "使用Bookworm打开所有支持的电子书格式"
+
+#. Translators: the main label of a button
+#: bookworm/gui/settings.py:62
+msgid "Associate files of type {format}"
+msgstr "关联类型为{format}的文件"
+
+#. Translators: the note of a button
+#: bookworm/gui/settings.py:64
+msgid "Associate files with {ext} extension so they always open in Bookworm"
+msgstr "将扩展名为{ext}的文件与Bookworm关联，以使他们在Bookworm中打开"
+
+#. Translators: the main label of a button
+#: bookworm/gui/settings.py:77
+msgid "Dissociate all supported file types"
+msgstr "取消所有支持文件类型的关联"
+
+#. Translators: the note of a button
+#: bookworm/gui/settings.py:79
+msgid "Unregister previously associated file types"
+msgstr "注销之前关联的文件类型"
+
+#. Translators: the text of a message indicating successful file association
+#: bookworm/gui/settings.py:96
+msgid "Files of type {format} have been associated with Bookworm."
+msgstr "{format}类型已与Bookworm关联。"
+
+#. Translators: the title of a message indicating successful file association
+#. Translators: the title of a message indicating successful removal of file
+#. association
+#: bookworm/gui/settings.py:100 bookworm/gui/settings.py:118
+msgid "Success"
+msgstr "成功"
+
+#. Translators: the text of a message indicating successful removal of file
+#. associations
+#: bookworm/gui/settings.py:109
+msgid "All supported file types have been set to open by default in Bookworm."
+msgstr "在Bookworm中，默认情况下将所有受支持的文件类型设置为打开。"
+
+#. Translators: the text of a message indicating successful removal of file
+#. associations
+#: bookworm/gui/settings.py:114
+msgid "All registered file associations have been removed."
+msgstr "已取消所有的文件关联"
+
+#. Translators: the title of a group of controls in the
+#. general settings page related to the UI
+#: bookworm/gui/settings.py:197
+msgid "User Interface"
+msgstr "用户界面"
+
+#. Translators: the label of a combobox containing display languages.
+#: bookworm/gui/settings.py:199
+msgid "Display Language:"
+msgstr "显示语言："
+
+#. Translators: the label of a checkbox
+#: bookworm/gui/settings.py:206
+msgid "Speak user interface messages"
+msgstr "读出用户介面信息"
+
+#. Translators: the label of a checkbox
+#: bookworm/gui/settings.py:213
+msgid "Open recently opened books from the last position"
+msgstr "最近阅读列表中打开书籍时跳转到上次阅读位置"
+
+#. Translators: the label of a checkbox
+#: bookworm/gui/settings.py:220
+msgid "Use file name instead of book title"
+msgstr "以文件名代替书籍名称"
+
+#. Translators: the title of a group of controls shown in the
+#. general settings page related to miscellaneous settings
+#: bookworm/gui/settings.py:225
+msgid "Miscellaneous"
+msgstr "杂项"
+
+#. Translators: the label of a checkbox
+#: bookworm/gui/settings.py:230
+msgid "Play pagination sound"
+msgstr "播放翻页音效"
+
+#. Translators: the label of a checkbox
+#: bookworm/gui/settings.py:237
+msgid "Automatically check for updates"
+msgstr "自动检测更新"
+
+#. Translators: the title of a group of controls shown in the
+#. general settings page related to file associations
+#: bookworm/gui/settings.py:243
+msgid "File Associations"
+msgstr "文件关联"
+
+#. Translators: the label of a button
+#: bookworm/gui/settings.py:248
+msgid "Manage File &Associations"
+msgstr "管理文件关联(&A)"
+
+#. Translators: the content of a message asking the user to restart
+#: bookworm/gui/settings.py:268
+msgid ""
+"You have changed the display language of Bookworm.\n"
+"For this setting to fully take effect, you need to restart the application.\n"
+"Would you like to restart the application right now?"
+msgstr ""
+"您更改了Bookworm的界面语言。\n"
+"为了使该设置生效，您需要重新启动应用程序。\n"
+"要立即重新启动应用程序吗？"
+
+#. Translators: the title of a message telling the user
+#. that the display language have been changed
+#: bookworm/gui/settings.py:275
+msgid "Language Changed"
+msgstr "语言已更改"
+
+#. Translators: the label of a page in the settings dialog
+#: bookworm/gui/settings.py:293
+msgid "General"
+msgstr "常规"
+
+#. Translators: the lable of the apply button in a dialog
+#: bookworm/gui/settings.py:348
+msgid "Apply"
+msgstr "应用(&A)"
+
+#. Translators: the text of the status bar when no book is currently open.
+#. It is being used also as a label for the page content text area when no book
+#. is opened.
+#: bookworm/gui/book_viewer/__init__.py:57
+msgid "Press (Ctrl + O) to open an ebook"
+msgstr "按（Ctrl + O）打开书籍"
+
+#. Translators: the label of the table-of-contents tree
+#: bookworm/gui/book_viewer/__init__.py:70
+msgid "Table of Contents"
+msgstr "目录"
+
+#. Translators: the label of a button in the application toolbar
+#: bookworm/gui/book_viewer/__init__.py:135
+msgid "Open"
+msgstr "打开"
+
+#. Translators: the label of a button in the application toolbar
+#: bookworm/gui/book_viewer/__init__.py:138
+msgid "Search"
+msgstr "搜索"
+
+#. Translators: the label of a button in the application toolbar
+#: bookworm/gui/book_viewer/__init__.py:140
+msgid "Go"
+msgstr "到"
+
+#. Translators: the label of a button in the application toolbar
+#: bookworm/gui/book_viewer/__init__.py:142
+msgid "View"
+msgstr "查看"
+
+#. Translators: the label of a button in the application toolbar
+#: bookworm/gui/book_viewer/__init__.py:145
+msgid "Big"
+msgstr "大"
+
+#. Translators: the label of a button in the application toolbar
+#: bookworm/gui/book_viewer/__init__.py:147
+msgid "Small"
+msgstr "小"
+
+#. Translators: the label of a button in the application toolbar
+#: bookworm/gui/book_viewer/__init__.py:150
+msgid "Settings"
+msgstr "设置"
+
+#. Translators: the content of an error message
+#: bookworm/gui/book_viewer/__init__.py:166
+msgid ""
+"Could not open file: {file}\n"
+"The file does not exist."
+msgstr ""
+"无法打开文件：{file} \n"
+"\n"
+"该文件不存在。"
+
+#. Translators: the title of an error message
+#: bookworm/gui/book_viewer/__init__.py:170
+msgid "File not found"
+msgstr "文件不存在"
+
+#. Translators: the content of a dialog asking the user
+#. for the password to decrypt the current e-book
+#: bookworm/gui/book_viewer/__init__.py:195
+msgid ""
+"This document is encrypted, and you need a password to access its content.\n"
+"Please enter the password billow and press enter."
+msgstr ""
+"该文档已加密，您需要输入密码才能查阅其内容。\n"
+"\n"
+"请输入密码，然后按Enter键。"
+
+#. Translators: the title of a dialog asking the user to enter a password to
+#. decrypt the e-book
+#. Translators: the content of a message
+#: bookworm/gui/book_viewer/__init__.py:206
+msgid ""
+"The password you've entered is invalid.\n"
+"Please try again."
+msgstr ""
+"您输入的密码无效。\n"
+"\n"
+"请再试一次。"
+
+#. Translators: the title of an error message
+#: bookworm/gui/book_viewer/__init__.py:208
+msgid "Invalid Password"
+msgstr "无效的密码"
+
+#. Translators: a message telling the user that the font size has been
+#. increased
+#: bookworm/gui/book_viewer/__init__.py:263
+msgid "The font size has been Increased"
+msgstr "增大字体"
+
+#. Translators: a message telling the user that the font size has been
+#. decreased
+#: bookworm/gui/book_viewer/__init__.py:269
+msgid "The font size has been decreased"
+msgstr "减小字体"
+
+#. Translators: a message telling the user that the font size has been reset
+#: bookworm/gui/book_viewer/__init__.py:273
+msgid "The font size has been reset"
+msgstr "重置字体"
+
+#. Translators: the label of a list of search results
+#: bookworm/gui/book_viewer/core_dialogs.py:34
+msgid "Search Results"
+msgstr "搜索结果"
+
+#. Translators: the title of a column in the search results list showing
+#. an excerpt of the text of the search result
+#: bookworm/gui/book_viewer/core_dialogs.py:45
+msgid "Text"
+msgstr "文本"
+
+#. Translators: the label of a progress bar indicating the progress of the
+#. search process
+#: bookworm/gui/book_viewer/core_dialogs.py:60
+msgid "Search Progress:"
+msgstr "搜索进度："
+
+#. Translators: the label of a button to close the dialog
+#. Translators: the label of an edit field in the search dialog
+#: bookworm/gui/book_viewer/core_dialogs.py:104
+msgid "Search term:"
+msgstr "搜索词："
+
+#. Translators: the label of a checkbox
+#: bookworm/gui/book_viewer/core_dialogs.py:110
+msgid "Case sensitive"
+msgstr "区分大小写"
+
+#. Translators: the label of a checkbox
+#: bookworm/gui/book_viewer/core_dialogs.py:112
+msgid "Match whole word only"
+msgstr "整词匹配"
+
+#. Translators: the label of a checkbox
+#: bookworm/gui/book_viewer/core_dialogs.py:114
+msgid "Regular expression"
+msgstr "正则表达式"
+
+#: bookworm/gui/book_viewer/core_dialogs.py:153
+msgid "Page number, of {total}:"
+msgstr "页码，共{total}："
+
+#. Translators: the content of the about message
+#: bookworm/gui/book_viewer/menubar.py:39
+msgid ""
+"{display_name}\n"
+"Version: {version}\n"
+"Website: {website}\n"
+"\n"
+"{display_name} is an accessible e-book reader that enables blind and "
+"visually impaired individuals to read e-books in an easy, accessible, and "
+"hassle-free manor. It is being developed by {author} with some contributions "
+"from the community.\n"
+"\n"
+"{copyright}\n"
+"This software is offered to you under the terms of The MIT license.\n"
+"You can view the license text from the help menu.\n"
+"\n"
+"As blind developers, our responsibility is to develop applications that "
+"provide independence for us, and for our fellow blind friends all over the "
+"world. So, if you've found Bookworm useful in any way, please help us in "
+"making Bookworm better for you and for others. At this initial stage, we "
+"want you to tell us about any errors you may encounter during your use of "
+"Bookworm. To do so, open a new issue with the details of the error at the "
+"issue tracker (https://github.com/mush42/bookworm/issues/). Your help is "
+"greatly appreciated."
+msgstr ""
+"{display_name}\n"
+"版本： {version}\n"
+"网站： {website}\n"
+"\n"
+"{display_name}是一款无障碍的电子书阅读器，它使盲人和视力障碍者能够以一种轻松"
+"且易于访问的方式来阅读电子书籍。\n"
+"开发者{author}和社区的一些贡献者正在不断的完善这款产品以使它变得更好。\n"
+"\n"
+"{copyright}\n"
+"本软件根据MIT许可证提供。您可以从“帮助”菜单查看该许可证文本。\n"
+"作为视障开发者，我们的责任是\n"
+"开发出让我们乃至全世界的盲人朋友变得更加独立的应用程序。\n"
+"因此，如果您发现Bookworm对您有用，请帮助我们让Bookworm变得更好。\n"
+"我们希望您告诉我们在使用Bookworm时可能遇到的任何错误。\n"
+"如果可以，请在问题跟踪器（https://github.com/mush42/bookworm/issues/）中提交"
+"包含详细错误信息的Issue。非常感谢您的帮助。"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:79
+msgid "Open...\tCtrl-O"
+msgstr "打开... \tCtrl-O"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:82
+msgid "&Save As Plain Text..."
+msgstr "另存为纯文本(&S)..."
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:87
+msgid "&Close Current Book\tCtrl-W"
+msgstr "关闭当前书籍(&C) \tCtrl-W"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:89
+msgid "Close the currently open e-book"
+msgstr "关闭当前打开的电子书"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:95
+msgid "&Recent Books"
+msgstr "最近阅读(&R)"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:97
+msgid "Opens a list of recently opened books."
+msgstr "查看最近打开的书籍列表。"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:102
+msgid "Clear list"
+msgstr "清除列表"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:104
+msgid "Clear the recent books list."
+msgstr "清除最近打开的书籍列表。"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:110
+msgid "&Preferences...\tCtrl-Shift-P"
+msgstr "首选项(&P)... \tCtrl-Shift-P"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:112
+msgid "Configure application"
+msgstr "应用程序设置"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:116
+msgid "Exit"
+msgstr "退出(&E)"
+
+#. Translators: the title of a file dialog to browse to an e-book
+#: bookworm/gui/book_viewer/menubar.py:140
+msgid "Choose an e-book"
+msgstr "选择一本电子书"
+
+#. Translators: the title of a dialog showing
+#. the progress of book export process
+#: bookworm/gui/book_viewer/menubar.py:173
+msgid "Exporting Book"
+msgstr "导出书籍"
+
+#. Translators: the message of a dialog showing the progress of book export
+#: bookworm/gui/book_viewer/menubar.py:175
+msgid "Converting your book to plain text."
+msgstr "将您的书籍转换为纯文本。"
+
+#: bookworm/gui/book_viewer/menubar.py:190
+msgid "Exporting Page {} of {}..."
+msgstr "正在导出第{}页，共{}页..."
+
+#. Translators: the title of the application preferences dialog
+#: bookworm/gui/book_viewer/menubar.py:213
+msgid "{app_name} Preferences"
+msgstr "{app_name} 首选项"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:233
+msgid "(No recent books)"
+msgstr "(无 最近书籍)"
+
+#: bookworm/gui/book_viewer/menubar.py:234
+msgid "No recent books"
+msgstr "没有最近阅读的书籍"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:260
+#: bookworm/gui/book_viewer/menubar.py:577
+msgid "&Find in Book...\tCtrl-F"
+msgstr "在书籍中查找(&F)... \tCtrl-F"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:262
+#: bookworm/gui/book_viewer/menubar.py:577
+msgid "Search this book."
+msgstr "在书籍中搜索"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:267
+msgid "&Find &Next\tF3"
+msgstr "查找下一个(&F) \\TF3(&F)"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:269
+msgid "Find next occurrence."
+msgstr "查找下一个匹配项。"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:274
+msgid "&Find &Previous\tShift-F3"
+msgstr "查找上一个(&F) \tShift-F3"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:276
+msgid "Find previous occurrence."
+msgstr "查找上一个匹配项。"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:281
+#: bookworm/gui/book_viewer/menubar.py:573
+msgid "&Go To Page...\tCtrl-G"
+msgstr "跳转页码(&G)"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:283
+msgid "Go to page"
+msgstr "跳转到"
+
+#. Translators: the title of the go to page dialog
+#: bookworm/gui/book_viewer/menubar.py:298
+msgid "Go To Page"
+msgstr "跳转页码"
+
+#. Translators: the title of the search dialog
+#: bookworm/gui/book_viewer/menubar.py:306
+msgid "Search book"
+msgstr "搜索书籍"
+
+#: bookworm/gui/book_viewer/menubar.py:327
+msgid "Searching For '{term}'"
+msgstr "搜索“{term}”"
+
+#. Translators: the final title of the search results dialog
+#. shown after the search is finished
+#: bookworm/gui/book_viewer/menubar.py:350
+msgid "Results | {total}"
+msgstr "结果{total}"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:394
+#: bookworm/gui/book_viewer/menubar.py:581
+msgid "&Render Page...\tCtrl-R"
+msgstr "渲染页面(&R)... \tCtrl-R"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:396
+#: bookworm/gui/book_viewer/menubar.py:582
+msgid "View a fully rendered version of this page."
+msgstr "查看本页的渲染版本"
+
+#: bookworm/gui/book_viewer/menubar.py:414
+msgid "Rendered Page"
+msgstr "渲染页面"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:427
+msgid "&User guide...\tF1"
+msgstr "用户指南(&U)... \tF1"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:429
+msgid "View Bookworm manuals"
+msgstr "查看Bookworm的用户指南"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:434
+msgid "Bookworm &website..."
+msgstr "Bookworm 网站(&W)..."
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:436
+msgid "Visit the official website of Bookworm"
+msgstr "访问Bookworm的官方网站"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:441
+msgid "&License"
+msgstr "许可协议(&L)..."
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:443
+msgid "View legal information about this program ."
+msgstr "查看有关本程序的法律许可信息。"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:448
+msgid "Con&tributors"
+msgstr "贡献者(&T)..."
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:450
+msgid "View a list of notable contributors to the program."
+msgstr "查看本程序的重要贡献者列表。"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:455
+msgid "&Check for updates"
+msgstr "检测更新(&C)..."
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:457
+msgid "Update the application"
+msgstr "更新应用程序"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:463
+msgid "&Restart with debug-mode enabled"
+msgstr "重新启动并启用调试模式(&R)..."
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:465
+msgid "Restart the program with debug mode enabled to show errors"
+msgstr "重新启动本程序，并启用调试模式以显示错误。"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:475
+msgid "&About Bookworm"
+msgstr "关于 Bookworm(&A)"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:477
+msgid "Show general information about this program"
+msgstr "显示有关该程序的信息"
+
+#. Translators: the title of the about dialog
+#: bookworm/gui/book_viewer/menubar.py:511
+msgid "About {app_name}"
+msgstr "关于 {app_name}"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:545
+msgid "&File"
+msgstr "文件(&F)"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:547
+msgid "&Search"
+msgstr "搜索(&S)"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:549
+msgid "&Tools"
+msgstr "工具(&T)"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:551
+msgid "&Help"
+msgstr "帮助(&H)"
+
+#: bookworm/gui/book_viewer/menubar.py:574
+msgid "Jump to a page"
+msgstr "跳转到页面"
+
+#: bookworm/gui/book_viewer/menubar.py:615
+msgid "Supported E-Book Formats ({display})|{ext}|"
+msgstr "支持的电子书格式({display})|{ext}|"
+
+#: bookworm/gui/book_viewer/render_view.py:108
+msgid "Zoom is at {factor} percent"
+msgstr "缩放比例{factor}"
+
+#: bookworm/ocr/__init__.py:32
+msgid "OCR"
+msgstr "OCR"
+
+#. Translators: the label of a combobox
+#: bookworm/ocr/ocr_gui.py:60
+msgid "Recognition Language:"
+msgstr "识别语言："
+
+#: bookworm/ocr/ocr_gui.py:63
+msgid "Supplied Image resolution::"
+msgstr "提供的图像分辨率："
+
+#. Translators: the label of a checkbox
+#: bookworm/ocr/ocr_gui.py:77
+msgid "&Save these options until I close the current book"
+msgstr "保存这些选项，直到我关闭当前书籍为止"
+
+#: bookworm/ocr/ocr_gui.py:115
+msgid "Scanning page. Please wait...."
+msgstr "正在扫描。请稍候..."
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/ocr/ocr_gui.py:127
+msgid "S&can Current Page...\tF4"
+msgstr "扫描当前页... \tF4"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/ocr/ocr_gui.py:129
+msgid "OCR current page"
+msgstr "OCR当前页"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/ocr/ocr_gui.py:134
+msgid "&Automatic OCR\tCtrl-F4"
+msgstr "自动OCR \tCtrl-F4"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/ocr/ocr_gui.py:136
+msgid "Auto run  OCR when turning pages."
+msgstr "翻页时自动执行OCR。"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/ocr/ocr_gui.py:142
+msgid "&Change OCR Options..."
+msgstr "更改OCR选项..."
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/ocr/ocr_gui.py:144
+msgid "Change OCR options"
+msgstr "更改OCR选项"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/ocr/ocr_gui.py:149
+msgid "Scan To Text File..."
+msgstr "扫描到文本文件..."
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/ocr/ocr_gui.py:151
+msgid "Scan pages and save the text to a .txt file."
+msgstr "扫描页面并将文本保存至.txt文件。"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/ocr/ocr_gui.py:156
+msgid "Image To Text..."
+msgstr "图片转文字..."
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/ocr/ocr_gui.py:158
+msgid "Run OCR on an image."
+msgstr "在图像上运行OCR。"
+
+#. Translators: the label of the OCR menu in the application menubar
+#: bookworm/ocr/ocr_gui.py:162
+msgid "OCR Tools"
+msgstr "OCR工具(&O)"
+
+#. Translators: content of a message
+#: bookworm/ocr/ocr_gui.py:211
+msgid ""
+"No language for OCR is present.\bPlease use Windos Regional Settings to "
+"download some languages."
+msgstr "没有可用于OCR的语言，请在Windows区域设置下载相应的语言包。"
+
+#: bookworm/ocr/ocr_gui.py:214
+msgid "No OCR Languages"
+msgstr "没有可用于OCR的语言"
+
+#: bookworm/ocr/ocr_gui.py:220
+msgid "OCR Options"
+msgstr "OCR选项"
+
+#: bookworm/ocr/ocr_gui.py:235
+msgid "Cancelled"
+msgstr "取消(&C)"
+
+#: bookworm/ocr/ocr_gui.py:269
+msgid "Automatic OCR is enabled"
+msgstr "自动OCR已启用"
+
+#: bookworm/ocr/ocr_gui.py:271
+msgid "Automatic OCR is disabled"
+msgstr "自动OCR已停用"
+
+#. Translators: the title of a save file dialog asking the user for a filename
+#. to export notes to
+#: bookworm/ocr/ocr_gui.py:284
+msgid "Save as"
+msgstr "另存为"
+
+#. Translators: file type in a save as dialog
+#: bookworm/ocr/ocr_gui.py:288
+msgid "Plain Text (*.txt)|.txt"
+msgstr "纯文本 (*.txt)|.txt"
+
+#. Translators: the title of a progress dialog
+#: bookworm/ocr/ocr_gui.py:300
+msgid "Scanning Pages"
+msgstr "扫描页面"
+
+#. Translators: the message of a progress dialog
+#: bookworm/ocr/ocr_gui.py:302
+msgid "Preparing book"
+msgstr "准备书籍"
+
+#: bookworm/ocr/ocr_gui.py:323
+msgid ""
+"Successfully processed {} pages.\n"
+"Extracted text was written to: {}"
+msgstr ""
+"已成功处理 {} 页。\n"
+"提取的文本已写入： {}"
+
+#: bookworm/ocr/ocr_gui.py:326
+msgid "OCR Completed"
+msgstr "OCR已完成"
+
+#: bookworm/ocr/ocr_gui.py:339
+msgid "Portable Network Graphics"
+msgstr "PNG"
+
+#: bookworm/ocr/ocr_gui.py:340
+msgid "JPEG images"
+msgstr "JPEG"
+
+#: bookworm/ocr/ocr_gui.py:341
+msgid "Bitmap images"
+msgstr "BMP"
+
+#: bookworm/ocr/ocr_gui.py:347
+msgid "All supported image formats|{ext}|"
+msgstr "所有支持的图像格式|{ext}|"
+
+#. Translators: the title of a file dialog to browse to an image
+#: bookworm/ocr/ocr_gui.py:351
+msgid "Choose image file"
+msgstr "选择图像文件"
+
+#: bookworm/ocr/ocr_gui.py:373
+msgid "OCR Results"
+msgstr "OCR结果"
+
+#: bookworm/ocr/ocr_gui.py:393
+msgid "Scan finished."
+msgstr "扫描完成。"
+
+#: bookworm/ocr/ocr_gui.py:400
+msgid "OCR cancelled"
+msgstr "取消OCR(&C)"
+
+#: bookworm/speechdriver/__init__.py:13
+msgid "No Speech"
+msgstr "无语音"
+
+#: bookworm/speechdriver/engines/onecore/oc_engine.py:33
+msgid "One-core Synthesizer"
+msgstr "Windows OneCore"
+
+#: bookworm/speechdriver/engines/sapi/sp_engine.py:30
+msgid "Microsoft Speech API Version 5"
+msgstr "Microsoft Speech API Version 5"
+
+#. Translators: the label of a page in the settings dialog
+#: bookworm/text_to_speech/__init__.py:147
+msgid "Reading"
+msgstr "阅读"
+
+#. Translators: the label of a page in the settings dialog
+#. Translators: the label of a group of controls in the
+#. speech settings page related to voice selection
+#: bookworm/text_to_speech/__init__.py:149
+#: bookworm/text_to_speech/__init__.py:160
+#: bookworm/text_to_speech/tts_gui.py:139
+msgid "Voice"
+msgstr "语音"
+
+#: bookworm/text_to_speech/__init__.py:157
+msgid "Back"
+msgstr "返回"
+
+#: bookworm/text_to_speech/__init__.py:158
+msgid "Play"
+msgstr "朗读"
+
+#: bookworm/text_to_speech/__init__.py:159
+msgid "Forward"
+msgstr "向前"
+
+#: bookworm/text_to_speech/__init__.py:268
+msgid "End of section: {chapter}."
+msgstr "章节末尾: {chapter}。"
+
+#. Translators: the title of a message telling the user that no TTS voice found
+#: bookworm/text_to_speech/__init__.py:337
+msgid "No TTS Voices"
+msgstr "无TTS引擎"
+
+#. Translators: a message telling the user that no TTS voice found
+#: bookworm/text_to_speech/__init__.py:339
+msgid ""
+"A valid Text-to-speech voice was not found for the current speech engine.\n"
+"Text-to-speech functionality will be disabled."
+msgstr ""
+"在您的计算机上找不到可用的 TTS 语音引擎。\n"
+"TTS功能将被禁用。"
+
+#. Translators: the title of a message telling the user that the TTS voice has
+#. been changed
+#: bookworm/text_to_speech/__init__.py:357
+msgid "Incompatible TTS Voice Detected"
+msgstr "检测到不兼容的TTS语音引擎"
+
+#. Translators: a message telling the user that the TTS voice has been changed
+#: bookworm/text_to_speech/__init__.py:359
+msgid ""
+"Bookworm has noticed that the currently configured Text-to-speech voice "
+"speaks a language different from that of this book. Because of this, "
+"Bookworm has temporary switched to another voice that speaks a language "
+"similar to the language  of this book."
+msgstr ""
+"Bookworm发现当前语音引擎的语言与本书不一致，因此，Bookworm已暂时切换到与本书"
+"相似的另一个语音引擎。"
+
+#. Translators: the name of a built-in voice profile
+#: bookworm/text_to_speech/tts_config.py:123
+msgid "Human-like"
+msgstr "Human-like"
+
+#. Translators: the name of a built-in voice profile
+#: bookworm/text_to_speech/tts_config.py:134
+msgid "Deep Reading"
+msgstr "Deep Reading"
+
+#. Translators: the name of a built-in voice profile
+#: bookworm/text_to_speech/tts_config.py:145
+msgid "Expresse"
+msgstr "Expresse"
+
+#. Translators: the label of a group of controls in the reading page
+#: bookworm/text_to_speech/tts_gui.py:50
+msgid "Reading Options"
+msgstr "阅读选项"
+
+#. Translators: the label of a checkbox to enable continuous reading
+#: bookworm/text_to_speech/tts_gui.py:55
+msgid "Use continuous reading mode"
+msgstr "使用连续阅读模式"
+
+#. Translators: the title of a group of radio buttons in the reading page
+#. in the application settings related to how to read.
+#: bookworm/text_to_speech/tts_gui.py:63
+msgid "When Pressing Play:"
+msgstr "开始朗读时："
+
+#. Translators: the label of a radio button
+#: bookworm/text_to_speech/tts_gui.py:68
+msgid "Read the entire book"
+msgstr "整本阅读"
+
+#. Translators: the label of a radio button
+#: bookworm/text_to_speech/tts_gui.py:70
+msgid "Read the current section"
+msgstr "阅读当前章节"
+
+#. Translators: the label of a radio button
+#: bookworm/text_to_speech/tts_gui.py:72
+msgid "Read the current page"
+msgstr "阅读当前页"
+
+#. Translators: the title of a group of radio buttons in the reading page
+#. in the application settings related to where to start reading from.
+#: bookworm/text_to_speech/tts_gui.py:80
+msgid "Start reading from:"
+msgstr "从以下位置开始阅读："
+
+#. Translators: the label of a radio button
+#: bookworm/text_to_speech/tts_gui.py:84
+msgid "Cursor position"
+msgstr "光标位置"
+
+#: bookworm/text_to_speech/tts_gui.py:84
+msgid "Beginning of page"
+msgstr "页面起始处"
+
+#. Translators: the label of a group of controls in the reading page
+#. of the settings related to behavior during reading  aloud
+#: bookworm/text_to_speech/tts_gui.py:88
+msgid "During Reading Aloud"
+msgstr "朗读过程中："
+
+#: bookworm/text_to_speech/tts_gui.py:93
+msgid "Speak page number"
+msgstr "读出页码"
+
+#. Translators: the label of a checkbox
+#: bookworm/text_to_speech/tts_gui.py:100
+msgid "Highlight spoken text"
+msgstr "高亮显示朗读内容"
+
+#. Translators: the label of a checkbox
+#: bookworm/text_to_speech/tts_gui.py:107
+msgid "Select spoken text"
+msgstr "选中朗读内容"
+
+#. Translators: the label of a checkbox
+#: bookworm/text_to_speech/tts_gui.py:114
+msgid "Play end of section sound"
+msgstr "章节结束时播放音效"
+
+#. Translators: the label of a combobox containing a list of tts engines
+#: bookworm/text_to_speech/tts_gui.py:142
+msgid "Speech Engine:"
+msgstr "语音引擎："
+
+#. Translators: the label of a button that opens a dialog to change the speech
+#. engine
+#: bookworm/text_to_speech/tts_gui.py:147
+msgid "Change..."
+msgstr "更改(&C)..."
+
+#. Translators: the label of a combobox containing a list of tts voices
+#: bookworm/text_to_speech/tts_gui.py:150
+msgid "Select Voice:"
+msgstr "语音："
+
+#. Translators: the label of the speech rate slider
+#: bookworm/text_to_speech/tts_gui.py:153
+msgid "Speech Rate:"
+msgstr "语速："
+
+#. Translators: the label of the speech volume slider
+#: bookworm/text_to_speech/tts_gui.py:159
+msgid "Speech Volume:"
+msgstr "音量："
+
+#. Translators: the label of a group of controls in the speech
+#. settings page related to speech pauses
+#: bookworm/text_to_speech/tts_gui.py:166
+msgid "Pauses"
+msgstr "停顿"
+
+#. Translators: the label of an edit field
+#: bookworm/text_to_speech/tts_gui.py:169
+msgid "Additional Pause At Sentence End (Ms)"
+msgstr "句末停顿 （毫秒）"
+
+#. Translators: the label of an edit field
+#: bookworm/text_to_speech/tts_gui.py:174
+msgid "Additional Pause At Paragraph End (Ms)"
+msgstr "段末停顿 （毫秒）"
+
+#. Translators: the label of an edit field
+#: bookworm/text_to_speech/tts_gui.py:179
+msgid "End of Page Pause (ms)"
+msgstr "页末停顿 （毫秒）"
+
+#. Translators: the label of an edit field
+#: bookworm/text_to_speech/tts_gui.py:188
+msgid "End of Section Pause (ms)"
+msgstr "章、节末停顿 （毫秒）"
+
+#: bookworm/text_to_speech/tts_gui.py:232
+msgid "Speech Engine"
+msgstr "语音引擎"
+
+#. Translators: the title of a dialog to edit a voice profile
+#: bookworm/text_to_speech/tts_gui.py:281
+msgid "Voice Profile: {profile}"
+msgstr "语音配置{profile}"
+
+#. Translators: the label of a combobox to select a voice profile
+#: bookworm/text_to_speech/tts_gui.py:308
+msgid "Select Voice Profile:"
+msgstr "选择语音配置："
+
+#. Translators: the label of a button to activate a voice profile
+#: bookworm/text_to_speech/tts_gui.py:314
+msgid "&Activate"
+msgstr "激活(&A)"
+
+#. Translators: the label of a button to create a new voice profile
+#: bookworm/text_to_speech/tts_gui.py:320
+msgid "&New Profile..."
+msgstr "新建配置(&N)..."
+
+#. Translators: the entry of the active voice profile in the voice profiles
+#. list
+#: bookworm/text_to_speech/tts_gui.py:354
+msgid "{profile} (active)"
+msgstr "{profile} (激活)"
+
+#. Translators: the label of an edit field to enter the voice profile name
+#: bookworm/text_to_speech/tts_gui.py:404
+msgid "Profile Name:"
+msgstr "配置名称"
+
+#. Translators: the title of a dialog to enter the name of a new voice profile
+#: bookworm/text_to_speech/tts_gui.py:406
+msgid "New Voice Profile"
+msgstr "新语音配置"
+
+#. Translators: the content of a message notifying the user
+#. user of the existance of a voice profile with the same name
+#: bookworm/text_to_speech/tts_gui.py:418
+msgid ""
+"A voice profile with the same name already exists. Please select another "
+"name."
+msgstr "具有相同名称的语音配置已存在。请换一个其他名称。"
+
+#. Translators: the title of a message telling the user that an error has
+#. occurred
+#: bookworm/text_to_speech/tts_gui.py:422
+msgid "Error"
+msgstr "错误"
+
+#. Translators: the content of a message telling the user that the voice
+#. profile he is removing is the active one
+#: bookworm/text_to_speech/tts_gui.py:444
+msgid ""
+"Voice profile {profile} is the active profile.\n"
+"Please deactivate it first by clicking 'Deactivate Active Voice Profile` "
+"menu item from the speech menu."
+msgstr ""
+"语音配置 {profile} 已激活。\n"
+"请先从语音菜单中单击“停用激活的语音配置”菜单项来停用该配置文件。"
+
+#. Translators: the title of a message telling the user that
+#. it is not possible to remove this voice profile
+#: bookworm/text_to_speech/tts_gui.py:451
+msgid "Cannot Remove Profile"
+msgstr "无法删除配置"
+
+#. Translators: the title of a message to confirm the removal of the voice
+#. profile
+#: bookworm/text_to_speech/tts_gui.py:457
+msgid ""
+"Are you sure you want to remove voice profile {profile}?\n"
+"This cannot be undone."
+msgstr ""
+"您确定要删除语音配置文件{profile}吗？\n"
+"\n"
+"不可撤销。"
+
+#. Translators: the title of a message to confirm the removal of a voice
+#. profile
+#: bookworm/text_to_speech/tts_gui.py:462
+msgid "Remove Voice Profile?"
+msgstr "删除语音配置？"
+
+#. Translators: the label of a combobox
+#: bookworm/text_to_speech/tts_gui.py:485
+msgid "Select Speech Engine:"
+msgstr "选择语音引擎："
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/text_to_speech/tts_gui.py:514
+msgid "&Play\tF5"
+msgstr "朗读(&P) \tF5"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/text_to_speech/tts_gui.py:516
+msgid "Start reading aloud"
+msgstr "开始朗读"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/text_to_speech/tts_gui.py:521
+msgid "Pa&use/Resume\tF6"
+msgstr "暂停/恢复(&U) \tF6"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/text_to_speech/tts_gui.py:523
+msgid "Pause/Resume reading aloud"
+msgstr "暂停/继续朗读"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/text_to_speech/tts_gui.py:528
+msgid "&Stop\tF7"
+msgstr "停止(&S) \tF7"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/text_to_speech/tts_gui.py:530
+msgid "Stop reading aloud"
+msgstr "停止朗读"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/text_to_speech/tts_gui.py:535
+msgid "&Rewind\tAlt-LeftArrow"
+msgstr "快退(&R) Alt-Left"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/text_to_speech/tts_gui.py:537
+msgid "Skip to previous paragraph"
+msgstr "跳到上一段"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/text_to_speech/tts_gui.py:542
+msgid "&Fast Forward\tAlt-RightArrow"
+msgstr "快进(&F) \tAlt-Right"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/text_to_speech/tts_gui.py:544
+msgid "Skip to next paragraph"
+msgstr "跳到下一段"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/text_to_speech/tts_gui.py:549
+msgid "&Voice Profiles\tCtrl-Shift-V"
+msgstr "语音配置(&V) \tCtrl-Shift-V"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/text_to_speech/tts_gui.py:551
+msgid "Manage voice profiles."
+msgstr "管理语音配置"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/text_to_speech/tts_gui.py:556
+msgid "&Deactivate Active Voice Profile"
+msgstr "停用语音配置(&D)"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/text_to_speech/tts_gui.py:558
+msgid "Deactivate the active voice profile."
+msgstr "停用激活的语音配置。"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/text_to_speech/tts_gui.py:563
+msgid "S&peech"
+msgstr "语音(&S)"
+
+#. Translators: a message that is announced when the speech is paused
+#: bookworm/text_to_speech/tts_gui.py:623
+msgid "Paused"
+msgstr "已暂停"
+
+#. Translators: a message that is announced when the speech is resumed
+#: bookworm/text_to_speech/tts_gui.py:627
+msgid "Resumed"
+msgstr "已恢复"
+
+#. Translators: a message that is announced when the speech is stopped
+#: bookworm/text_to_speech/tts_gui.py:638
+msgid "Stopped"
+msgstr "已停止"
+
+#. Translators: the title of the voice profiles dialog
+#: bookworm/text_to_speech/tts_gui.py:643
+msgid "Voice Profiles"
+msgstr "语音配置"
+
+#~ msgid "Play a sound when the current page contains notes"
+#~ msgstr "当前页含有注释内容时播放音效"
+
+#~ msgid "Highlight bookmarked positions"
+#~ msgstr "高亮显示书签位置"
+
+#~ msgid "Notes"
+#~ msgstr "笔记"
+
+#~ msgid "Title"
+#~ msgstr "标题"
+
+#~ msgid "Remove Entry?"
+#~ msgstr "删除条目？"
+
+#~ msgid "View Note..."
+#~ msgstr "查看笔记..."
+
+#~ msgid "Take A Note..."
+#~ msgstr "添加笔记..."
+
+#~ msgid "Edit Note..."
+#~ msgstr "编辑笔记..."
+
+#~ msgid "Note Title:"
+#~ msgstr "笔记标题："
+
+#~ msgid "Note Content:"
+#~ msgstr "笔记内容"
+
+#~ msgid ""
+#~ "Empty fields are present. Please make sure you have filled-in all fields."
+#~ msgstr "存在空白条目。请确保您已填写了所有条目。"
+
+#~ msgid "Cannot Save Note"
+#~ msgstr "无法保存笔记"
+
+#~ msgid "Whole Book"
+#~ msgstr "整本书"
+
+#~ msgid "Current Section"
+#~ msgstr "当前章节"
+
+#~ msgid "Export Range"
+#~ msgstr "导出范围"
+
+#~ msgid "&Cancel"
+#~ msgstr "取消(&C)"
+
+#~ msgid ""
+#~ "There are no notes for this book or the selected section.\n"
+#~ "Please make sure you have added some notes before using the export "
+#~ "functionality."
+#~ msgstr ""
+#~ "此书籍或当前所选章节没有笔记。\\ n\n"
+#~ "使用导出功能之前，请确保已添加过笔记。"
+
+#~ msgid "No Notes"
+#~ msgstr "无笔记"
+
+#~ msgid ""
+#~ "The provided file name is not valid. Please try again with a different "
+#~ "name."
+#~ msgstr "提供的文件名无效。请换个名称再试一次。"
+
+#~ msgid "Invalid File Name"
+#~ msgstr "无效的文件名"
+
+#~ msgid "Open an e-book"
+#~ msgstr "打开一本电子书"
+
+#~ msgid "Search e-book"
+#~ msgstr "搜索电子书"
+
+#~ msgid "View a fully rendered version of this page"
+#~ msgstr "查看此页面的完整版本"
+
+#~ msgid "Note"
+#~ msgstr "笔记"
+
+#~ msgid "Add note"
+#~ msgstr "添加笔记"
+
+#~ msgid "Rewind"
+#~ msgstr "回放"
+
+#~ msgid "Play/Resume"
+#~ msgstr "朗读/继续"
+
+#~ msgid "Customize TTS voice parameters."
+#~ msgstr "自定义TTS语音参数。"
+
+#~ msgid "Zoom out"
+#~ msgstr "缩小"
+
+#~ msgid "Make font smaller"
+#~ msgstr "减小字体"
+
+#~ msgid "Zoom in"
+#~ msgstr "放大"
+
+#~ msgid "Make font larger"
+#~ msgstr "增大字体"
+
+#~ msgid "Preferences"
+#~ msgstr "优先"
+
+#~ msgid "Configure the application"
+#~ msgstr "配置应用程序"
+
+#~ msgid "Take &Note...\tCtrl-N"
+#~ msgstr "添加笔记(&N)... \tCtrl-N"
+
+#~ msgid "&Manage Notes...\tCtrl-Shift-N"
+#~ msgstr "管理笔记(&M)... \tCtrl-Shift-N"
+
+#~ msgid "Notes &Exporter"
+#~ msgstr "导出笔记(&E)"
+
+#~ msgid "Export notes to a file."
+#~ msgstr "将笔记导出到文件。"
+
+#~ msgid "&Speech"
+#~ msgstr "语音(&S)"
+
+#~ msgid "Bookmark This Location"
+#~ msgstr "在此位置添加书签"
+
+#~ msgid "Export Notes | {book}"
+#~ msgstr "导出笔记 | {book}"
+
+#~ msgid "Converting book..."
+#~ msgstr "正在转换书籍..."
+
+#~ msgid ""
+#~ "The file\n"
+#~ "{file}\n"
+#~ "was not found."
+#~ msgstr ""
+#~ "文件\n"
+#~ "\n"
+#~ "{file} \\ n\n"
+#~ "未找到。"

--- a/docs/userguides/zh_CN/bookworm.md
+++ b/docs/userguides/zh_CN/bookworm.md
@@ -1,0 +1,195 @@
+# Bookworm User Guide
+
+## Introduction
+
+**Bookworm** is an ACCESSIBLEebook reader that enables blind and visually impaired individuals to read e-books in an easy and hassle free manor. The main highlights of Bookworm are:
+
+* Supports popular e-book formats, including EPUB and PDF
+* You can add named bookmarks to mark interesting positions in the text for later reference
+* You can add notes to capture an interesting thought or create a summary of the content at a specific position of the text. Bookworm allows you to quickly jump to a specific note and view it. Later on, you can export these notes to a text file or an HTML document for future reference.
+* Two different styles of viewing pages; plain-text and fully rendered, zoomable, images.
+* Full text search with customizable search options
+* Book navigation via Table of content is extensively supported for all e-book formats
+* Support for reading books aloud using Text-to-speech, with configurable voice parameters.
+* The ability to customize  text-to-speech with voice profiles. Each voice profile configures the style of the speech, and you can freely activate/deactivate any voice profile, even while reading aloud!
+* Support for standard zoom-in/zoom-out/reset commands, Ctrl + =, Ctrl + -, and Ctrl + 0 respectively. This functionality is supported in the plain text view and the rendered page view.
+* Support for exporting any e-book format to a plain text file.
+
+
+## Installation
+
+To get Bookworm up and running on your computer, follow these steps:
+
+1. Point your web browser to the [official website of Bookworm](https://mush42.github.io/bookworm/) and download the installer that suits your operating system. Bookworm comes in two flavors:
+
+* A 32-bit installer for computers running a 32-bit variant of Windows 
+* A 64-bit installer for computers running a 64-bit variant of Windows 
+
+2. Run the installer and follow the prompts
+3. After the installation has finished successfully , you can launch Bookworm from the *Desktop* or from the program list found in the Start Menu
+
+
+## Usage
+
+### Opening A Book
+
+You can open a book by selecting the "Open..." menu item from the "File" Menu. Alternatively you can use the Ctrl+O shortcut. Either way, the familiar "open file" dialog is shown. Browse to your e-book, and click open to load it.
+
+### The Reader Window
+
+The main window of Bookworm consists of the following two parts:
+
+1. The "Table of contents": This part shows the e-book chapters'. It allows you to explore the content structure. Use navigation keys to navigate chapters, and press enter to navigate to specific chapter.
+
+2. The "Textual View" area: This part contains the text of the current page. In this part you can use your usual reading commands to navigate the text. Additionally, you can use the following keyboard  shortcuts to navigate the e-book:
+
+* Enter: navigate to the next page in the current section
+* Backspace: navigate to the previous page in the current section
+* While the caret is at the first line, pressing the up arrow two times in succession navigates to the previous page.
+* While the caret is at the last line, pressing the down arrow two times in succession navigates to the next page.
+* Alt + Home: navigate to the first page of the current section
+* Alt + End: navigate to the last page of the current section
+* Alt + Page down: navigate to next section
+* Alt + Page up: navigate to previous section
+
+
+### Bookmarks & Notes
+
+Bookworm allows you to annotate the opened book.  You can add a bookmark to remember a specific location in the book, and later on, quickly jump to  it. Also, you can take a note to capture a thought or summarize some content.
+
+#### Adding Bookmarks
+
+While reading a book, you can press Ctrl + B (or select the "Add Bookmark" menu item from the "Annotations" menu to add a bookmark. The bookmark is added at the current position of the cursor. You'll be asked to provide a title for the bookmark. Type the desired title and click the OK Button. A bookmark will be added at the current location, and the current line will be visually highlighted.
+
+#### Viewing Bookmarks
+
+Press Ctrl + Shift + B, or select the "View Bookmarks" menu item from the "Annotations" menu. A dialog containing added bookmarks will be shown. Clicking any item in the bookmarks list will immediately take you to the position of that bookmark.
+
+Additionally, you can press F2 to edit the title of the selected bookmark in place, or you can click the "Delete" button or the "Delete" key on your keyboard to remove the selected bookmark.
+
+#### Taking Notes
+
+While reading a book, you can press Ctrl + N (or select the "Take Note" menu item from the "Annotations" menu to take a note. The note will be added at the current position of the cursor. You'll be asked to provide the title and the content for the note. Type the desired title and content, and then click the OK button. A note will be added at the current location.
+
+When you navigate to a page containing at least one note, you will hear a little sound indicating the existence of a note in the current page..
+
+#### Managing Notes
+
+Press Ctrl + Shift + N, or select the "Manage Notes" menu item from the "Annotations" menu. A dialog containing added notes will be shown. Clicking any item in the notes list will immediately take you to the position of that note. Clicking the "View" button will bring up a dialog showing the title and the content of the selected note.
+
+Additionally, you can click the "Edit" button to edit the title and the content of the selected note, press  F2 to edit the title of the selected note in place, or you can click the "Delete" button or the "Delete" key on your keyboard to remove the selected note.
+
+#### Exporting Notes
+
+Bookworm allows you to export your notes to a plain-text file, or to an HTML document which you can then open in your web browser.  Optionally, Bookworm allows you to export your notes to markdown, which is a text-base format for writing structured documents popular among expert computer users.
+
+To export your notes, follow these steps:
+
+1. From the "Annotations" menu select the "Notes Exporter..." menu item
+2. Select the export range. This tells Bookworm whether you want to export the notes of the whole book, or you just want to export the notes of the current section. 
+3. Select the output format. This determines the format of the file you get after exporting. Exporting to a plain-text gives you a simple, nicely formatted text file, exporting to HTML gives you a web page, and exporting to markdown gives you a markdown document which is a text format popular among expert computer users.
+4. If you want Bookworm to open the file to which your notes have been exported, you can check the "Open file after exporting" checkbox.
+5. Click Export. You will be asked to select the file name of the exported file, and the location to which the file is saved. Clicking "Save" will save the file, and open it if you have instructed Bookworm to do so.
+
+
+### Reading Aloud
+
+Bookworm supports reading the content of the opened book aloud using an installed text-to-speech voice. Just press F5 to start the speech, F6 to pause or resume the speech, and F7 to stop the speech entirely.
+
+You can configure the speech in two ways:
+1. Using A Voice Profile: A voice profile contains your custom speech configurations, you can activate/deactivate the voice profile at any time. You can access voice profiles from the speech menu or by pressing Ctrl + Shift + V. Note that Bookworm comes with some exemplary, built-in voice profiles.
+2. The Global speech settings: these settings will be used by default when no voice profile is active. You can configure the global speech settings from the application preferences. 
+
+During reading aloud, you can skip backward or foreword by paragraph by pressing Alt plus the left and right arrow  keys.
+
+
+### Configuring The Reading Style
+
+In addition to the speech settings, Bookworm gives you the ability to fine-tune its reading behavior through these settings. All of the following settings could be found in the reading page of the application preferences.
+
+* What to read: this option controls what happens when you instruct Bookworm to "Play" the current book. You can choose to "Read the entire book", "Read the current section", or read just "The current page". By default, Bookworm reads the entire book in a continuous manner, unless you instruct it to stop when it reaches the end of the page or the end of the current section.
+* Where to start: this option controls the position from which to start reading aloud. You can choose to start reading from the "Position of the caret" or the "Start of the current page".
+* How to read: this set of options control how Bookworm behave during reading aloud. You can turn on/off any one of the following options by checking/unchecking its respective checkbox:
+
+* Highlight spoken text: if this option is turned on, the currently spoken text is visually highlighted.
+* Select spoken text: if this option is turned on, the currently spoken text is selected. This enables you, for instance, to press Ctrl + C to copy the currently spoken paragraph.
+* Play end-of-section sound: if this option is turned on, Bookworm plays a little sound when it reaches the end of a section.
+
+
+### Continuous Reading Mode
+
+In addition to Bookworm's built-in text-to-speech features, you can take advantage of your screen reader's continuous reading functionality (also known as "say all"). Bookworm provides support for this functionality through its "continuous reading mode". This mode is active by default, and you can disable it from the reading page of the application preferences. While the continuous reading mode is active, pages are turned automatically as the screen reader progresses through the book.
+
+Note that due to the way this feature is currently implemented, the following limitations should be expected:
+
+* Continuous reading will be interrupted if an empty page is reached. If you reached an empty page, simply navigate to a non-empty page and reactivate your screen reader's continuous reading functionality from there.
+* Moving the caret to the last character in the page will immediately switch to the next page
+
+
+
+### Viewing A Fully Rendered Version of The Current Page
+
+Bookworm allows you to view a fully rendered version of the book. While a book is opened, you can press Ctrl + R or select the "Render Page" menu item from the tools menu. We call this view "The Render View" as oppose to the, default, Textual View.
+
+When you are in the Render View, you can use the usual zoom commands to zoom the page in and out:
+
+* Ctrl + = zoom-in 
+* Ctrl + - zoom-out
+* Ctrl + 0 reset the zoom level
+
+Note that you can also use the book navigation commands, mentioned above,  to navigate the render view as well. You can also press the escape key to dismiss this view and return to the default textual view.
+
+
+### Navigating To A Specific Page
+
+To navigate to a specific page in the currently opened book., press Ctrl + G, or select the "Go To..." menu item from the tools menu to show the "Go To Page" dialog. In this dialog you can type the number of any page you want to navigate to, and Bookworm will take you to it. Note that this dialog will indicate to you the total number of pages found in the current book.
+
+ 
+### Searching The Book
+
+To find a specific term, or a portion of text in the currently opened book, you can press Ctrl + F to bring up the "Search Book Dialog". This Dialog allows you to type the text you want to search for as well as configuring the  search process itself. The following options are available:
+
+* Case Sensitive: The search will take into account the case of the letters in the search term.
+* Whole Word Only: The search term must be found as a whole word, i.e. not as a part of another word
+* Search Range: This allows you to confine the search to certain pages or a specific section.
+
+After clicking the OK button in the "Search Book Dialog", another dialog containing search results will be shown. Clicking any item in the search results list will immediately take you to the position of that result with the search term highlighted for you.
+
+Note that if you've closed the search results window, you can press F3 and Shift + F3 to move to the next and previous occurrence of the last search respectively.
+
+
+## Managing File Associations
+
+The "Manage File Associations" button, found in the general page in the application preferences, helps you to manage which file types are associated with Bookworm. Associating files with Bookworm means that when you click on a file in Windows explorer, that file would be opened in Bookworm by default. Note that this dialog is always shown to the user in the first run of the program.
+
+Once you launch the file associations manager, you will have the following options:
+
+* Associate all: this changes your settings so that if a file is supported by Bookworm, Windows will use Bookworm to open it. 
+* Dissociate all supported file types: this will remove previously registered file associations
+* Individual buttons for each supported file type: clicking any button of those will associate its respective file type with Bookworm.
+
+
+## Updating Bookworm
+
+By default, Bookworm checks for new versions upon startup. This ensures that you get the latest and greatest of Bookworm as early as possible. You can disable this default behavior from the application preferences.   You can also check for updates manually by clicking the "Check for updates" menu item found under the "Help" menu.
+
+Either way, when a new version is found, Bookworm will ask you if you want to install it. If you click "Yes", the application will go ahead and download the update bundle, and will show a dialog indicating the progress of download. After the update is downloaded, Bookworm will alert you with a message, telling you it will restart the application in order to update. Just click "OK" to complete the update process.
+
+
+## Reporting Problems & Issues
+
+As blind developers, our responsibility is to develop applications that provide independence for us, and for our fellow blind friends all over the world. So, if you've found Bookworm useful in any way, please help us in making Bookworm better for you and for others. At this initial stage, we want you to tell us about any errors you may encounter during your use of Bookworm. To do so, open a new issue with the details of the error at [the issue tracker](https://github.com/mush42/bookworm/issues/). Your help is greatly appreciated.
+
+Before submitting a new issue, make sure that you ran Bookworm in debug mode. To turn on debug mode, go to the "Help" menu and then click "Restart with debug-mode enabled" and try to reproduce the issue with debug mode enabled. In the majority of cases, when the error happens again with debug mode enabled, a dialog will be shown with the details of that error. You can then copy this information and include it with your problem report.
+
+Note that some issues could be tricky to reproduce, they go away when you restart the program. In this case, it is okay to report the issue without the detailed information from the debug mode. Just make sure you include as much information as possible about the particulars of your system and usage scenario.
+
+
+## News & Updates
+
+To keep yourself updated with the latest news about Bookworm, you can visit Bookworm's website at: [mush42.github.io/bookworm](https://mush42.github.io/bookworm/). You can also follow the lead developer, Musharraf Omer, at [@mush42](https://twitter.com/mush42/) on Twitter.
+
+
+## License
+
+**Bookworm** is copyright (c) 2019 Musharraf Omer and Bookworm Contributors. It is licensed under the [MIT License](https://github.com/mush42/bookworm/blob/master/LICENSE).


### PR DESCRIPTION
## Link to issue number:
none 

### Summary of the issue:
Simplified Chinese support added

### Description of how this pull request fixes the issue:
Bookworm does not support simplified Chinese display.

### Testing performed:
Based on the Bookworm v0.2 Development Version (Dev1) of the translation, Has been tested.
Simplified Chinese can be displayed.

### Known issues with pull request:
User guide part has not yet been translated
