### PR TITLE
Fix: Made some labels in element list dialog translatable.

### DIFF
--- a/bookworm/gui/book_viewer/core_dialogs.py
+++ b/bookworm/gui/book_viewer/core_dialogs.py
@@ -243,7 +243,7 @@ class ElementListDialog(SimpleDialog):
         self.elementTypeRadio = EnumRadioBox(
             parent,
             -1,
-            label=("Element Type"),
+            label=_("Element Type"),
             choice_enum=ElementKind,
             majorDimension=0,
             style=wx.RA_SPECIFY_COLS,

--- a/bookworm/gui/book_viewer/core_dialogs.py
+++ b/bookworm/gui/book_viewer/core_dialogs.py
@@ -279,7 +279,7 @@ class ElementListDialog(SimpleDialog):
         label = SEMANTIC_ELEMENT_OUTPUT_OPTIONS[
             self.elementTypeRadio.GetSelectedValue().value
         ][0]
-        self.elementListViewLabel.SetLabelText(label)
+        self.elementListViewLabel.SetLabelText(_(label))
 
     def populate_element_list(self, element_type):
         if (element_infos := self.__element_Info_cache.get(element_type)) is None:

--- a/bookworm/resources/locale/zh_CN/LC_MESSAGES/bookworm.po
+++ b/bookworm/resources/locale/zh_CN/LC_MESSAGES/bookworm.po
@@ -1,5 +1,5 @@
 # Simplified Chinese translations for Bookworm.
-# Copyright (C) 2019-2022 Cary-rowen
+# Copyright (C) 2019-2023 Cary-rowen
 # This file is distributed under the same license as the Bookworm project.
 # Cary-rowen <manchen_0528@outlook.com>, 2019-2022.
 #

--- a/bookworm/resources/locale/zh_CN/LC_MESSAGES/bookworm.po
+++ b/bookworm/resources/locale/zh_CN/LC_MESSAGES/bookworm.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 'Bookworm'\n"
 "Report-Msgid-Bugs-To: ibnomer2011@hotmail.com\n"
-"POT-Creation-Date: 2023-02-01 12:21+0000\n"
-"PO-Revision-Date: 2023-03-14 10:44+0800\n"
+"POT-Creation-Date: 2023-03-20 01:27+0000\n"
+"PO-Revision-Date: 2023-03-20 13:51+0800\n"
 "Last-Translator: Cary-rowen <manchen_0528@outlook.com>\n"
 "Language-Team: Cary-Rowen <manchen_0528@outlook.com>\n"
 "Language: zh_CN\n"
@@ -28,7 +28,7 @@ msgstr "当前无法连接网络，请稍后再试。"
 #. Translators: the title of a message indicating a connection error
 #. Translators: the title of a message indicating a failure in downloading an
 #. update
-#: bookworm/otau.py:78 bookworm/platforms/win32/updater.py:119
+#: bookworm/otau.py:78 bookworm/platforms/win32/updater.py:120
 msgid "Network Error"
 msgstr "网络错误"
 
@@ -76,127 +76,127 @@ msgid "Update the application"
 msgstr "更新应用程序"
 
 #. Translators: the title of the window when an e-book is open
-#: bookworm/reader.py:439
+#: bookworm/reader.py:426
 msgid "{title} — by {author}"
 msgstr "{title} —作者 {author}"
 
 #. Translators: title of a message dialog that shows a table as html document
-#: bookworm/reader.py:456
+#: bookworm/reader.py:443
 msgid "Table View"
 msgstr "表格试图"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/annotation/__init__.py:69
+#: bookworm/annotation/__init__.py:61
 msgid "&Annotation"
 msgstr "注解(&A)"
 
-#: bookworm/annotation/__init__.py:77
+#: bookworm/annotation/__init__.py:69
 msgid "&Bookmark...\tCtrl-B"
 msgstr "添加书签... \tCtrl-B"
 
-#: bookworm/annotation/__init__.py:78 bookworm/annotation/__init__.py:84
+#: bookworm/annotation/__init__.py:70 bookworm/annotation/__init__.py:76
 msgid "Bookmark the current location"
 msgstr "在当前位置添加书签"
 
-#: bookworm/annotation/__init__.py:83
+#: bookworm/annotation/__init__.py:75
 msgid "&Named Bookmark...\tCtrl-Shift-B"
 msgstr "命名书签(&N)...\tCtrl-Shift-B"
 
-#: bookworm/annotation/__init__.py:89
+#: bookworm/annotation/__init__.py:81
 msgid "Co&mment...\tCtrl-m"
 msgstr "注释... \tCtrl-m"
 
-#: bookworm/annotation/__init__.py:90
+#: bookworm/annotation/__init__.py:82
 msgid "Add a comment at the current location"
 msgstr "在当前位置添加注释"
 
-#: bookworm/annotation/__init__.py:100
+#: bookworm/annotation/__init__.py:92
 msgid "Highlight Selection\tCtrl-Shift-H"
 msgstr "标记为高亮... \tCtrl-Shift-H"
 
-#: bookworm/annotation/__init__.py:101
+#: bookworm/annotation/__init__.py:93
 msgid "Highlight and save selected text."
 msgstr "高亮显示并保存所选文本。"
 
 #. Translators: the label of a button in the application toolbar
 #. Translators: spoken message when jumping to a bookmark
-#: bookworm/annotation/__init__.py:110 bookworm/annotation/__init__.py:147
+#: bookworm/annotation/__init__.py:102 bookworm/annotation/__init__.py:139
 msgid "Bookmark"
 msgstr "书签"
 
 #. Translators: the label of a button in the application toolbar
-#: bookworm/annotation/__init__.py:112
+#: bookworm/annotation/__init__.py:104
 msgid "Comment"
 msgstr "注释"
 
 #. Translators: the label of a page in the settings dialog
 #. Translators: label for a aria region containing annotation
 #. used when exporting annotations to HTML
-#: bookworm/annotation/__init__.py:122
+#: bookworm/annotation/__init__.py:114
 #: bookworm/annotation/exporters/core_renderers.py:171
 msgid "Annotation"
 msgstr "注解"
 
 #. Translators: spoken message
-#: bookworm/annotation/__init__.py:135
+#: bookworm/annotation/__init__.py:127
 msgid "No next bookmark"
 msgstr "往下没有书签"
 
 #. Translators: spoken message
-#: bookworm/annotation/__init__.py:138
+#: bookworm/annotation/__init__.py:130
 msgid "No previous bookmark"
 msgstr "往上没有书签"
 
 #. Translators: spoken message
-#: bookworm/annotation/__init__.py:165
+#: bookworm/annotation/__init__.py:157
 msgid "No next comment"
 msgstr "往下没有注释"
 
 #. Translators: spoken message
-#: bookworm/annotation/__init__.py:168
+#: bookworm/annotation/__init__.py:160
 msgid "No previous comment"
 msgstr "往上没有注释"
 
 #. Translators: spoken message when jumping to a comment
-#: bookworm/annotation/__init__.py:179
+#: bookworm/annotation/__init__.py:171
 msgid "Comment: {comment}"
 msgstr "注释： {comment}"
 
 #. Translators: spoken message
-#: bookworm/annotation/__init__.py:192
+#: bookworm/annotation/__init__.py:184
 msgid "No next highlight"
 msgstr "往下没有高亮"
 
 #. Translators: spoken message
-#: bookworm/annotation/__init__.py:195
+#: bookworm/annotation/__init__.py:187
 msgid "No previous highlight"
 msgstr "往上没有高亮"
 
-#: bookworm/annotation/__init__.py:205
+#: bookworm/annotation/__init__.py:197
 msgid "Highlight"
 msgstr "高亮"
 
 #. Translators: spoken message indicating the presence of an annotation when
 #. the user navigates the text
-#: bookworm/annotation/__init__.py:247
+#: bookworm/annotation/__init__.py:239
 msgid "Bookmarked"
 msgstr "书签"
 
 #. Translators: spoken message indicating the presence of an annotation when
 #. the user navigates the text
-#: bookworm/annotation/__init__.py:250
+#: bookworm/annotation/__init__.py:242
 msgid "Highlighted"
 msgstr "高亮"
 
 #. Translators: spoken message indicating the presence of an annotation when
 #. the user navigates the text
-#: bookworm/annotation/__init__.py:253
+#: bookworm/annotation/__init__.py:245
 msgid "Line contains highlight"
 msgstr "行包含高亮"
 
 #. Translators: spoken message indicating the presence of an annotation when
 #. the user navigates the text
-#: bookworm/annotation/__init__.py:256
+#: bookworm/annotation/__init__.py:248
 msgid "Has comment"
 msgstr "有注释"
 
@@ -207,16 +207,16 @@ msgstr "有注释"
 #. content when searching the bookshelf
 #. Translators: the label of the text area which shows the
 #. content of the current page
-#: bookworm/annotation/annotation_dialogs.py:59
-#: bookworm/annotation/annotation_dialogs.py:266
-#: bookworm/bookshelf/local_bookshelf/dialogs.py:126
-#: bookworm/gui/book_viewer/__init__.py:317
+#: bookworm/annotation/annotation_dialogs.py:56
+#: bookworm/annotation/annotation_dialogs.py:263
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:122
+#: bookworm/gui/book_viewer/__init__.py:307
 msgid "Content"
 msgstr "内容"
 
 #. Translators: header of a group of controls in a dialog to view/edit
 #. comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:63
+#: bookworm/annotation/annotation_dialogs.py:60
 msgid "Metadata"
 msgstr "元数据"
 
@@ -225,21 +225,21 @@ msgstr "元数据"
 #. Translators: label of an edit control that allows the user to edit the tag
 #. set of a comment/highlight
 #. Translators: written to output document when exporting a comment/highlight
-#: bookworm/annotation/annotation_dialogs.py:66
-#: bookworm/annotation/annotation_dialogs.py:522
+#: bookworm/annotation/annotation_dialogs.py:63
+#: bookworm/annotation/annotation_dialogs.py:519
 #: bookworm/annotation/exporters/core_renderers.py:201
 msgid "Tags"
 msgstr "标签"
 
 #. Translators: label of an edit control in a dialog to view/edit
 #. comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:71
+#: bookworm/annotation/annotation_dialogs.py:68
 msgid "Date Created"
 msgstr "创建日期"
 
 #. Translators: label of an edit control in a dialog to view/edit
 #. comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:77
+#: bookworm/annotation/annotation_dialogs.py:74
 msgid "Last updated"
 msgstr "最近更新时间"
 
@@ -247,38 +247,38 @@ msgstr "最近更新时间"
 #. Translators: the label of the cancel button in a dialog
 #. Translators: the label of the close button in a dialog
 #. Translators: the label of a button to close the dialog
-#: bookworm/annotation/annotation_dialogs.py:91
-#: bookworm/annotation/annotation_dialogs.py:148
-#: bookworm/bookshelf/local_bookshelf/dialogs.py:177
-#: bookworm/bookshelf/local_bookshelf/dialogs.py:245
-#: bookworm/gui/book_viewer/core_dialogs.py:407 bookworm/gui/settings.py:107
-#: bookworm/ocr/ocr_dialogs.py:428 bookworm/text_to_speech/tts_gui.py:331
+#: bookworm/annotation/annotation_dialogs.py:88
+#: bookworm/annotation/annotation_dialogs.py:145
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:173
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:241
+#: bookworm/gui/book_viewer/core_dialogs.py:398 bookworm/gui/settings.py:103
+#: bookworm/ocr/ocr_dialogs.py:416 bookworm/text_to_speech/tts_gui.py:328
 #: bookworm/webservices/wikiworm.py:215
 msgid "&Close"
 msgstr "关闭(&C)"
 
 #. Translators: label for unnamed bookmarks shown
 #. when editing a single bookmark which has no name
-#: bookworm/annotation/annotation_dialogs.py:125
+#: bookworm/annotation/annotation_dialogs.py:122
 msgid "[Unnamed Bookmark]"
 msgstr "[未命名书签]"
 
 #. Translators: label of a list control containing bookmarks
-#: bookworm/annotation/annotation_dialogs.py:130
+#: bookworm/annotation/annotation_dialogs.py:127
 msgid "Saved Bookmarks"
 msgstr "保存书签"
 
 #. Translators: text of a button to remove bookmarks
 #. Translators: text of a button to remove a language from Tesseract OCR Engine
 #. Translators: the label of a button to remove a voice profile
-#: bookworm/annotation/annotation_dialogs.py:133
-#: bookworm/ocr/ocr_dialogs.py:467 bookworm/text_to_speech/tts_gui.py:325
+#: bookworm/annotation/annotation_dialogs.py:130
+#: bookworm/ocr/ocr_dialogs.py:455 bookworm/text_to_speech/tts_gui.py:322
 msgid "&Remove"
 msgstr "删除(&R)"
 
 #. Translators: the title of a column in the bookmarks list
-#: bookworm/annotation/annotation_dialogs.py:157
-#: bookworm/gui/book_viewer/core_dialogs.py:265
+#: bookworm/annotation/annotation_dialogs.py:154
+#: bookworm/gui/book_viewer/core_dialogs.py:256
 msgid "Name"
 msgstr "名称"
 
@@ -289,11 +289,11 @@ msgstr "名称"
 #. Translators: the title of a column in the search results list
 #. Translators: the label of the image of a page in a dialog to render the
 #. current page
-#: bookworm/annotation/annotation_dialogs.py:164
-#: bookworm/annotation/annotation_dialogs.py:355
+#: bookworm/annotation/annotation_dialogs.py:161
+#: bookworm/annotation/annotation_dialogs.py:352
 #: bookworm/annotation/exporters/core_renderers.py:178
-#: bookworm/bookshelf/local_bookshelf/dialogs.py:196
-#: bookworm/gui/book_viewer/core_dialogs.py:60
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:192
+#: bookworm/gui/book_viewer/core_dialogs.py:51
 #: bookworm/gui/book_viewer/render_view.py:32
 msgid "Page"
 msgstr "页"
@@ -302,16 +302,16 @@ msgstr "页"
 #. Translators: label of an editable combobox to filter annotations by section
 #. Translators: the title of a column in the search results list
 #. showing the title of the chapter in which this occurrence was found
-#: bookworm/annotation/annotation_dialogs.py:172
-#: bookworm/annotation/annotation_dialogs.py:261
+#: bookworm/annotation/annotation_dialogs.py:169
+#: bookworm/annotation/annotation_dialogs.py:258
 #: bookworm/annotation/exporters/core_renderers.py:145
-#: bookworm/gui/book_viewer/core_dialogs.py:75
+#: bookworm/gui/book_viewer/core_dialogs.py:66
 msgid "Section"
 msgstr "章节"
 
 #. Translators: content of a message asking the user if they want to delete a
 #. bookmark
-#: bookworm/annotation/annotation_dialogs.py:219
+#: bookworm/annotation/annotation_dialogs.py:216
 msgid ""
 "This action can not be reverted.\r\n"
 "Are you sure you want to remove this bookmark?"
@@ -321,88 +321,88 @@ msgstr ""
 
 #. Translators: title of a message asking the user if they want to delete a
 #. bookmark
-#: bookworm/annotation/annotation_dialogs.py:223
+#: bookworm/annotation/annotation_dialogs.py:220
 msgid "Remove Bookmark?"
 msgstr "删除书签？"
 
 #. Translators: label of an editable combobox to filter annotations by book
 #. Translators: text of a toggle button to sort comments/highlights list
-#: bookworm/annotation/annotation_dialogs.py:250
-#: bookworm/annotation/annotation_dialogs.py:359
-#: bookworm/annotation/annotation_dialogs.py:555
+#: bookworm/annotation/annotation_dialogs.py:247
+#: bookworm/annotation/annotation_dialogs.py:356
+#: bookworm/annotation/annotation_dialogs.py:552
 #: bookworm/annotation/exporters/core_renderers.py:143
 msgid "Book"
 msgstr "文档"
 
 #. Translators: label of an editable combobox to filter annotations by tag
-#: bookworm/annotation/annotation_dialogs.py:255
+#: bookworm/annotation/annotation_dialogs.py:252
 #: bookworm/annotation/exporters/core_renderers.py:147
 msgid "Tag"
 msgstr "标签"
 
 #. Translators: text of a button to apply chosen filters in a dialog to view
 #. user's comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:271
+#: bookworm/annotation/annotation_dialogs.py:268
 msgid "&Apply"
 msgstr "应用(&A)"
 
 #. Translators: the title of a column in the comments/highlights list
 #. Translators: header of a group of controls in a dialog to view user's
 #. comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:338
+#: bookworm/annotation/annotation_dialogs.py:335
 msgid "Filter By"
 msgstr "过滤"
 
 #. Translators: header of a group of controls in a dialog to view user's
 #. comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:347
+#: bookworm/annotation/annotation_dialogs.py:344
 msgid "Sort By"
 msgstr "排序方式"
 
 #. Translators: text of a toggle button to sort comments/highlights list
-#: bookworm/annotation/annotation_dialogs.py:353
+#: bookworm/annotation/annotation_dialogs.py:350
 msgid "Date"
 msgstr "日期"
 
 #. Translators: text of a toggle button to sort comments/highlights list
-#: bookworm/annotation/annotation_dialogs.py:365
+#: bookworm/annotation/annotation_dialogs.py:362
 msgid "Ascending"
 msgstr "上升"
 
 #. Translators: text of a button in a dialog to view comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:374
+#: bookworm/annotation/annotation_dialogs.py:371
 msgid "&View..."
 msgstr "查看(&V)"
 
 #. Translators: text of a button in a dialog to view comments/highlights
 #. Translators: the label of a button to edit a voice profile
-#: bookworm/annotation/annotation_dialogs.py:377
-#: bookworm/text_to_speech/tts_gui.py:323
+#: bookworm/annotation/annotation_dialogs.py:374
+#: bookworm/text_to_speech/tts_gui.py:320
 msgid "&Edit..."
 msgstr "编辑(&E)"
 
 #. Translators: text of a button in a dialog to view comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:380
+#: bookworm/annotation/annotation_dialogs.py:377
 msgid "&Delete..."
 msgstr "删除(&D)..."
 
 #. Translators: text of a button in a dialog to view comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:382
+#: bookworm/annotation/annotation_dialogs.py:379
 msgid "E&xport..."
 msgstr "导出(&X)"
 
 #. Translators: title of a dialog to view or edit a single comment/highlight
-#: bookworm/annotation/annotation_dialogs.py:454
+#: bookworm/annotation/annotation_dialogs.py:451
 msgid "Editing"
 msgstr "编辑"
 
-#: bookworm/annotation/annotation_dialogs.py:454
+#: bookworm/annotation/annotation_dialogs.py:451
 msgid "View"
 msgstr "查看"
 
 #. Translators: content of a message asking the user if they want to delete a
 #. comment/highlight
-#: bookworm/annotation/annotation_dialogs.py:471
+#: bookworm/annotation/annotation_dialogs.py:468
 msgid ""
 "This action can not be reverted.\r\n"
 "Are you sure you want to remove this item?"
@@ -412,259 +412,259 @@ msgstr ""
 
 #. Translators: title of a message asking the user if they want to delete a
 #. bookmark
-#: bookworm/annotation/annotation_dialogs.py:475
+#: bookworm/annotation/annotation_dialogs.py:472
 msgid "Delete Annotation?"
 msgstr "删除注释？"
 
 #. Translators: title of a dialog that allows the user to edit the tag set of a
 #. comment/highlight
-#: bookworm/annotation/annotation_dialogs.py:520
+#: bookworm/annotation/annotation_dialogs.py:517
 msgid "Edit Tags"
 msgstr "编辑标签"
 
 #. Translators: title of a dialog that allows the user to customize
 #. how comments/highlights are exported
-#: bookworm/annotation/annotation_dialogs.py:533
+#: bookworm/annotation/annotation_dialogs.py:530
 msgid "Export Options"
 msgstr "导出选项"
 
 #. Translators: label of a checkbox in a dialog to set export options for
 #. comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:593
+#: bookworm/annotation/annotation_dialogs.py:590
 msgid "Include book title"
 msgstr "包含书名"
 
-#: bookworm/annotation/annotation_dialogs.py:598
+#: bookworm/annotation/annotation_dialogs.py:595
 msgid "Include section title"
 msgstr "包含章节标题"
 
-#: bookworm/annotation/annotation_dialogs.py:604
+#: bookworm/annotation/annotation_dialogs.py:601
 msgid "Include  page number"
 msgstr "包含页码"
 
 #. Translators: label of a checkbox in a dialog to set export options for
 #. comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:607
+#: bookworm/annotation/annotation_dialogs.py:604
 msgid "Include tags"
 msgstr "包含标签"
 
 #. Translators: label of a choice control in a dialog to set export options for
 #. comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:609
+#: bookworm/annotation/annotation_dialogs.py:606
 msgid "Output format:"
 msgstr "输出格式："
 
 #. Translators: label of an edit control in a dialog to set export options for
 #. comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:614
+#: bookworm/annotation/annotation_dialogs.py:611
 msgid "Output File"
 msgstr "输出文件"
 
 #. Translators: text of a button in a dialog to set export options for
 #. comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:619
+#: bookworm/annotation/annotation_dialogs.py:616
 msgid "&Browse"
 msgstr "浏览(&B)"
 
 #. Translators: label of a checkbox in a dialog to set export options for
 #. comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:624
+#: bookworm/annotation/annotation_dialogs.py:621
 msgid "Open file after exporting"
 msgstr "导出后打开文件"
 
 #. Translators: the title of a save file dialog asking the user for a filename
 #. to export annotations to
 #. Translators: the title of a dialog to save the exported book
-#: bookworm/annotation/annotation_dialogs.py:651
-#: bookworm/gui/book_viewer/menubar.py:253
+#: bookworm/annotation/annotation_dialogs.py:648
+#: bookworm/gui/book_viewer/menubar.py:247
 msgid "Save As"
 msgstr "另存为"
 
 #. Translators: the title of a group of controls in the settings dialog
-#: bookworm/annotation/annotation_gui.py:28
+#: bookworm/annotation/annotation_gui.py:25
 msgid "When navigating text"
 msgstr "文本导航过程中"
 
 #. Translators: the label of a checkbox
-#: bookworm/annotation/annotation_gui.py:33
+#: bookworm/annotation/annotation_gui.py:30
 msgid "Play a sound to indicate the presence of annotations"
 msgstr "使用音效提示有注释"
 
 #. Translators: the label of a checkbox
-#: bookworm/annotation/annotation_gui.py:40
+#: bookworm/annotation/annotation_gui.py:37
 msgid "Speak a message to indicate the presence of annotations"
 msgstr "使用语音提示有注释"
 
 #. Translators: the title of a group of controls in the settings dialog
-#: bookworm/annotation/annotation_gui.py:44
+#: bookworm/annotation/annotation_gui.py:41
 msgid "Miscellaneous settings"
 msgstr "杂项设置"
 
 #. Translators: the label of a checkbox
-#: bookworm/annotation/annotation_gui.py:49
+#: bookworm/annotation/annotation_gui.py:46
 msgid "Speak the bookmark when jumping"
 msgstr "跳转时读出书签"
 
 #. Translators: the label of a checkbox
-#: bookworm/annotation/annotation_gui.py:56
+#: bookworm/annotation/annotation_gui.py:53
 msgid "Select the bookmarked line when jumping"
 msgstr "跳转时选中书签线"
 
 #. Translators: the label of a checkbox
-#: bookworm/annotation/annotation_gui.py:63
+#: bookworm/annotation/annotation_gui.py:60
 msgid "Use visual styles to indicate annotations"
 msgstr "使用视觉样式显示注释"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:102
+#: bookworm/annotation/annotation_gui.py:99
 msgid "Add &Bookmark\tCtrl-B"
 msgstr "添加书签... \tCtrl-B"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:104
+#: bookworm/annotation/annotation_gui.py:101
 msgid "Add a bookmark at the current position"
 msgstr "在当前位置添加书签"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:109
+#: bookworm/annotation/annotation_gui.py:106
 msgid "Add &Named Bookmark...\tCtrl-Shift-B"
 msgstr "添加命名书签... \tCtrl-Shift-B"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:111
+#: bookworm/annotation/annotation_gui.py:108
 msgid "Add a named bookmark at the current position"
 msgstr "在当前位置添加并命名书签"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:116
+#: bookworm/annotation/annotation_gui.py:113
 msgid "Add Co&mment...\tCtrl-M"
 msgstr "添加注释... \tCtrl-M"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:118
+#: bookworm/annotation/annotation_gui.py:115
 msgid "Add a comment at the current position"
 msgstr "在当前位置添加注释"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:123
+#: bookworm/annotation/annotation_gui.py:120
 msgid "&Highlight Selection\tCtrl-H"
 msgstr "标记为高亮(&H)... \tCtrl-H"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:125
+#: bookworm/annotation/annotation_gui.py:122
 msgid "Highlight selected text and save it."
 msgstr "高亮显示所选文本并保存。"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:130
+#: bookworm/annotation/annotation_gui.py:127
 msgid "Saved &Bookmarks..."
 msgstr "已保存的书签(&B)..."
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:132
+#: bookworm/annotation/annotation_gui.py:129
 msgid "View added bookmarks"
 msgstr "查看已添加的书签"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:137
+#: bookworm/annotation/annotation_gui.py:134
 msgid "Saved Co&mments..."
 msgstr "已保存的注释(&M)..."
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:139
+#: bookworm/annotation/annotation_gui.py:136
 msgid "View, edit, and remove comments."
 msgstr "查看，编辑和删除注释。"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:144
+#: bookworm/annotation/annotation_gui.py:141
 msgid "Saved &Highlights..."
 msgstr "已保存的高亮(&H)..."
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:146
+#: bookworm/annotation/annotation_gui.py:143
 msgid "View saved highlights."
 msgstr "查看已保存的高亮显示。"
 
-#: bookworm/annotation/annotation_gui.py:184
+#: bookworm/annotation/annotation_gui.py:181
 msgid "Bookmark removed"
 msgstr "书签已删除"
 
 #. Translators: spoken message
-#: bookworm/annotation/annotation_gui.py:187
+#: bookworm/annotation/annotation_gui.py:184
 msgid "Bookmark Added"
 msgstr "书签已添加"
 
 #. Translators: title of a dialog
-#: bookworm/annotation/annotation_gui.py:196
+#: bookworm/annotation/annotation_gui.py:193
 msgid "Add Named Bookmark"
 msgstr "命名书签"
 
 #. Translators: label of a text entry
-#: bookworm/annotation/annotation_gui.py:198
+#: bookworm/annotation/annotation_gui.py:195
 msgid "Bookmark name:"
 msgstr "书签名称："
 
 #. Translators: the title of a dialog to add a comment
-#: bookworm/annotation/annotation_gui.py:208
+#: bookworm/annotation/annotation_gui.py:205
 msgid "New Comment"
 msgstr "添加注释"
 
 #. Translators: the label of an edit field to enter a comment
-#: bookworm/annotation/annotation_gui.py:210
+#: bookworm/annotation/annotation_gui.py:207
 msgid "Comment:"
 msgstr "注释："
 
 #. Translators: title of a dialog
-#: bookworm/annotation/annotation_gui.py:223
+#: bookworm/annotation/annotation_gui.py:220
 msgid "Tag Comment"
 msgstr "标签注释"
 
 #. Translators: label of a text entry
-#: bookworm/annotation/annotation_gui.py:225
-#: bookworm/annotation/annotation_gui.py:272
+#: bookworm/annotation/annotation_gui.py:222
+#: bookworm/annotation/annotation_gui.py:269
 msgid "Tags:"
 msgstr "标签："
 
-#: bookworm/annotation/annotation_gui.py:237
+#: bookworm/annotation/annotation_gui.py:234
 msgid "No selection"
 msgstr "无章节"
 
 #. Translators: spoken message
-#: bookworm/annotation/annotation_gui.py:245
+#: bookworm/annotation/annotation_gui.py:242
 msgid "Highlight removed"
 msgstr "已取消高亮"
 
 #. Translators: spoken message
-#: bookworm/annotation/annotation_gui.py:248
+#: bookworm/annotation/annotation_gui.py:245
 msgid "Already highlighted"
 msgstr "已高亮显示"
 
 #. Translators: spoken message
-#: bookworm/annotation/annotation_gui.py:255
-#: bookworm/annotation/annotation_gui.py:261
+#: bookworm/annotation/annotation_gui.py:252
+#: bookworm/annotation/annotation_gui.py:258
 msgid "Highlight extended"
 msgstr "高亮扩展"
 
 #. Translators: spoken message
-#: bookworm/annotation/annotation_gui.py:264
+#: bookworm/annotation/annotation_gui.py:261
 msgid "Selection highlighted"
 msgstr "高亮显示选中"
 
 #. Translators: title of a dialog
-#: bookworm/annotation/annotation_gui.py:270
+#: bookworm/annotation/annotation_gui.py:267
 msgid "Tag Highlight"
 msgstr "标签高亮"
 
 #. Translators: the title of a dialog to view bookmarks
-#: bookworm/annotation/annotation_gui.py:285
+#: bookworm/annotation/annotation_gui.py:282
 msgid "Bookmarks | {book}"
 msgstr "书签 | {book}"
 
-#: bookworm/annotation/annotation_gui.py:295
+#: bookworm/annotation/annotation_gui.py:292
 msgid "Comments"
 msgstr "注释"
 
-#: bookworm/annotation/annotation_gui.py:308
+#: bookworm/annotation/annotation_gui.py:305
 msgid "Highlights"
 msgstr "高亮"
 
@@ -672,7 +672,7 @@ msgstr "高亮"
 #. Translators: a name of a file format
 #. Translators: file type in a save as dialog
 #: bookworm/annotation/exporters/core_renderers.py:15
-#: bookworm/gui/book_viewer/menubar.py:257 bookworm/ocr/ocr_menu.py:287
+#: bookworm/gui/book_viewer/menubar.py:251 bookworm/ocr/ocr_menu.py:285
 msgid "Plain Text"
 msgstr "纯文本"
 
@@ -727,14 +727,14 @@ msgid "Copy to clipboard"
 msgstr "复制到剪贴板"
 
 #. Translators: the label of a page in the settings dialog
-#: bookworm/bookshelf/__init__.py:56
+#: bookworm/bookshelf/__init__.py:54
 msgid "Bookshelf"
 msgstr "书架"
 
 #. Translators: the label of an item in the application menubar
 #. Translators: the label of the bookshelf sub menu found in the file menu of
 #. the application
-#: bookworm/bookshelf/__init__.py:66
+#: bookworm/bookshelf/__init__.py:64
 msgid "Boo&kshelf"
 msgstr "书架(&K)"
 
@@ -742,7 +742,7 @@ msgstr "书架(&K)"
 #. preferences dialog
 #. Translators: the name of a book shelf type.
 #. This bookshelf type is stored in a local database
-#: bookworm/bookshelf/local_bookshelf/__init__.py:68
+#: bookworm/bookshelf/local_bookshelf/__init__.py:47
 #: bookworm/bookshelf/viewer_integration.py:36
 msgid "Local Bookshelf"
 msgstr "本地书架"
@@ -794,24 +794,24 @@ msgstr "无法添加文档"
 msgid "Reading list and collections"
 msgstr "阅读清单和收藏"
 
-#: bookworm/bookshelf/window.py:56
+#: bookworm/bookshelf/window.py:51
 msgid "{name} ({count})"
 msgstr "{name} ({count})"
 
 #. Translators: label of a text box to filter documents in bookshelf
-#: bookworm/bookshelf/window.py:80
+#: bookworm/bookshelf/window.py:74
 msgid "Filter documents..."
 msgstr "查找文档..."
 
 #. Translators: label of the bookshelf document list. This label is shown when
 #. the documents are being loaded from the database
-#: bookworm/bookshelf/window.py:86
+#: bookworm/bookshelf/window.py:80
 msgid "Loading items"
 msgstr "加载项目"
 
 #. Translators: content of a message shown when the bookshelf fails to load and
 #. show documents
-#: bookworm/bookshelf/window.py:196
+#: bookworm/bookshelf/window.py:190
 msgid ""
 "Failed to retrieve documents.\n"
 "Please try again."
@@ -832,179 +832,179 @@ msgstr ""
 #. Translators: title of a messagebox
 #. Translators: the title of a message telling the user that an error has
 #. occurred
-#: bookworm/bookshelf/local_bookshelf/__init__.py:291
-#: bookworm/bookshelf/local_bookshelf/__init__.py:337
-#: bookworm/bookshelf/local_bookshelf/__init__.py:383
-#: bookworm/bookshelf/local_bookshelf/dialogs.py:229
-#: bookworm/bookshelf/window.py:198 bookworm/gui/settings.py:584
-#: bookworm/ocr/ocr_dialogs.py:215 bookworm/ocr/ocr_dialogs.py:625
+#: bookworm/bookshelf/local_bookshelf/__init__.py:270
+#: bookworm/bookshelf/local_bookshelf/__init__.py:316
+#: bookworm/bookshelf/local_bookshelf/__init__.py:362
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:225
+#: bookworm/bookshelf/window.py:192 bookworm/gui/settings.py:579
+#: bookworm/ocr/ocr_dialogs.py:203 bookworm/ocr/ocr_dialogs.py:613
 #: bookworm/platforms/win32/pandoc_download.py:63
-#: bookworm/platforms/win32/tesseract_download.py:96
-#: bookworm/text_to_speech/tts_gui.py:429 bookworm/webservices/wikiworm.py:170
+#: bookworm/platforms/win32/tesseract_download.py:94
+#: bookworm/text_to_speech/tts_gui.py:426 bookworm/webservices/wikiworm.py:170
 msgid "Error"
 msgstr "错误"
 
 #. Translators: label of an item in the context menu of a document in the
 #. bookshelf
 #. Translators: the label of the close button in a dialog
-#: bookworm/bookshelf/window.py:238
-#: bookworm/gui/book_viewer/core_dialogs.py:397
+#: bookworm/bookshelf/window.py:232
+#: bookworm/gui/book_viewer/core_dialogs.py:388
 msgid "&Open"
 msgstr "打开(&O)"
 
 #. Translators: label of an item in the context menu of a document in the
 #. bookshelf
-#: bookworm/bookshelf/window.py:243
+#: bookworm/bookshelf/window.py:237
 msgid "Open in &system viewer"
 msgstr "在系统查看器中打开(&S)"
 
 #. Translators: label of an item in the context menu of a document in the
 #. bookshelf
-#: bookworm/bookshelf/window.py:248
+#: bookworm/bookshelf/window.py:242
 msgid "Edit &title"
 msgstr "编辑标题(&T)"
 
 #. Translators: spoken message when activating a document
 #. Translators: spoken message when no matching documents were found when
 #. filtering the document list
-#: bookworm/bookshelf/window.py:301
+#: bookworm/bookshelf/window.py:295
 msgid "No matching documents"
 msgstr "没有匹配的文档"
 
 #. Translators: message shown when loading documents in the bookshelf
-#: bookworm/bookshelf/window.py:355 bookworm/bookshelf/window.py:367
+#: bookworm/bookshelf/window.py:349 bookworm/bookshelf/window.py:361
 msgid "Retrieving items..."
 msgstr "正在检索项目..."
 
 #. Translators: label of an item in the context menu of a document in the
 #. bookshelf
-#: bookworm/bookshelf/window.py:392
+#: bookworm/bookshelf/window.py:386
 msgid "Document &info..."
 msgstr "文档信息(&I)..."
 
 #. Translators: label of the combo box showing a list of bookshelf providers.
 #. Currently, only the Local Bookshelf provider is implemented. In the future,
 #. other providers may be added, such as Bookshare and Pocket.
-#: bookworm/bookshelf/window.py:423
+#: bookworm/bookshelf/window.py:417
 msgid "Provider"
 msgstr "来源"
 
 #. Translators: label of the bookshelf tree that shows reading lists and
 #. collections and other categories
 #. Translators: label of the settings categories list box
-#: bookworm/bookshelf/window.py:430 bookworm/bookshelf/window.py:436
-#: bookworm/gui/settings.py:627
+#: bookworm/bookshelf/window.py:424 bookworm/bookshelf/window.py:430
+#: bookworm/gui/settings.py:622
 msgid "Categories"
 msgstr "类别"
 
 #. Translators: title of Bookshelf window
-#: bookworm/bookshelf/window.py:473
+#: bookworm/bookshelf/window.py:467
 msgid "Bookworm Bookshelf: {name}"
 msgstr "Bookworm 书架： {name}"
 
 #. Translators: label of a menu item to exit the application
-#: bookworm/bookshelf/window.py:497
+#: bookworm/bookshelf/window.py:491
 msgid "&Exit"
 msgstr "退出(&E)"
 
 #. Translators: lable of the file menu in the menu bar
 #. Translators: the label of an item in the application menubar
-#: bookworm/bookshelf/window.py:500 bookworm/gui/book_viewer/menubar.py:889
+#: bookworm/bookshelf/window.py:494 bookworm/gui/book_viewer/menubar.py:883
 msgid "&File"
 msgstr "文件(&F)"
 
 #. Translators: the label of a menu item to remove a bookshelf reading list or
 #. collection
-#: bookworm/bookshelf/local_bookshelf/__init__.py:77
+#: bookworm/bookshelf/local_bookshelf/__init__.py:56
 msgid "Remove..."
 msgstr "删除..."
 
 #. Translators: the label of a menu item to change the name of a bookshelf
 #. reading list or collection
-#: bookworm/bookshelf/local_bookshelf/__init__.py:82
+#: bookworm/bookshelf/local_bookshelf/__init__.py:61
 msgid "Edit name..."
 msgstr "编辑名称..."
 
 #. Translators: the label of a menu item to remove all documents under a
 #. specific bookshelf reading list or collection
-#: bookworm/bookshelf/local_bookshelf/__init__.py:87
+#: bookworm/bookshelf/local_bookshelf/__init__.py:66
 msgid "Clear documents..."
 msgstr "清除文档..."
 
 #. Translators: the name of a category in the bookshelf for recently added
 #. documents
-#: bookworm/bookshelf/local_bookshelf/__init__.py:111
+#: bookworm/bookshelf/local_bookshelf/__init__.py:90
 msgid "Recently Added"
 msgstr "最近添加"
 
 #. Translators: the name of a category in the bookshelf for documents currently
 #. being read by the user
-#: bookworm/bookshelf/local_bookshelf/__init__.py:118
+#: bookworm/bookshelf/local_bookshelf/__init__.py:97
 msgid "Currently Reading"
 msgstr "正在阅读"
 
 #. Translators: the name of a category in the bookshelf for documents the user
 #. wants to read
-#: bookworm/bookshelf/local_bookshelf/__init__.py:127
+#: bookworm/bookshelf/local_bookshelf/__init__.py:106
 msgid "Want to Read"
 msgstr "想要阅读"
 
 #. Translators: the name of a category in the bookshelf for documents favored
 #. by the user
-#: bookworm/bookshelf/local_bookshelf/__init__.py:136
+#: bookworm/bookshelf/local_bookshelf/__init__.py:115
 msgid "Favorites"
 msgstr "最爱"
 
 #. Translators: the name of a category in the bookshelf which contains the
 #. user's reading lists
-#: bookworm/bookshelf/local_bookshelf/__init__.py:146
+#: bookworm/bookshelf/local_bookshelf/__init__.py:125
 msgid "Reading Lists"
 msgstr "阅读清单"
 
 #. Translators: the name of a category in the bookshelf which contains the
 #. user's collections
 #. Translators: label of a text box for entering a document's collections
-#: bookworm/bookshelf/local_bookshelf/__init__.py:151
-#: bookworm/bookshelf/local_bookshelf/dialogs.py:51
+#: bookworm/bookshelf/local_bookshelf/__init__.py:130
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:47
 msgid "Collections"
 msgstr "收藏"
 
 #. Translators: the name of a reading list in the bookshelf which contains
 #. documents that do not have any category assigned to them
 #. Translators: the label of a page in the settings dialog
-#: bookworm/bookshelf/local_bookshelf/__init__.py:159
-#: bookworm/gui/settings.py:595
+#: bookworm/bookshelf/local_bookshelf/__init__.py:138
+#: bookworm/gui/settings.py:590
 msgid "General"
 msgstr "常规"
 
 #. Translators: the label of a menu item in the bookshelf to add a new reading
 #. list or collection
-#: bookworm/bookshelf/local_bookshelf/__init__.py:168
+#: bookworm/bookshelf/local_bookshelf/__init__.py:147
 msgid "Add New..."
 msgstr "新增..."
 
 #. Translators: the name of a category in the bookshelf that lists the authors
 #. of the documents stored in the bookshelf
-#: bookworm/bookshelf/local_bookshelf/__init__.py:187
-#: bookworm/gui/book_viewer/core_dialogs.py:362
+#: bookworm/bookshelf/local_bookshelf/__init__.py:166
+#: bookworm/gui/book_viewer/core_dialogs.py:353
 msgid "Authors"
 msgstr "作者"
 
 #. Translators: the label of a menu item in the bookshelf file menu to import
 #. documents to the bookshelf
-#: bookworm/bookshelf/local_bookshelf/__init__.py:198
+#: bookworm/bookshelf/local_bookshelf/__init__.py:177
 msgid "Import Documents...\tCtrl+O"
 msgstr "导入文档...\tCtrl+O"
 
 #. Translators: the label of a menu item in the bookshelf file menu to import
 #. an entire folder to the bookshelf
-#: bookworm/bookshelf/local_bookshelf/__init__.py:203
+#: bookworm/bookshelf/local_bookshelf/__init__.py:182
 msgid "Import documents from folder..."
 msgstr "从文件夹导入文档(&F)..."
 
 #. Translators: the label of a menu item in the bookshelf file menu to search
 #. documents contained in the bookshelf
-#: bookworm/bookshelf/local_bookshelf/__init__.py:207
+#: bookworm/bookshelf/local_bookshelf/__init__.py:186
 msgid "Search Bookshelf..."
 msgstr "搜索书架..."
 
@@ -1012,18 +1012,18 @@ msgstr "搜索书架..."
 #. files added to the bookshelf to a private folder that blongs to Bookworm.
 #. This is important to make the bookshelf works with  portable copies, or if
 #. the user wants to move or rename added documents
-#: bookworm/bookshelf/local_bookshelf/__init__.py:210
+#: bookworm/bookshelf/local_bookshelf/__init__.py:189
 msgid "Bundle Documents..."
 msgstr "存档文档..."
 
 #. Translators: the label of a menu item in the bookshelf file menu to clear
 #. documents that no longer exist in the file system
-#: bookworm/bookshelf/local_bookshelf/__init__.py:213
+#: bookworm/bookshelf/local_bookshelf/__init__.py:192
 msgid "Clear invalid documents..."
 msgstr "清除无效文档..."
 
 #. Translators: the title of a file dialog to browse to a document
-#: bookworm/bookshelf/local_bookshelf/__init__.py:225
+#: bookworm/bookshelf/local_bookshelf/__init__.py:204
 msgid "Import Documents To Bookshelf"
 msgstr "将文档导入书架"
 
@@ -1031,82 +1031,82 @@ msgstr "将文档导入书架"
 #. collection
 #. Translators: title of a dialog to change the reading list or collection for
 #. a document
-#: bookworm/bookshelf/local_bookshelf/__init__.py:241
-#: bookworm/bookshelf/local_bookshelf/__init__.py:641
+#: bookworm/bookshelf/local_bookshelf/__init__.py:220
+#: bookworm/bookshelf/local_bookshelf/__init__.py:620
 msgid "Edit reading list/collections"
 msgstr "编辑阅读列表/收藏"
 
 #. Translators: a message shown when Bookworm is importing documents to the
 #. bookshelf
-#: bookworm/bookshelf/local_bookshelf/__init__.py:258
+#: bookworm/bookshelf/local_bookshelf/__init__.py:237
 msgid "Importing document..."
 msgstr "正在导入文档..."
 
 #. Translators: a message shown when Bookworm is importing documents to the
 #. bookshelf
-#: bookworm/bookshelf/local_bookshelf/__init__.py:261
+#: bookworm/bookshelf/local_bookshelf/__init__.py:240
 msgid "Importing documents..."
 msgstr "正在导入文档..."
 
 #. Translators: content of a message shown when importing documents to the
 #. bookshelf has failed
-#: bookworm/bookshelf/local_bookshelf/__init__.py:289
+#: bookworm/bookshelf/local_bookshelf/__init__.py:268
 msgid "Failed to import document. Please try again."
 msgstr "文档导入失败。请重试。"
 
 #. Translators: title of a dialog to import an entire folder to the bookshelf
-#: bookworm/bookshelf/local_bookshelf/__init__.py:302
+#: bookworm/bookshelf/local_bookshelf/__init__.py:281
 msgid "Import Documents From Folder"
 msgstr "从文件夹导入文档"
 
 #. Translators: a message shown when importing an entire folder to the
 #. bookshelf
-#: bookworm/bookshelf/local_bookshelf/__init__.py:316
+#: bookworm/bookshelf/local_bookshelf/__init__.py:295
 msgid "Importing documents from folder. Please wait..."
 msgstr "正在从文件夹导入文档。请稍等..."
 
 #. Translators: content of a message shown when importing documents from a
 #. folder to the bookshelf is successful
-#: bookworm/bookshelf/local_bookshelf/__init__.py:325
+#: bookworm/bookshelf/local_bookshelf/__init__.py:304
 msgid "Documents imported from folder."
 msgstr "从文件夹导入的文档。"
 
 #. Translators: title of a message shown when importing documents from a folder
 #. to the bookshelf is successful
-#: bookworm/bookshelf/local_bookshelf/__init__.py:327
+#: bookworm/bookshelf/local_bookshelf/__init__.py:306
 msgid "Operation Completed"
 msgstr "操作完成"
 
 #. Translators: content of a message shown when importing documents from a
 #. folder to the bookshelf has failed
-#: bookworm/bookshelf/local_bookshelf/__init__.py:335
+#: bookworm/bookshelf/local_bookshelf/__init__.py:314
 msgid "Failed to import documents from folder."
 msgstr "从文件夹导入文档失败。"
 
 #. Translators: title of a dialog to search bookshelf
-#: bookworm/bookshelf/local_bookshelf/__init__.py:345
+#: bookworm/bookshelf/local_bookshelf/__init__.py:324
 msgid "Search Bookshelf"
 msgstr "搜索书架"
 
 #. Translators: a message shown while searching bookshelf
-#: bookworm/bookshelf/local_bookshelf/__init__.py:358
+#: bookworm/bookshelf/local_bookshelf/__init__.py:337
 msgid "Searching bookshelf..."
 msgstr "搜索书架..."
 
 #. Translators: content of a message shown when searching bookshelf has failed
-#: bookworm/bookshelf/local_bookshelf/__init__.py:381
+#: bookworm/bookshelf/local_bookshelf/__init__.py:360
 msgid "Failed to search bookshelf,"
 msgstr "搜索书架失败,"
 
 #. Translators: title of a dialog that shows bookshelf search results. It
 #. searches documents by title and content, hence full-text
-#: bookworm/bookshelf/local_bookshelf/__init__.py:398
+#: bookworm/bookshelf/local_bookshelf/__init__.py:377
 msgid "Full Text Search Results"
 msgstr "全文搜索结果"
 
 #. Translators: content of a message to confirm the bundling of documents added
 #. to bookshelf
-#: bookworm/bookshelf/local_bookshelf/__init__.py:408
+#: bookworm/bookshelf/local_bookshelf/__init__.py:387
 msgid ""
 "This will create copies of all of the documents you have added to your Local "
 "Bookshelf.\n"
@@ -1122,35 +1122,35 @@ msgstr ""
 
 #. Translators: title of a message to confirm the bundling of documents added
 #. to bookshelf
-#: bookworm/bookshelf/local_bookshelf/__init__.py:412
+#: bookworm/bookshelf/local_bookshelf/__init__.py:391
 msgid "Bundle Documents?"
 msgstr "存档文档？"
 
 #. Translators: a message shown when bundling documents added to bookshelf
-#: bookworm/bookshelf/local_bookshelf/__init__.py:420
+#: bookworm/bookshelf/local_bookshelf/__init__.py:399
 msgid "Bundling documents. Please wait..."
 msgstr "正在存档，请稍后..."
 
 #. Translators: content of a message when bundling of documents is successful
-#: bookworm/bookshelf/local_bookshelf/__init__.py:449
+#: bookworm/bookshelf/local_bookshelf/__init__.py:428
 msgid "Bundled {num_documents} files."
 msgstr "存档了 {num_documents} 个文件。"
 
 #. Translators: title of a message when bundling of documents is successful
-#: bookworm/bookshelf/local_bookshelf/__init__.py:451
+#: bookworm/bookshelf/local_bookshelf/__init__.py:430
 msgid "Done"
 msgstr "完毕"
 
 #. Translators: title of a dialog that shows titles and paths of documents
 #. which have not been bundled successfully
-#: bookworm/bookshelf/local_bookshelf/__init__.py:459
+#: bookworm/bookshelf/local_bookshelf/__init__.py:438
 msgid "Bundle Results: {num_succesfull} successfull, {num_faild} faild"
 msgstr "存档结果： {num_succesfull} 成功，{num_faild} 失败"
 
 #. Translators: content of a message to confirm the clearing of documents
 #. which have been added to bookshelf, but they have been moved, renamed, or
 #. deleted
-#: bookworm/bookshelf/local_bookshelf/__init__.py:471
+#: bookworm/bookshelf/local_bookshelf/__init__.py:450
 msgid ""
 "This action will clear invalid documents from your bookshelf.\n"
 "Invalid documents are the documents which no longer exist on your computer."
@@ -1162,25 +1162,25 @@ msgstr ""
 #. Translators: title of a message to confirm the clearing of documents
 #. which have been added to bookshelf, but they have been moved, renamed, or
 #. deleted
-#: bookworm/bookshelf/local_bookshelf/__init__.py:476
+#: bookworm/bookshelf/local_bookshelf/__init__.py:455
 msgid "Clear Invalid Documents?"
 msgstr "清除无效文档？"
 
 #. Translators: label of a text box to change the name of a reading list or
 #. collection
-#: bookworm/bookshelf/local_bookshelf/__init__.py:491
+#: bookworm/bookshelf/local_bookshelf/__init__.py:470
 msgid "New name:"
 msgstr "新名称："
 
 #. Translators: title of a dialog to change the name of a reading list or
 #. collection
-#: bookworm/bookshelf/local_bookshelf/__init__.py:493
+#: bookworm/bookshelf/local_bookshelf/__init__.py:472
 msgid "Edit Name"
 msgstr "编辑名称"
 
 #. Translators: content of a message when changing the name of a reading list
 #. or collection was not successful
-#: bookworm/bookshelf/local_bookshelf/__init__.py:503
+#: bookworm/bookshelf/local_bookshelf/__init__.py:482
 msgid ""
 "The given name {name} already exists.\n"
 "Please choose another name."
@@ -1188,13 +1188,13 @@ msgstr "名称 {name} 已存在。请选择其他名称。"
 
 #. Translators: title of a message when changing the name of a reading list or
 #. collection was not successful
-#: bookworm/bookshelf/local_bookshelf/__init__.py:507
+#: bookworm/bookshelf/local_bookshelf/__init__.py:486
 msgid "Duplicate name"
 msgstr "重复名称"
 
 #. Translators: content of a message to confirm the removal of a reading list
 #. or collection
-#: bookworm/bookshelf/local_bookshelf/__init__.py:517
+#: bookworm/bookshelf/local_bookshelf/__init__.py:496
 msgid ""
 "Are you sure you want to remove {name}?\n"
 "This will not remove document classified under {name}."
@@ -1206,15 +1206,15 @@ msgstr ""
 #. collection
 #. Translators: title of a message box
 #. Translators: title of a messagebox
-#: bookworm/bookshelf/local_bookshelf/__init__.py:521
-#: bookworm/gui/components.py:610 bookworm/ocr/ocr_dialogs.py:541
-#: bookworm/ocr/ocr_dialogs.py:583
+#: bookworm/bookshelf/local_bookshelf/__init__.py:500
+#: bookworm/gui/components.py:610 bookworm/ocr/ocr_dialogs.py:529
+#: bookworm/ocr/ocr_dialogs.py:571
 msgid "Confirm"
 msgstr "确认"
 
 #. Translators: content of a message to confirm the removal of all documents
 #. classified under a specific reading list or collection
-#: bookworm/bookshelf/local_bookshelf/__init__.py:532
+#: bookworm/bookshelf/local_bookshelf/__init__.py:511
 msgid ""
 "Are you sure you want to clear all documents classified under {name}?\n"
 "This will remove those documents from your bookshelf."
@@ -1224,72 +1224,72 @@ msgstr ""
 
 #. Translators: title of a message to confirm the removal of all documents
 #. classified under a specific reading list or collection
-#: bookworm/bookshelf/local_bookshelf/__init__.py:536
+#: bookworm/bookshelf/local_bookshelf/__init__.py:515
 msgid "Clear All Documents"
 msgstr "清除所有文档"
 
 #. Translators: label of a text box for the name of a new reading list or
 #. collection
-#: bookworm/bookshelf/local_bookshelf/__init__.py:549
+#: bookworm/bookshelf/local_bookshelf/__init__.py:528
 msgid "Enter name:"
 msgstr "输入名称："
 
 #. Translators: title of a dialog  for adding a new reading list or collection
-#: bookworm/bookshelf/local_bookshelf/__init__.py:551
+#: bookworm/bookshelf/local_bookshelf/__init__.py:530
 msgid "Add New"
 msgstr "新增"
 
 #. Translators: label of an item in the context menu of a document in the
 #. bookshelf
-#: bookworm/bookshelf/local_bookshelf/__init__.py:576
+#: bookworm/bookshelf/local_bookshelf/__init__.py:555
 msgid "&Edit reading list / collections..."
 msgstr "编辑阅读列表/收藏(&D)..."
 
 #. Translators: label of an item in the context menu of a document in the
 #. bookshelf
-#: bookworm/bookshelf/local_bookshelf/__init__.py:581
+#: bookworm/bookshelf/local_bookshelf/__init__.py:560
 msgid "Remove from &currently reading"
 msgstr "从正在阅读中删除(&C)"
 
 #. Translators: label of an item in the context menu of a document in the
 #. bookshelf
-#: bookworm/bookshelf/local_bookshelf/__init__.py:583
+#: bookworm/bookshelf/local_bookshelf/__init__.py:562
 msgid "Add to &currently reading"
 msgstr "添加到正在阅读(&C)"
 
 #. Translators: label of an item in the context menu of a document in the
 #. bookshelf
-#: bookworm/bookshelf/local_bookshelf/__init__.py:588
+#: bookworm/bookshelf/local_bookshelf/__init__.py:567
 msgid "Remove from &want to read"
 msgstr "从想要阅读中删除(&W)"
 
 #. Translators: label of an item in the context menu of a document in the
 #. bookshelf
-#: bookworm/bookshelf/local_bookshelf/__init__.py:590
+#: bookworm/bookshelf/local_bookshelf/__init__.py:569
 msgid "Add to &want to read"
 msgstr "添加到想要阅读(&W)"
 
 #. Translators: label of an item in the context menu of a document in the
 #. bookshelf
-#: bookworm/bookshelf/local_bookshelf/__init__.py:595
+#: bookworm/bookshelf/local_bookshelf/__init__.py:574
 msgid "Remove from &favorites"
 msgstr "从最爱中删除(&F)"
 
 #. Translators: label of an item in the context menu of a document in the
 #. bookshelf
-#: bookworm/bookshelf/local_bookshelf/__init__.py:597
+#: bookworm/bookshelf/local_bookshelf/__init__.py:576
 msgid "Add to &favorites"
 msgstr "添加到最爱(&F)"
 
 #. Translators: label of an item in the context menu of a document in the
 #. bookshelf
-#: bookworm/bookshelf/local_bookshelf/__init__.py:602
+#: bookworm/bookshelf/local_bookshelf/__init__.py:581
 msgid "&Remove from bookshelf"
 msgstr "从书架中删除(&R)"
 
 #. Translators: content of a message to confirm the removal of this document
 #. from bookshelf
-#: bookworm/bookshelf/local_bookshelf/__init__.py:668
+#: bookworm/bookshelf/local_bookshelf/__init__.py:647
 msgid ""
 "Are you sure you want to remove this document from your bookshelf?\n"
 "Title: {title}\n"
@@ -1301,45 +1301,45 @@ msgstr ""
 
 #. Translators: title of a message to confirm the removal of this document from
 #. bookshelf
-#: bookworm/bookshelf/local_bookshelf/__init__.py:672
+#: bookworm/bookshelf/local_bookshelf/__init__.py:651
 msgid "Remove From Bookshelf?"
 msgstr "从书架上删除？"
 
 #. Translators: the name of a category under the Authors category. This
 #. category shows documents for which  author info is not available
-#: bookworm/bookshelf/local_bookshelf/__init__.py:704
+#: bookworm/bookshelf/local_bookshelf/__init__.py:683
 msgid "Unknown Author"
 msgstr "未知作者"
 
 #. Translators: label of a combo box for choosing a document's reading list
 #. Translators: label of a button
-#: bookworm/bookshelf/local_bookshelf/dialogs.py:47
-#: bookworm/bookshelf/local_bookshelf/dialogs.py:90
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:43
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:86
 msgid "Reading List"
 msgstr "阅读列表"
 
 #. Translators: label of a check box
-#: bookworm/bookshelf/local_bookshelf/dialogs.py:55
-#: bookworm/bookshelf/local_bookshelf/dialogs.py:97
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:51
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:93
 msgid "Add to full-text search index"
 msgstr "添加到全文搜索索引"
 
 #. Translators: label of an edit control for entering the path to a folder to
 #. import to the bookshelf
-#: bookworm/bookshelf/local_bookshelf/dialogs.py:84
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:80
 msgid "Select a folder:"
 msgstr "选择一个文件夹："
 
 #. Translators: label of a text box for entering a search term
 #. Translators: the label of a button in the application toolbar
-#: bookworm/bookshelf/local_bookshelf/dialogs.py:116
-#: bookworm/gui/book_viewer/__init__.py:412
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:112
+#: bookworm/gui/book_viewer/__init__.py:402
 msgid "Search"
 msgstr "搜索"
 
 #. Translators: title of a group of controls to select which document field to
 #. search in when searching bookshelf
-#: bookworm/bookshelf/local_bookshelf/dialogs.py:120
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:116
 msgid "Search Field"
 msgstr "搜索范围"
 
@@ -1349,55 +1349,55 @@ msgstr "搜索范围"
 #. of search results of matching document titles
 #. Translators: title of a list control colum showing the document titles  of
 #. documents not bundled due to errors when bundling documents
-#: bookworm/bookshelf/local_bookshelf/dialogs.py:124
-#: bookworm/bookshelf/local_bookshelf/dialogs.py:190
-#: bookworm/bookshelf/local_bookshelf/dialogs.py:233
-#: bookworm/gui/book_viewer/core_dialogs.py:351
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:120
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:186
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:229
+#: bookworm/gui/book_viewer/core_dialogs.py:342
 msgid "Title"
 msgstr "标题"
 
 #. Translators: label of a list showing search results of documents with title
 #. matching the given  search query
-#: bookworm/bookshelf/local_bookshelf/dialogs.py:158
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:154
 msgid "Title matches"
 msgstr "标题匹配"
 
 #. Translators: the label of a tab in a tabl control in a dialog showing a list
 #. of search results in the bookshelf
-#: bookworm/bookshelf/local_bookshelf/dialogs.py:161
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:157
 msgid "Title Matches"
 msgstr "标题匹配"
 
 #. Translators: label of a list showing search results of content matching the
 #. given  search query
-#: bookworm/bookshelf/local_bookshelf/dialogs.py:168
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:164
 msgid "Content matches"
 msgstr "内容匹配"
 
 #. Translators: the label of a tab in a tabl control in a dialog showing a list
 #. of search results in the bookshelf
-#: bookworm/bookshelf/local_bookshelf/dialogs.py:171
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:167
 msgid "Content Matches"
 msgstr "内容匹配"
 
-#: bookworm/bookshelf/local_bookshelf/dialogs.py:187
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:183
 msgid "Snippet"
 msgstr "片段"
 
 #. Translators: title of a list control colum showing the file names of files
 #. not bundled due to errors when bundling documents
-#: bookworm/bookshelf/local_bookshelf/dialogs.py:231
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:227
 msgid "File Name"
 msgstr "文件名"
 
 #. Translators: label of a list control showing file copy errors
-#: bookworm/bookshelf/local_bookshelf/dialogs.py:236
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:232
 msgid "Errors"
 msgstr "错误"
 
 #. Translators: label shown in a list control indicating the failure to copy
 #. the document when bundling documents
-#: bookworm/bookshelf/local_bookshelf/dialogs.py:239
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:235
 msgid "Failed to copy document"
 msgstr "无法复制文档"
 
@@ -1430,42 +1430,42 @@ msgid "Full text"
 msgstr "全文"
 
 #. Translators: the name of a document file format
-#: bookworm/document/formats/archive.py:46
+#: bookworm/document/formats/archive.py:42
 msgid "Archive File"
 msgstr "存档文件"
 
 #. Translators: the name of a document file format
-#: bookworm/document/formats/epub.py:47
+#: bookworm/document/formats/epub.py:48
 msgid "Electronic Publication (EPUB)"
 msgstr "Electronic Publication (EPUB)"
 
 #. Translators: the name of a document file format
-#: bookworm/document/formats/fb2.py:24 bookworm/document/formats/fb2.py:36
+#: bookworm/document/formats/fb2.py:23 bookworm/document/formats/fb2.py:34
 msgid "Fiction Book (FB2)"
 msgstr "Fiction Book (FB2)"
 
 #. Translators: the name of a document file format
-#: bookworm/document/formats/fitz.py:175
+#: bookworm/document/formats/fitz.py:169
 msgid "XPS Document"
 msgstr "XPS Document"
 
 #. Translators: the name of a document file format
-#: bookworm/document/formats/fitz.py:183
+#: bookworm/document/formats/fitz.py:176
 msgid "Comic Book Archive"
 msgstr "Comic Book Archive"
 
 #. Translators: the name of a document file format
-#: bookworm/document/formats/html.py:189 bookworm/document/formats/html.py:259
+#: bookworm/document/formats/html.py:174 bookworm/document/formats/html.py:243
 msgid "HTML Document"
 msgstr "HTML Document"
 
 #. Translators: the name of a document file format
-#: bookworm/document/formats/markdown.py:20
+#: bookworm/document/formats/markdown.py:19
 msgid "Markdown File"
 msgstr "Markdown File"
 
 #. Translators: the name of a document file format
-#: bookworm/document/formats/mobi.py:40
+#: bookworm/document/formats/mobi.py:39
 msgid "Kindle eBook"
 msgstr "Kindle eBook"
 
@@ -1480,37 +1480,37 @@ msgid "Open Document Presentation"
 msgstr "Open Document Presentation"
 
 #: bookworm/document/formats/odf.py:191
-#: bookworm/document/formats/powerpoint.py:156
+#: bookworm/document/formats/powerpoint.py:155
 msgid "Slide {number}"
 msgstr "幻灯片 {number}"
 
 #. Translators: the name of a document file format
-#: bookworm/document/formats/pandoc.py:39
+#: bookworm/document/formats/pandoc.py:38
 msgid "Rich Text Document"
 msgstr "富文本文档"
 
 #. Translators: the name of a document file format
-#: bookworm/document/formats/pandoc.py:48
+#: bookworm/document/formats/pandoc.py:47
 msgid "Docbook Document"
 msgstr "Docbook Document"
 
 #. Translators: the name of a document file format
-#: bookworm/document/formats/pandoc.py:57
+#: bookworm/document/formats/pandoc.py:56
 msgid "Jupyter notebook"
 msgstr "Jupyter notebook"
 
 #. Translators: the name of a document file format
-#: bookworm/document/formats/pandoc.py:66
+#: bookworm/document/formats/pandoc.py:65
 msgid "LaTeX Document"
 msgstr "LaTeX 文档"
 
 #. Translators: the name of a document file format
-#: bookworm/document/formats/pandoc.py:75
+#: bookworm/document/formats/pandoc.py:74
 msgid "Text2Tags Document"
 msgstr "Text2Tags 文档"
 
 #. Translators: the name of a document file format
-#: bookworm/document/formats/pandoc.py:84
+#: bookworm/document/formats/pandoc.py:83
 msgid "Unix manual page"
 msgstr "Unix manual page"
 
@@ -1520,7 +1520,7 @@ msgid "Portable Document (PDF)"
 msgstr "Portable Document (PDF)"
 
 #. Translators: the name of a document file format
-#: bookworm/document/formats/plain_text.py:31
+#: bookworm/document/formats/plain_text.py:28
 msgid "Plain Text File"
 msgstr "Plain Text File"
 
@@ -1529,17 +1529,17 @@ msgid "Slide Notes"
 msgstr "幻灯片备注"
 
 #. Translators: the name of a document file format
-#: bookworm/document/formats/powerpoint.py:116
+#: bookworm/document/formats/powerpoint.py:115
 msgid "PowerPoint Presentation"
 msgstr "PowerPoint Presentation"
 
 #. Translators: the name of a document file format
-#: bookworm/document/formats/word.py:45
+#: bookworm/document/formats/word.py:44
 msgid "Word Document"
 msgstr "Word Document"
 
 #. Translators: the name of a document file format
-#: bookworm/document/formats/word.py:136
+#: bookworm/document/formats/word.py:134
 msgid "Word 97 - 2003 Document"
 msgstr "Word 97 - 2003 Document"
 
@@ -1563,11 +1563,11 @@ msgstr "无法启动 Web 查看器"
 msgid "An error occurred while opening the web viewer. Please try again."
 msgstr "打开 Web 查看器时出错。请重试。"
 
-#: bookworm/epub_serve/webapp.py:148
+#: bookworm/epub_serve/webapp.py:140
 msgid "404 Not Found"
 msgstr "404 Not Found"
 
-#: bookworm/epub_serve/webapp.py:149
+#: bookworm/epub_serve/webapp.py:141
 msgid ""
 "The book you are trying to access does not exist or has been closed. Please "
 "make sure you opened the book from within Bookworm. All URLs are temporary "
@@ -1576,11 +1576,11 @@ msgstr ""
 "您尝试访问的图书不存在或已关闭。请确保您是从 Bookworm 中打开这本书的。所有 "
 "URL 都是临时的，在您关闭页面后可能无法使用。"
 
-#: bookworm/epub_serve/webapp.py:188
+#: bookworm/epub_serve/webapp.py:180
 msgid "Failed to load content"
 msgstr "无法加载内容"
 
-#: bookworm/epub_serve/webapp.py:189
+#: bookworm/epub_serve/webapp.py:181
 msgid "Cannot retreive content. Probably the eBook has been closed."
 msgstr "无法检索内容。可能该电子书已关闭。"
 
@@ -1625,14 +1625,14 @@ msgstr "所选章节："
 
 #. Translators: the label of the OK button in a dialog
 #: bookworm/gui/components.py:277 bookworm/gui/components.py:318
-#: bookworm/gui/settings.py:651
+#: bookworm/gui/settings.py:646
 msgid "OK"
 msgstr "确定(&O)"
 
 #. Translators: the lable of the cancel button in a dialog
 #. Translators: the label of the cancel button in a dialog
 #: bookworm/gui/components.py:280 bookworm/gui/components.py:321
-#: bookworm/gui/settings.py:654
+#: bookworm/gui/settings.py:649
 msgid "Cancel"
 msgstr "取消(&C)"
 
@@ -1648,11 +1648,11 @@ msgstr ""
 "你确定要中止吗？"
 
 #. Translators: the title of the file associations dialog
-#: bookworm/gui/settings.py:48
+#: bookworm/gui/settings.py:44
 msgid "Bookworm File Associations"
 msgstr "Bookworm文件关联"
 
-#: bookworm/gui/settings.py:60
+#: bookworm/gui/settings.py:56
 msgid ""
 "This dialog will help you to setup file associations.\n"
 "Associating files with Bookworm means that when you click on a file in "
@@ -1663,37 +1663,37 @@ msgstr ""
 "文件 "
 
 #. Translators: the main label of a button
-#: bookworm/gui/settings.py:73
+#: bookworm/gui/settings.py:69
 msgid "Associate all"
 msgstr "关联所有格式"
 
 #. Translators: the note of a button
-#: bookworm/gui/settings.py:75
+#: bookworm/gui/settings.py:71
 msgid "Use Bookworm to open all supported document formats"
 msgstr "使用Bookworm打开所有支持的文档格式"
 
 #. Translators: the main label of a button
-#: bookworm/gui/settings.py:83
+#: bookworm/gui/settings.py:79
 msgid "Associate files of type {format}"
 msgstr "{format}文件"
 
 #. Translators: the note of a button
-#: bookworm/gui/settings.py:85
+#: bookworm/gui/settings.py:81
 msgid "Associate files with {ext} extension so they always open in Bookworm"
 msgstr "{ext} 在 Bookworm 中打开该类型的文件"
 
 #. Translators: the main label of a button
-#: bookworm/gui/settings.py:98
+#: bookworm/gui/settings.py:94
 msgid "Dissociate all supported file types"
 msgstr "取消所有支持文件类型的关联"
 
 #. Translators: the note of a button
-#: bookworm/gui/settings.py:100
+#: bookworm/gui/settings.py:96
 msgid "Remove previously associated file types"
 msgstr "删除之前关联的文件类型"
 
 #. Translators: the text of a message indicating successful file association
-#: bookworm/gui/settings.py:117
+#: bookworm/gui/settings.py:113
 msgid "Files of type {format} have been associated with Bookworm."
 msgstr "{format}类型已与Bookworm关联。"
 
@@ -1701,102 +1701,102 @@ msgstr "{format}类型已与Bookworm关联。"
 #. Translators: the title of a message indicating successful removal of file
 #. association
 #. Translators: title of a message box
-#: bookworm/gui/book_viewer/menubar.py:337 bookworm/gui/settings.py:121
-#: bookworm/gui/settings.py:139 bookworm/platforms/win32/pandoc_download.py:45
-#: bookworm/platforms/win32/tesseract_download.py:76
+#: bookworm/gui/book_viewer/menubar.py:331 bookworm/gui/settings.py:117
+#: bookworm/gui/settings.py:135 bookworm/platforms/win32/pandoc_download.py:45
+#: bookworm/platforms/win32/tesseract_download.py:74
 msgid "Success"
 msgstr "成功"
 
 #. Translators: the text of a message indicating successful removal of file
 #. associations
-#: bookworm/gui/settings.py:130
+#: bookworm/gui/settings.py:126
 msgid "All supported file types have been set to open by default in Bookworm."
 msgstr "在Bookworm中，默认情况下将所有受支持的文件类型设置为打开。"
 
 #. Translators: the text of a message indicating successful removal of file
 #. associations
-#: bookworm/gui/settings.py:135
+#: bookworm/gui/settings.py:131
 msgid "All registered file associations have been removed."
 msgstr "已取消所有的文件关联。"
 
 #. Translators: the title of a group of controls in the
 #. general settings page related to the UI
-#: bookworm/gui/settings.py:220
+#: bookworm/gui/settings.py:215
 msgid "User Interface"
 msgstr "用户界面"
 
 #. Translators: the label of a combobox containing display languages.
-#: bookworm/gui/settings.py:222
+#: bookworm/gui/settings.py:217
 msgid "Display Language:"
 msgstr "显示语言："
 
 #. Translators: the title of a group of controls shown in the
 #. general settings page related to spoken feedback
-#: bookworm/gui/settings.py:227
+#: bookworm/gui/settings.py:222
 msgid "Spoken feedback"
 msgstr "语音反馈"
 
 #. Translators: the label of a checkbox
-#: bookworm/gui/settings.py:232
+#: bookworm/gui/settings.py:227
 msgid "Speak user interface messages"
 msgstr "读出用户介面信息"
 
 #. Translators: the title of a group of controls shown in the
 #. general settings page related to miscellaneous settings
-#: bookworm/gui/settings.py:237
+#: bookworm/gui/settings.py:232
 msgid "Miscellaneous"
 msgstr "杂项"
 
 #. Translators: the label of a checkbox
-#: bookworm/gui/settings.py:242
+#: bookworm/gui/settings.py:237
 msgid "Play pagination sound"
 msgstr "播放翻页音效"
 
 #. Translators: the label of a checkbox
-#: bookworm/gui/settings.py:249
+#: bookworm/gui/settings.py:244
 msgid "Include page label in page title"
 msgstr "在页标题中包含页标签"
 
 #. Translators: the label of a checkbox
-#: bookworm/gui/settings.py:256
+#: bookworm/gui/settings.py:251
 msgid "Use file name instead of book title"
 msgstr "以文件名代替文档名称"
 
 #. Translators: the label of a checkbox
-#: bookworm/gui/settings.py:263
+#: bookworm/gui/settings.py:258
 msgid "Show reading progress percentage"
 msgstr "显示阅读进度百分比"
 
 #. Translators: the label of a checkbox
-#: bookworm/gui/settings.py:270
+#: bookworm/gui/settings.py:265
 msgid "Open recently opened books from the last position"
 msgstr "最近阅读列表中打开文档时跳转到上次阅读位置"
 
 #. Translators: the label of a checkbox to enable continuous reading
-#: bookworm/gui/settings.py:277
+#: bookworm/gui/settings.py:272
 msgid ""
 "Try to support the screen reader's continuous reading mode by automatically "
 "turning pages (may not work in some cases)"
 msgstr "自动翻页兼容屏幕阅读器的全文朗读（在某些情况下可能无效）"
 
 #. Translators: the label of a checkbox
-#: bookworm/gui/settings.py:286
+#: bookworm/gui/settings.py:281
 msgid "Automatically check for updates"
 msgstr "自动检测更新"
 
 #. Translators: the title of a group of controls shown in the
 #. general settings page related to file associations
-#: bookworm/gui/settings.py:292
+#: bookworm/gui/settings.py:287
 msgid "File Associations"
 msgstr "文件关联"
 
 #. Translators: the label of a button
-#: bookworm/gui/settings.py:297
+#: bookworm/gui/settings.py:292
 msgid "Manage File &Associations"
 msgstr "管理文件关联(&A)"
 
 #. Translators: the content of a message asking the user to restart
-#: bookworm/gui/settings.py:327
+#: bookworm/gui/settings.py:322
 msgid ""
 "You have changed the display language of Bookworm.\n"
 "For this setting to fully take effect, you need to restart the application.\n"
@@ -1808,84 +1808,84 @@ msgstr ""
 
 #. Translators: the title of a message telling the user
 #. that the display language have been changed
-#: bookworm/gui/settings.py:334
+#: bookworm/gui/settings.py:329
 msgid "Language Changed"
 msgstr "语言已更改"
 
 #. Translators: the title of a group of controls in the
 #. appearance settings page related to the UI
-#: bookworm/gui/settings.py:356
+#: bookworm/gui/settings.py:351
 msgid "General Appearance"
 msgstr "普通外观"
 
 #. Translators: the label of a checkbox
-#: bookworm/gui/settings.py:361
+#: bookworm/gui/settings.py:356
 msgid "Maximize the application window upon startup"
 msgstr "启动时最大化窗口"
 
 #. Translators: the label of a checkbox
-#: bookworm/gui/settings.py:368
+#: bookworm/gui/settings.py:363
 msgid "Show the application's toolbar"
 msgstr "显示应用程序工具栏"
 
-#: bookworm/gui/settings.py:371
+#: bookworm/gui/settings.py:366
 msgid "Text Styling"
 msgstr "文本样式"
 
 #. Translators: the label of a checkbox
-#: bookworm/gui/settings.py:376
+#: bookworm/gui/settings.py:371
 msgid "Apply text styling (when available)"
 msgstr "使用文本样式（如果可用）"
 
-#: bookworm/gui/settings.py:379
+#: bookworm/gui/settings.py:374
 msgid "Text view margins percentage"
 msgstr "文本视图边距百分比"
 
 #. Translators: the title of a group of controls in the
 #. appearance settings page related to the font
-#: bookworm/gui/settings.py:383
+#: bookworm/gui/settings.py:378
 msgid "Font"
 msgstr "字体"
 
 #. Translators: label of a checkbox
-#: bookworm/gui/settings.py:388
+#: bookworm/gui/settings.py:383
 msgid "Use Open-&dyslexic font"
 msgstr "使用阅读障碍字体(&D)"
 
 #. Translators: label of a combobox
-#: bookworm/gui/settings.py:392
+#: bookworm/gui/settings.py:387
 msgid "Font Face"
 msgstr "字体"
 
 #. Translators: label of an static
-#: bookworm/gui/settings.py:399
+#: bookworm/gui/settings.py:394
 msgid "Font Size"
 msgstr "字体大小"
 
 #. Translators: the label of a checkbox
-#: bookworm/gui/settings.py:405
+#: bookworm/gui/settings.py:400
 msgid "Bold style"
 msgstr "加粗样式"
 
 #. Translators: label of a button
-#: bookworm/gui/settings.py:465
+#: bookworm/gui/settings.py:460
 msgid "Download Pandoc: The universal document converter"
 msgstr "下载 Pandoc：通用文档转换器"
 
 #. Translators: description of a button
-#: bookworm/gui/settings.py:467
+#: bookworm/gui/settings.py:462
 msgid ""
 "Add support for additional document formats including RTF and Word 2003 "
 "documents."
 msgstr "添加对其他文档格式的支持，包括 RTF 和 Word 2003 文档。"
 
 #. Translators: label of a button
-#: bookworm/gui/settings.py:477
+#: bookworm/gui/settings.py:472
 msgid "Update Pandoc (the universal document converter)"
 msgstr "更新 Pandoc（通用文档转换器）"
 
 #. Translators: description of a button
-#: bookworm/gui/settings.py:479
+#: bookworm/gui/settings.py:474
 msgid ""
 "Update Pandoc to the latest version to improve performance and conversion "
 "quality."
@@ -1894,34 +1894,34 @@ msgstr "将 Pandoc 更新到最新版本以提高性能和转换质量。"
 #. Translators: the title of a group of controls in the
 #. advanced settings page
 #. Translators: label of a button
-#: bookworm/gui/settings.py:486 bookworm/gui/settings.py:491
+#: bookworm/gui/settings.py:481 bookworm/gui/settings.py:486
 msgid "Reset Settings"
 msgstr "重置设置"
 
 #. Translators: description of a button
-#: bookworm/gui/settings.py:493
+#: bookworm/gui/settings.py:488
 msgid "Reset Bookworm's settings to their defaults"
 msgstr "将 Bookworm 的设置重置为默认值"
 
 #. Translators: title of a progress dialog
-#: bookworm/gui/settings.py:501
+#: bookworm/gui/settings.py:496
 msgid "Downloading Pandoc"
 msgstr "下载 Pandoc"
 
 #. Translators: message of a progress dialog
 #. Translators: content of a progress dialog
-#: bookworm/gui/settings.py:503 bookworm/ocr/ocr_dialogs.py:141
-#: bookworm/ocr/ocr_dialogs.py:556
+#: bookworm/gui/settings.py:498 bookworm/ocr/ocr_dialogs.py:129
+#: bookworm/ocr/ocr_dialogs.py:544
 msgid "Getting download information..."
 msgstr "正在获取下载信息..."
 
 #. Translators: message of a dialog
-#: bookworm/gui/settings.py:516 bookworm/ocr/ocr_dialogs.py:174
+#: bookworm/gui/settings.py:511 bookworm/ocr/ocr_dialogs.py:162
 msgid "Checking for updates. Please wait..."
 msgstr "正在检查更新。请稍候..."
 
 #. Translators: content of a message box
-#: bookworm/gui/settings.py:524
+#: bookworm/gui/settings.py:519
 msgid ""
 "You will lose  all of your custom settings.\n"
 "Are you sure you want to restore all settings to their default values?"
@@ -1930,22 +1930,22 @@ msgstr ""
 "您确定要将所有设置恢复为默认值吗？"
 
 #. Translators: title of a message box
-#: bookworm/gui/settings.py:528
+#: bookworm/gui/settings.py:523
 msgid "Reset Settings?"
 msgstr "重置设置？"
 
 #. Translators: title of a message box
-#: bookworm/gui/settings.py:541 bookworm/ocr/ocr_dialogs.py:161
+#: bookworm/gui/settings.py:536 bookworm/ocr/ocr_dialogs.py:149
 msgid "Restart Required"
 msgstr "需要重新启动"
 
 #. Translators: content of a message box
-#: bookworm/gui/settings.py:543
+#: bookworm/gui/settings.py:538
 msgid "Bookworm will now restart to complete the installation of Pandoc."
 msgstr "Bookworm 现在将重新启动以完成 Pandoc 的安装。"
 
 #. Translators: content of a message box
-#: bookworm/gui/settings.py:552
+#: bookworm/gui/settings.py:547
 msgid ""
 "A new version of Pandoc is available for download.\n"
 "It is strongly recommended to update to the latest version for the best "
@@ -1957,66 +1957,66 @@ msgstr ""
 "您想更新到新版本吗？"
 
 #. Translators: title of a message box
-#: bookworm/gui/settings.py:556
+#: bookworm/gui/settings.py:551
 msgid "Update Pandoc?"
 msgstr "更新 Pandoc?"
 
 #. Translators: message of a dialog
-#: bookworm/gui/settings.py:565
+#: bookworm/gui/settings.py:560
 msgid "Removing old Pandoc version. Please wait..."
 msgstr "正在删除旧版 Pandoc 请稍等..."
 
 #. Translators: content of a message box
-#: bookworm/gui/settings.py:571
+#: bookworm/gui/settings.py:566
 msgid "Your version of Pandoc is up to date."
 msgstr "您的 Pandoc 版本是最新的。"
 
 #. Translators: title of a message box
-#: bookworm/gui/settings.py:573 bookworm/ocr/ocr_dialogs.py:204
+#: bookworm/gui/settings.py:568 bookworm/ocr/ocr_dialogs.py:192
 msgid "No updates"
 msgstr "当前已是最新版"
 
 #. Translators: content of a message box
-#: bookworm/gui/settings.py:580
+#: bookworm/gui/settings.py:575
 msgid "Failed to check for updates. Please check your internet connection."
 msgstr ""
 "检测更新失败。\n"
 "请检查您的互联网连接。"
 
 #. Translators: the label of a page in the settings dialog
-#: bookworm/gui/settings.py:597
+#: bookworm/gui/settings.py:592
 msgid "Appearance"
 msgstr "外观"
 
 #. Translators: the label of a page in the settings dialog
-#: bookworm/gui/settings.py:599
+#: bookworm/gui/settings.py:594
 msgid "Advanced"
 msgstr "高级"
 
 #. Translators: the label of the apply button in a dialog
-#: bookworm/gui/settings.py:656
+#: bookworm/gui/settings.py:651
 msgid "Apply"
 msgstr "应用(&A)"
 
-#: bookworm/gui/book_viewer/__init__.py:86
+#: bookworm/gui/book_viewer/__init__.py:76
 msgid "Failed to open document"
 msgstr "无法打开文档"
 
-#: bookworm/gui/book_viewer/__init__.py:87
+#: bookworm/gui/book_viewer/__init__.py:77
 msgid "The document you are trying to open could not be opened in Bookworm."
 msgstr "该文档无法在 Bookworm 中打开。"
 
-#: bookworm/gui/book_viewer/__init__.py:101
+#: bookworm/gui/book_viewer/__init__.py:91
 msgid "Opening document, please wait..."
 msgstr "正在打开文档，请稍候..."
 
 #. Translators: the title of an error message
-#: bookworm/gui/book_viewer/__init__.py:119
+#: bookworm/gui/book_viewer/__init__.py:109
 msgid "Document not found"
 msgstr "文档不存在"
 
 #. Translators: the content of an error message
-#: bookworm/gui/book_viewer/__init__.py:121
+#: bookworm/gui/book_viewer/__init__.py:111
 msgid ""
 "Could not open Document.\n"
 "The document does not exist."
@@ -2025,12 +2025,12 @@ msgstr ""
 "该文档不存在。"
 
 #. Translators: the title of an error message
-#: bookworm/gui/book_viewer/__init__.py:133
+#: bookworm/gui/book_viewer/__init__.py:123
 msgid "Document Restricted"
 msgstr "文档受限"
 
 #. Translators: the content of an error message
-#: bookworm/gui/book_viewer/__init__.py:135
+#: bookworm/gui/book_viewer/__init__.py:125
 msgid ""
 "Could not open Document.\n"
 "The document is restricted by the publisher."
@@ -2040,23 +2040,23 @@ msgstr ""
 
 #. Translators: the title of a message shown
 #. when the format of the e-book is not supported
-#: bookworm/gui/book_viewer/__init__.py:147
+#: bookworm/gui/book_viewer/__init__.py:137
 msgid "Unsupported Document Format"
 msgstr "不支持的文档格式"
 
 #. Translators: the content of a message shown
 #. when the format of the e-book is not supported
-#: bookworm/gui/book_viewer/__init__.py:150
+#: bookworm/gui/book_viewer/__init__.py:140
 msgid "The format of the given document is not supported by Bookworm."
 msgstr "Bookworm不支持该文档格式。"
 
 #. Translators: the title of an error message
-#: bookworm/gui/book_viewer/__init__.py:159
+#: bookworm/gui/book_viewer/__init__.py:149
 msgid "Archive contains no documents"
 msgstr "存档中未包含文档"
 
 #. Translators: the content of an error message
-#: bookworm/gui/book_viewer/__init__.py:161
+#: bookworm/gui/book_viewer/__init__.py:151
 msgid ""
 "Bookworm cannot open this archive file.\n"
 "The archive contains no documents."
@@ -2064,21 +2064,21 @@ msgstr ""
 "Bookworm 无法打开该存档文件。\n"
 "该存档中未包含文档。"
 
-#: bookworm/gui/book_viewer/__init__.py:170
+#: bookworm/gui/book_viewer/__init__.py:160
 msgid "Documents"
 msgstr "文档"
 
-#: bookworm/gui/book_viewer/__init__.py:171
+#: bookworm/gui/book_viewer/__init__.py:161
 msgid "Multiple documents found"
 msgstr "发现多个文档"
 
 #. Translators: the title of an error message
-#: bookworm/gui/book_viewer/__init__.py:185
+#: bookworm/gui/book_viewer/__init__.py:175
 msgid "Error Opening Document"
 msgstr "打开文档时出错"
 
 #. Translators: the content of an error message
-#: bookworm/gui/book_viewer/__init__.py:187
+#: bookworm/gui/book_viewer/__init__.py:177
 msgid ""
 "Could not open file\n"
 ".Either the file  has been damaged during download, or it has been corrupted "
@@ -2088,12 +2088,12 @@ msgstr ""
 "文件以损坏。"
 
 #. Translators: the title of an error message
-#: bookworm/gui/book_viewer/__init__.py:200
+#: bookworm/gui/book_viewer/__init__.py:190
 msgid "Error Openning Document"
 msgstr "打开文档时出错"
 
 #. Translators: the content of an error message
-#: bookworm/gui/book_viewer/__init__.py:202
+#: bookworm/gui/book_viewer/__init__.py:192
 msgid ""
 "Could not open document.\n"
 "An unknown error occurred while loading the file."
@@ -2103,7 +2103,7 @@ msgstr ""
 "加载文件时发生未知错误。"
 
 #. Translators: content of a message
-#: bookworm/gui/book_viewer/__init__.py:214
+#: bookworm/gui/book_viewer/__init__.py:204
 msgid ""
 "Failed to open document.\n"
 "Would you like to remove its entry from the 'recent documents' and 'pinned "
@@ -2113,57 +2113,57 @@ msgstr ""
 "您想从“最近打开的文档”和“固定的文档”列表中删除对应条目吗？"
 
 #. Translators: title of a message box
-#: bookworm/gui/book_viewer/__init__.py:218
+#: bookworm/gui/book_viewer/__init__.py:208
 msgid "Remove from lists?"
 msgstr "从列表中删除？"
 
 #. Translators: the text of the status bar when no book is currently open.
 #. It is being used also as a label for the page content text area when no book
 #. is opened.
-#: bookworm/gui/book_viewer/__init__.py:287
+#: bookworm/gui/book_viewer/__init__.py:277
 msgid "Press (Ctrl + O) to open a document"
 msgstr "按 (Control + O) 打开文档"
 
 #. Translators: the label of the table-of-contents tree
-#: bookworm/gui/book_viewer/__init__.py:301
+#: bookworm/gui/book_viewer/__init__.py:291
 msgid "Table of Contents"
 msgstr "目录"
 
-#: bookworm/gui/book_viewer/__init__.py:324
+#: bookworm/gui/book_viewer/__init__.py:314
 msgid "Reading progress percentage"
 msgstr "阅读进度百分比"
 
 #. Translators: the label of a button in the application toolbar
-#: bookworm/gui/book_viewer/__init__.py:409
+#: bookworm/gui/book_viewer/__init__.py:399
 msgid "Open"
 msgstr "打开"
 
 #. Translators: the label of a button in the application toolbar
-#: bookworm/gui/book_viewer/__init__.py:414
+#: bookworm/gui/book_viewer/__init__.py:404
 msgid "Mode"
 msgstr "模式"
 
 #. Translators: the label of a button in the application toolbar
-#: bookworm/gui/book_viewer/__init__.py:417
+#: bookworm/gui/book_viewer/__init__.py:407
 msgid "Big"
 msgstr "大"
 
 #. Translators: the label of a button in the application toolbar
-#: bookworm/gui/book_viewer/__init__.py:419
+#: bookworm/gui/book_viewer/__init__.py:409
 msgid "Small"
 msgstr "小"
 
 #. Translators: title of a message telling the user that they entered an
 #. incorrect
 #. password for opening the book
-#: bookworm/gui/book_viewer/__init__.py:464
+#: bookworm/gui/book_viewer/__init__.py:454
 msgid "Incorrect Password"
 msgstr "密码错误"
 
 #. Translators: content of a message telling the user that they entered an
 #. incorrect
 #. password for opening the book
-#: bookworm/gui/book_viewer/__init__.py:467
+#: bookworm/gui/book_viewer/__init__.py:457
 msgid ""
 "The password you provided is incorrect.\n"
 "Please try again with the correct password."
@@ -2172,57 +2172,57 @@ msgstr ""
 "请键入正确的密码再试一次。"
 
 #. Translators: spoken message when the document has been closed
-#: bookworm/gui/book_viewer/__init__.py:528
+#: bookworm/gui/book_viewer/__init__.py:518
 msgid "Document closed."
 msgstr "已关闭文档。"
 
 #. Translators: text of reading progress shown in the status bar
-#: bookworm/gui/book_viewer/__init__.py:565
+#: bookworm/gui/book_viewer/__init__.py:555
 msgid "{percentage} completed"
 msgstr "{percentage} 完成"
 
 #. Translators: label of content text control when the currently opened
 #. document is a single page document
-#: bookworm/gui/book_viewer/__init__.py:623
+#: bookworm/gui/book_viewer/__init__.py:613
 msgid "Document content"
 msgstr "文档内容"
 
-#: bookworm/gui/book_viewer/__init__.py:654
+#: bookworm/gui/book_viewer/__init__.py:644
 msgid "{text}: {item_type}"
 msgstr "{text}: {item_type}"
 
-#: bookworm/gui/book_viewer/__init__.py:671
+#: bookworm/gui/book_viewer/__init__.py:661
 msgid "No next {item}"
 msgstr "往下没有{item}"
 
-#: bookworm/gui/book_viewer/__init__.py:673
+#: bookworm/gui/book_viewer/__init__.py:663
 msgid "No previous {item}"
 msgstr "往上没有{item}"
 
 #. Translators: a message telling the user that the font size has been
 #. increased
-#: bookworm/gui/book_viewer/__init__.py:689
+#: bookworm/gui/book_viewer/__init__.py:679
 msgid "The font size has been Increased"
 msgstr "增大字体"
 
 #. Translators: a message telling the user that the font size has been
 #. decreased
-#: bookworm/gui/book_viewer/__init__.py:695
+#: bookworm/gui/book_viewer/__init__.py:685
 msgid "The font size has been decreased"
 msgstr "减小字体"
 
 #. Translators: a message telling the user that the font size has been reset
-#: bookworm/gui/book_viewer/__init__.py:699
+#: bookworm/gui/book_viewer/__init__.py:689
 msgid "The font size has been reset"
 msgstr "重置字体"
 
-#: bookworm/gui/book_viewer/__init__.py:729
+#: bookworm/gui/book_viewer/__init__.py:719
 msgid "Reading progress: {percentage}"
 msgstr "阅读进度百分比： {percentage}"
 
 #. Translators: the content of a dialog asking the user
 #. for the password to decrypt the current e-book
-#: bookworm/gui/book_viewer/__init__.py:750
+#: bookworm/gui/book_viewer/__init__.py:740
 msgid ""
 "This document is encrypted with a password.\n"
 "You need to provide the password in order to access its content.\n"
@@ -2234,107 +2234,111 @@ msgstr ""
 
 #. Translators: the title of a dialog asking the user to enter a password to
 #. decrypt the e-book
-#: bookworm/gui/book_viewer/__init__.py:756
+#: bookworm/gui/book_viewer/__init__.py:746
 msgid "Enter Password"
 msgstr "输入密码"
 
 #. Translators: the label of the page content text area
 #. Translators: a message to announce when navigating to another page
-#: bookworm/gui/book_viewer/__init__.py:794
-#: bookworm/text_to_speech/__init__.py:179
+#: bookworm/gui/book_viewer/__init__.py:784
+#: bookworm/text_to_speech/__init__.py:167
 msgid "Page {page} of {total}"
 msgstr "第{page}页，共{total}页。"
 
-#: bookworm/gui/book_viewer/__init__.py:879
+#: bookworm/gui/book_viewer/__init__.py:869
 msgid "Opening page: {url}"
 msgstr "打开页面：{url}"
 
 #. Translators: the label of a list of search results
-#: bookworm/gui/book_viewer/core_dialogs.py:56
+#: bookworm/gui/book_viewer/core_dialogs.py:47
 msgid "Search Results"
 msgstr "搜索结果"
 
 #. Translators: the title of a column in the search results list showing
 #. an excerpt of the text of the search result
-#: bookworm/gui/book_viewer/core_dialogs.py:67
+#: bookworm/gui/book_viewer/core_dialogs.py:58
 msgid "Text"
 msgstr "文本"
 
 #. Translators: the label of a progress bar indicating the progress of the
 #. search process
-#: bookworm/gui/book_viewer/core_dialogs.py:83
+#: bookworm/gui/book_viewer/core_dialogs.py:74
 msgid "Search Progress:"
 msgstr "搜索进度："
 
 #. Translators: the label of a button to close the dialog
 #. Translators: the label of an edit field in the search dialog
-#: bookworm/gui/book_viewer/core_dialogs.py:157
+#: bookworm/gui/book_viewer/core_dialogs.py:148
 msgid "Search term:"
 msgstr "搜索词："
 
 #. Translators: the label of a checkbox
-#: bookworm/gui/book_viewer/core_dialogs.py:163
+#: bookworm/gui/book_viewer/core_dialogs.py:154
 msgid "Case sensitive"
 msgstr "区分大小写"
 
 #. Translators: the label of a checkbox
-#: bookworm/gui/book_viewer/core_dialogs.py:165
+#: bookworm/gui/book_viewer/core_dialogs.py:156
 msgid "Match whole word only"
 msgstr "整词匹配"
 
 #. Translators: the label of a checkbox
-#: bookworm/gui/book_viewer/core_dialogs.py:167
+#: bookworm/gui/book_viewer/core_dialogs.py:158
 msgid "Regular expression"
 msgstr "正则表达式"
 
-#: bookworm/gui/book_viewer/core_dialogs.py:216
+#: bookworm/gui/book_viewer/core_dialogs.py:207
 msgid "Page number, of {total}:"
 msgstr "页码，共{total}："
 
-#: bookworm/gui/book_viewer/core_dialogs.py:260
+#: bookworm/gui/book_viewer/core_dialogs.py:246
+msgid "Element Type"
+msgstr "元素类型"
+
+#: bookworm/gui/book_viewer/core_dialogs.py:251
 msgid "Elements"
 msgstr "元素"
 
 #. Translators: title of a dialog
-#: bookworm/gui/book_viewer/core_dialogs.py:336
+#: bookworm/gui/book_viewer/core_dialogs.py:327
 msgid "Document Info"
 msgstr "文档信息"
 
-#: bookworm/gui/book_viewer/core_dialogs.py:365
+#: bookworm/gui/book_viewer/core_dialogs.py:356
 msgid "Author"
 msgstr "作者"
 
-#: bookworm/gui/book_viewer/core_dialogs.py:369
+#: bookworm/gui/book_viewer/core_dialogs.py:360
 msgid "Description"
 msgstr "描述"
 
-#: bookworm/gui/book_viewer/core_dialogs.py:378
+#: bookworm/gui/book_viewer/core_dialogs.py:369
 msgid "Number of Sections"
 msgstr "章节数"
 
-#: bookworm/gui/book_viewer/core_dialogs.py:382
+#: bookworm/gui/book_viewer/core_dialogs.py:373
 msgid "Number of Pages"
 msgstr "页数"
 
 #. Translators: the title of a column in the Tesseract language list
-#: bookworm/gui/book_viewer/core_dialogs.py:385 bookworm/ocr/ocr_dialogs.py:496
+#: bookworm/gui/book_viewer/core_dialogs.py:376 bookworm/ocr/ocr_dialogs.py:484
 msgid "Language"
 msgstr "语言"
 
-#: bookworm/gui/book_viewer/core_dialogs.py:388
+#: bookworm/gui/book_viewer/core_dialogs.py:379
 msgid "Publisher"
 msgstr "出版商"
 
-#: bookworm/gui/book_viewer/core_dialogs.py:390
+#: bookworm/gui/book_viewer/core_dialogs.py:381
 msgid "Created at"
 msgstr "创建于"
 
-#: bookworm/gui/book_viewer/core_dialogs.py:393
+#: bookworm/gui/book_viewer/core_dialogs.py:384
 msgid "Publication Date"
 msgstr "出版日期"
 
 #. Translators: the content of the about message
-#: bookworm/gui/book_viewer/menubar.py:52
+#: bookworm/gui/book_viewer/menubar.py:46
 msgid ""
 "{display_name}\n"
 "Version: {version}\n"
@@ -2370,288 +2374,288 @@ msgstr ""
 "证。\n"
 "有关更多详细信息，您可以从帮助菜单中查看完整许可协议。\n"
 
-#: bookworm/gui/book_viewer/menubar.py:64
+#: bookworm/gui/book_viewer/menubar.py:58
 msgid ""
 "This release of Bookworm is generously sponsored  by Capeds (www.capeds.net)."
 msgstr "此版本的 Bookworm 由 Capeds (www.capeds.net) 赞助开发。"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:94
+#: bookworm/gui/book_viewer/menubar.py:88
 msgid "Open...\tCtrl-O"
 msgstr "打开... \tCtrl-O"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:96
+#: bookworm/gui/book_viewer/menubar.py:90
 msgid "New Window...\tCtrl-N"
 msgstr "新窗口...\tCtrl-N"
 
-#: bookworm/gui/book_viewer/menubar.py:100
+#: bookworm/gui/book_viewer/menubar.py:94
 msgid "&Pin\tCtrl-P"
 msgstr "固定\tCtrl-P"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:103
+#: bookworm/gui/book_viewer/menubar.py:97
 msgid "&Save As Plain Text..."
 msgstr "另存为纯文本(&S)..."
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:108
+#: bookworm/gui/book_viewer/menubar.py:102
 msgid "&Close Current Document\tCtrl-W"
 msgstr "关闭当前文档(&C)\tCtrl+W"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:110
+#: bookworm/gui/book_viewer/menubar.py:104
 msgid "Close the currently open document"
 msgstr "关闭当前打开的文档"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:116
+#: bookworm/gui/book_viewer/menubar.py:110
 msgid "C&lear Documents Cache..."
 msgstr "清除文档缓存(&L)..."
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:118
+#: bookworm/gui/book_viewer/menubar.py:112
 msgid ""
 "Clear the document cache. Helps in fixing some issues with openning "
 "documents."
 msgstr "清除文档缓存。有助于解决打开文档的一些问题。"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:126
+#: bookworm/gui/book_viewer/menubar.py:120
 msgid "Pi&nned Documents"
 msgstr "固定的文档(&N)"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:128
+#: bookworm/gui/book_viewer/menubar.py:122
 msgid "Opens a list of documents you pinned."
 msgstr "查看固定的文档列表。"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:134
-#: bookworm/gui/book_viewer/menubar.py:148
+#: bookworm/gui/book_viewer/menubar.py:128
+#: bookworm/gui/book_viewer/menubar.py:142
 msgid "Clear list"
 msgstr "清除列表"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:136
+#: bookworm/gui/book_viewer/menubar.py:130
 msgid "Clear the pinned documents list"
 msgstr "清除固定的文档列表"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:141
+#: bookworm/gui/book_viewer/menubar.py:135
 msgid "&Recently Opened"
 msgstr "最近打开的文档(&D)"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:143
+#: bookworm/gui/book_viewer/menubar.py:137
 msgid "Opens a list of recently opened books."
 msgstr "查看最近打开的文档列表。"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:150
+#: bookworm/gui/book_viewer/menubar.py:144
 msgid "Clear the recent books list."
 msgstr "清除最近打开的文档列表。"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:156
+#: bookworm/gui/book_viewer/menubar.py:150
 msgid "&Preferences...\tCtrl-Shift-P"
 msgstr "首选项(&P)... \tCtrl-Shift-P"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:158
+#: bookworm/gui/book_viewer/menubar.py:152
 msgid "Configure application"
 msgstr "应用程序设置"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:162
+#: bookworm/gui/book_viewer/menubar.py:156
 msgid "Exit"
 msgstr "退出(&E)"
 
 #. Translators: the title of a file dialog to browse to a document
-#: bookworm/gui/book_viewer/menubar.py:213
+#: bookworm/gui/book_viewer/menubar.py:207
 msgid "Select a document"
 msgstr "选择文档"
 
-#: bookworm/gui/book_viewer/menubar.py:242
+#: bookworm/gui/book_viewer/menubar.py:236
 msgid "Pinned"
 msgstr "固定"
 
-#: bookworm/gui/book_viewer/menubar.py:246
+#: bookworm/gui/book_viewer/menubar.py:240
 msgid "Unpinned"
 msgstr "取消固定"
 
 #. Translators: the title of a dialog showing
 #. the progress of book export process
-#: bookworm/gui/book_viewer/menubar.py:272
+#: bookworm/gui/book_viewer/menubar.py:266
 msgid "Exporting Document"
 msgstr "导出文档"
 
 #. Translators: the message of a dialog showing the progress of book export
-#: bookworm/gui/book_viewer/menubar.py:274
+#: bookworm/gui/book_viewer/menubar.py:268
 msgid "Converting document to plain text."
 msgstr "将文档转换为纯文本格式。"
 
 #. Translators: a message shown when the book is being exported
-#: bookworm/gui/book_viewer/menubar.py:292
+#: bookworm/gui/book_viewer/menubar.py:286
 msgid "Exporting Page {current} of {total}..."
 msgstr "正在导出第 {current} 页，共 {total} 页..."
 
 #. Translators: the title of the application preferences dialog
-#: bookworm/gui/book_viewer/menubar.py:314
+#: bookworm/gui/book_viewer/menubar.py:308
 msgid "{app_name} Preferences"
 msgstr "{app_name} 首选项"
 
 #. Translators: content of a message
-#: bookworm/gui/book_viewer/menubar.py:325
+#: bookworm/gui/book_viewer/menubar.py:319
 msgid "Are you sure you want to clear the documents cache?"
 msgstr "您确定要清除文档缓存吗？"
 
 #. Translators: title of a message box
-#: bookworm/gui/book_viewer/menubar.py:327
+#: bookworm/gui/book_viewer/menubar.py:321
 msgid "Clear Documents Cache?"
 msgstr "清除文档缓存？"
 
 #. Translators: content of a message box
-#: bookworm/gui/book_viewer/menubar.py:335
+#: bookworm/gui/book_viewer/menubar.py:329
 msgid "Documents cache has been cleared."
 msgstr "文档缓存已清除。"
 
 #. Translators: content of a message in a message box
-#: bookworm/gui/book_viewer/menubar.py:344
+#: bookworm/gui/book_viewer/menubar.py:338
 msgid "Clearing documents cache..."
 msgstr "正在清除文档缓存..."
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:388
+#: bookworm/gui/book_viewer/menubar.py:382
 msgid "(No recent books)"
 msgstr "(无最近的文档)"
 
-#: bookworm/gui/book_viewer/menubar.py:389
+#: bookworm/gui/book_viewer/menubar.py:383
 msgid "No recent books"
 msgstr "没有最近阅读的文档"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:426
+#: bookworm/gui/book_viewer/menubar.py:420
 msgid "Document &Info..."
 msgstr "文档信息(&I)..."
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:428
+#: bookworm/gui/book_viewer/menubar.py:422
 msgid "Show information about number of chapters, word count..etc."
 msgstr "显示有关章节数、字数等信息。"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:433
+#: bookworm/gui/book_viewer/menubar.py:427
 msgid "&Element list...\tCtrl+F7"
 msgstr "元素列表...\\TCtrl+F7"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:435
+#: bookworm/gui/book_viewer/menubar.py:429
 msgid "Show a list of semantic elements."
 msgstr "显示元素列表。"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:440
+#: bookworm/gui/book_viewer/menubar.py:434
 msgid "Change Reading &Mode...\tCtrl-Shift-M"
 msgstr "更改阅读模式(&M)...\tCtrl-Shift-M"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:442
+#: bookworm/gui/book_viewer/menubar.py:436
 msgid "Change the current reading mode."
 msgstr "更改当前阅读模式。"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:447
-#: bookworm/gui/book_viewer/menubar.py:953
+#: bookworm/gui/book_viewer/menubar.py:441
+#: bookworm/gui/book_viewer/menubar.py:947
 msgid "&Render Page...\tCtrl-R"
 msgstr "渲染页面(&R)...\tCtrl-R"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:449
-#: bookworm/gui/book_viewer/menubar.py:954
+#: bookworm/gui/book_viewer/menubar.py:443
+#: bookworm/gui/book_viewer/menubar.py:948
 msgid "View a fully rendered version of this page."
 msgstr "查看本页的渲染版本。"
 
-#: bookworm/gui/book_viewer/menubar.py:491
+#: bookworm/gui/book_viewer/menubar.py:485
 msgid "Rendered Page"
 msgstr "渲染页面"
 
-#: bookworm/gui/book_viewer/menubar.py:508
+#: bookworm/gui/book_viewer/menubar.py:502
 msgid "Available reading modes"
 msgstr "可用的阅读模式"
 
-#: bookworm/gui/book_viewer/menubar.py:509
+#: bookworm/gui/book_viewer/menubar.py:503
 msgid "Select Reading Mode "
 msgstr "选择阅读模式 "
 
-#: bookworm/gui/book_viewer/menubar.py:534
+#: bookworm/gui/book_viewer/menubar.py:528
 msgid "Element List"
 msgstr "元素列表"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:561
-#: bookworm/gui/book_viewer/menubar.py:943
+#: bookworm/gui/book_viewer/menubar.py:555
+#: bookworm/gui/book_viewer/menubar.py:937
 msgid "&Find in Document...\tCtrl-F"
 msgstr "在文档中查找(&F)...\tCtrl-F"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:563
-#: bookworm/gui/book_viewer/menubar.py:944
+#: bookworm/gui/book_viewer/menubar.py:557
+#: bookworm/gui/book_viewer/menubar.py:938
 msgid "Search this document."
 msgstr "搜索本文档。"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:568
+#: bookworm/gui/book_viewer/menubar.py:562
 msgid "Find &Next\tF3"
 msgstr "查找下一个(&N)\\TF3"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:570
+#: bookworm/gui/book_viewer/menubar.py:564
 msgid "Find next occurrence."
 msgstr "查找下一个匹配项。"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:575
+#: bookworm/gui/book_viewer/menubar.py:569
 msgid "Find &Previous\tShift-F3"
 msgstr "查找上一个(&P)\tShift-F3"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:577
+#: bookworm/gui/book_viewer/menubar.py:571
 msgid "Find previous occurrence."
 msgstr "查找上一个匹配项。"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:582
+#: bookworm/gui/book_viewer/menubar.py:576
 msgid "&Jump to Line...\tCtrl-L"
 msgstr "行跳转(&G)\tCtrl-L"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:584
+#: bookworm/gui/book_viewer/menubar.py:578
 msgid "Jump to a line within the current page or document"
 msgstr "跳转到当前页面或文档中的某一行"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:589
-#: bookworm/gui/book_viewer/menubar.py:937
+#: bookworm/gui/book_viewer/menubar.py:583
+#: bookworm/gui/book_viewer/menubar.py:931
 msgid "&Go To Page...\tCtrl-G"
 msgstr "页码跳转(&G)"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:591
+#: bookworm/gui/book_viewer/menubar.py:585
 msgid "Go to page"
 msgstr "跳转到"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:596
+#: bookworm/gui/book_viewer/menubar.py:590
 msgid "&Go To Page By Label...\tCtrl-Shift-G"
 msgstr "标签跳转(&G)...\tCtrl-Shift-G"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:598
+#: bookworm/gui/book_viewer/menubar.py:592
 msgid "Go to a page using its label"
 msgstr "使用标签跳转页面"
 
-#: bookworm/gui/book_viewer/menubar.py:631
+#: bookworm/gui/book_viewer/menubar.py:625
 msgid ""
 "You are here: {current_line}\n"
 "You can't go further than: {last_line}"
@@ -2659,131 +2663,131 @@ msgstr ""
 "此处：{current_line}\n"
 "无法继续往后：{last_line}"
 
-#: bookworm/gui/book_viewer/menubar.py:634
+#: bookworm/gui/book_viewer/menubar.py:628
 msgid "Line number"
 msgstr "行号"
 
-#: bookworm/gui/book_viewer/menubar.py:635
+#: bookworm/gui/book_viewer/menubar.py:629
 msgid "Jump to line"
 msgstr "跳转到行"
 
 #. Translators: the title of the go to page dialog
-#: bookworm/gui/book_viewer/menubar.py:648
+#: bookworm/gui/book_viewer/menubar.py:642
 msgid "Go To Page"
 msgstr "跳转页码"
 
-#: bookworm/gui/book_viewer/menubar.py:655
+#: bookworm/gui/book_viewer/menubar.py:649
 msgid "Go To Page By Label"
 msgstr "按标签跳转"
 
-#: bookworm/gui/book_viewer/menubar.py:655
+#: bookworm/gui/book_viewer/menubar.py:649
 msgid "Page Label"
 msgstr "页标签"
 
 #. Translators: the title of the search dialog
-#: bookworm/gui/book_viewer/menubar.py:663
+#: bookworm/gui/book_viewer/menubar.py:657
 msgid "Search Document"
 msgstr "搜索文档"
 
-#: bookworm/gui/book_viewer/menubar.py:689
+#: bookworm/gui/book_viewer/menubar.py:683
 msgid "Searching For '{term}'"
 msgstr "搜索“{term}”"
 
 #. Translators: message to announce the number of search results
 #. also used as the final title of the search results dialog
-#: bookworm/gui/book_viewer/menubar.py:704
+#: bookworm/gui/book_viewer/menubar.py:698
 msgid "Results | {total}"
 msgstr "结果{total}"
 
-#: bookworm/gui/book_viewer/menubar.py:741
+#: bookworm/gui/book_viewer/menubar.py:735
 msgid "Search Result"
 msgstr "搜索结果"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:779
+#: bookworm/gui/book_viewer/menubar.py:773
 msgid "&User guide...\tF1"
 msgstr "用户指南(&U)... \tF1"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:781
+#: bookworm/gui/book_viewer/menubar.py:775
 msgid "View Bookworm manuals"
 msgstr "查看Bookworm的用户指南"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:786
+#: bookworm/gui/book_viewer/menubar.py:780
 msgid "Bookworm &website..."
 msgstr "Bookworm 网站(&W)..."
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:788
+#: bookworm/gui/book_viewer/menubar.py:782
 msgid "Visit the official website of Bookworm"
 msgstr "访问Bookworm的官方网站"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:793
+#: bookworm/gui/book_viewer/menubar.py:787
 msgid "&License"
 msgstr "许可协议(&L)"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:795
+#: bookworm/gui/book_viewer/menubar.py:789
 msgid "View legal information about this program ."
 msgstr "查看有关本程序的法律许可信息。"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:800
+#: bookworm/gui/book_viewer/menubar.py:794
 msgid "Con&tributors"
 msgstr "贡献者(&T)"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:802
+#: bookworm/gui/book_viewer/menubar.py:796
 msgid "View a list of notable contributors to the program."
 msgstr "查看本程序的重要贡献者列表。"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:808
+#: bookworm/gui/book_viewer/menubar.py:802
 msgid "&Restart with debug-mode enabled"
 msgstr "重新启动并启用调试模式(&R)"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:810
+#: bookworm/gui/book_viewer/menubar.py:804
 msgid "Restart the program with debug mode enabled to show errors"
 msgstr "重新启动本程序，并启用调试模式以显示错误"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:820
+#: bookworm/gui/book_viewer/menubar.py:814
 msgid "&About Bookworm"
 msgstr "关于 Bookworm(&A)"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:822
+#: bookworm/gui/book_viewer/menubar.py:816
 msgid "Show general information about this program"
 msgstr "显示有关该程序的信息"
 
 #. Translators: the title of the about dialog
-#: bookworm/gui/book_viewer/menubar.py:855
+#: bookworm/gui/book_viewer/menubar.py:849
 msgid "About {app_name}"
 msgstr "关于 {app_name}"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:891
+#: bookworm/gui/book_viewer/menubar.py:885
 msgid "&Search"
 msgstr "搜索(&R)"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:893
+#: bookworm/gui/book_viewer/menubar.py:887
 msgid "&Document"
 msgstr "文档(&D)"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:895
+#: bookworm/gui/book_viewer/menubar.py:889
 msgid "&Help"
 msgstr "帮助(&H)"
 
-#: bookworm/gui/book_viewer/menubar.py:938
+#: bookworm/gui/book_viewer/menubar.py:932
 msgid "Jump to a page"
 msgstr "跳转到页面"
 
-#: bookworm/gui/book_viewer/menubar.py:992
+#: bookworm/gui/book_viewer/menubar.py:986
 msgid "Supported document formats"
 msgstr "支持的文档格式"
 
@@ -2797,94 +2801,94 @@ msgstr "页 {}"
 
 #. Translators: content of a message in a progress dialog
 #: bookworm/http_tools/http_resource.py:43
-#: bookworm/platforms/win32/updater.py:195
+#: bookworm/platforms/win32/updater.py:196
 msgid "Downloaded {downloaded} MB of {total} MB"
 msgstr "已下载 {downloaded} MB，共 {total} MB"
 
 #. Translators: the label of a page in the settings dialog
 #. Translators: the label of an item in the application menubar
-#: bookworm/ocr/__init__.py:75 bookworm/ocr/__init__.py:94
-#: bookworm/ocr/__init__.py:97
+#: bookworm/ocr/__init__.py:70 bookworm/ocr/__init__.py:89
+#: bookworm/ocr/__init__.py:92
 msgid "OCR"
 msgstr "OCR"
 
 #. Translators: the label of a group of controls in the reading page
-#: bookworm/ocr/ocr_dialogs.py:63 bookworm/ocr/ocr_menu.py:209
+#: bookworm/ocr/ocr_dialogs.py:51 bookworm/ocr/ocr_menu.py:207
 msgid "OCR Options"
 msgstr "识别选项"
 
 #. Translators: the title of a group of radio buttons in the OCR page
 #. in the application settings.
-#: bookworm/ocr/ocr_dialogs.py:70
+#: bookworm/ocr/ocr_dialogs.py:58
 msgid "Default OCR Engine"
 msgstr "默认 OCR 引擎"
 
 #. Translators: the label of a group of controls in the OCR page
 #. of the settings related to Tesseract OCR engine
-#: bookworm/ocr/ocr_dialogs.py:77
+#: bookworm/ocr/ocr_dialogs.py:65
 #: bookworm/ocr_engines/tesseract_ocr_engine/__init__.py:25
 #: bookworm/ocr_engines/tesseract_ocr_engine/alt_tess.py:29
 msgid "Tesseract OCR Engine"
 msgstr "Tesseract OCR 引擎"
 
-#: bookworm/ocr/ocr_dialogs.py:82
+#: bookworm/ocr/ocr_dialogs.py:70
 msgid "Download Tesseract OCR Engine"
 msgstr "下载 Tesseract OCR 引擎"
 
-#: bookworm/ocr/ocr_dialogs.py:83
+#: bookworm/ocr/ocr_dialogs.py:71
 msgid "Get a free, high-quality OCR engine that supports over 100 languages."
 msgstr "获取支持 100 多种语言的免费且高质量的 OCR 引擎。"
 
 #. Translators: label of a button
-#: bookworm/ocr/ocr_dialogs.py:93
+#: bookworm/ocr/ocr_dialogs.py:81
 msgid "Manage Tesseract OCR Languages"
 msgstr "管理 Tesseract OCR 语言"
 
 #. Translators: description of a button
-#: bookworm/ocr/ocr_dialogs.py:95
+#: bookworm/ocr/ocr_dialogs.py:83
 msgid "Add support for new languages, and /or remove installed languages."
 msgstr "添加对新语言的支持，和（或）删除已安装的语言。"
 
 #. Translators: label of a button
-#: bookworm/ocr/ocr_dialogs.py:101
+#: bookworm/ocr/ocr_dialogs.py:89
 msgid "Update Tesseract OCr Engine"
 msgstr "更新 Tesseract OCR 引擎"
 
 #. Translators: description of a button
-#: bookworm/ocr/ocr_dialogs.py:103
+#: bookworm/ocr/ocr_dialogs.py:91
 msgid "Check for and install updates for Tesseract OCR Engine"
 msgstr "检查并更新 Tesseract OCR 引擎"
 
 #. Translators: the label of a group of controls in the reading page
 #. of the settings related to image enhancement
-#: bookworm/ocr/ocr_dialogs.py:109
+#: bookworm/ocr/ocr_dialogs.py:97
 msgid "Image processing"
 msgstr "图像处理"
 
 #. Translators: the label of a checkbox
-#: bookworm/ocr/ocr_dialogs.py:115
+#: bookworm/ocr/ocr_dialogs.py:103
 msgid "Enable default image enhancement filters"
 msgstr "启用默认图像增强过滤器"
 
 #. Translators: title of a progress dialog
-#: bookworm/ocr/ocr_dialogs.py:139
+#: bookworm/ocr/ocr_dialogs.py:127
 msgid "Downloading Tesseract OCR Engine"
 msgstr "下载 Tesseract OCR 引擎"
 
 #. Translators: title of a dialog to manage Tesseract OCR engine languages
-#: bookworm/ocr/ocr_dialogs.py:152
+#: bookworm/ocr/ocr_dialogs.py:140
 msgid "Manage Tesseract OCR Engine Languages"
 msgstr "管理 Tesseract OCR 引擎的语言"
 
 #. Translators: content of a message box
-#: bookworm/ocr/ocr_dialogs.py:163
+#: bookworm/ocr/ocr_dialogs.py:151
 msgid ""
 "Bookworm will now restart to complete the installation of the Tesseract OCR "
 "Engine."
 msgstr "Bookworm 现在将重新启动以完成 Tesseract OCR 引擎的安装。"
 
 #. Translators: content of a message box
-#: bookworm/ocr/ocr_dialogs.py:183
+#: bookworm/ocr/ocr_dialogs.py:171
 msgid ""
 "A new version of Tesseract OCr engine is available for download.\n"
 "It is strongly recommended to update to the latest version for the best "
@@ -2898,145 +2902,145 @@ msgstr ""
 "您想更新到新版本吗？"
 
 #. Translators: title of a message box
-#: bookworm/ocr/ocr_dialogs.py:187
+#: bookworm/ocr/ocr_dialogs.py:175
 msgid "Update Tesseract OCr Engine?"
 msgstr "是否更新 Tesseract OCr 引擎？"
 
 #. Translators: message of a dialog
-#: bookworm/ocr/ocr_dialogs.py:196
+#: bookworm/ocr/ocr_dialogs.py:184
 msgid "Removing old Tesseract version. Please wait..."
 msgstr "正在删除旧版 Tesseract 请稍等..."
 
 #. Translators: content of a message box
-#: bookworm/ocr/ocr_dialogs.py:202
+#: bookworm/ocr/ocr_dialogs.py:190
 msgid "Your version of Tesseract OCR engine is up to date."
 msgstr "您的 Tesseract OCR 引擎版本是最新的。"
 
 #. Translators: content of a message box
-#: bookworm/ocr/ocr_dialogs.py:213
+#: bookworm/ocr/ocr_dialogs.py:201
 msgid "Failed to check for updates for Tesseract OCr engine."
 msgstr "检查 Tesseract OCr 引擎更新失败。"
 
 #. Translators: title of a group of controls
-#: bookworm/ocr/ocr_dialogs.py:247
+#: bookworm/ocr/ocr_dialogs.py:235
 msgid "Recognition Language"
 msgstr "识别语言"
 
 #. Translators: the label of a combobox
-#: bookworm/ocr/ocr_dialogs.py:249
+#: bookworm/ocr/ocr_dialogs.py:237
 msgid "Primary recognition Language"
 msgstr "主要识别语言"
 
-#: bookworm/ocr/ocr_dialogs.py:256
+#: bookworm/ocr/ocr_dialogs.py:244
 msgid "Add a secondary recognition language"
 msgstr "新增辅助识别语言"
 
-#: bookworm/ocr/ocr_dialogs.py:260
+#: bookworm/ocr/ocr_dialogs.py:248
 msgid "Secondary recognition Language"
 msgstr "辅助识别语言"
 
-#: bookworm/ocr/ocr_dialogs.py:268
+#: bookworm/ocr/ocr_dialogs.py:256
 #: bookworm/structured_text/structural_elements.py:71
 msgid "Image"
 msgstr "图片"
 
-#: bookworm/ocr/ocr_dialogs.py:269
+#: bookworm/ocr/ocr_dialogs.py:257
 msgid "Supplied Image resolution::"
 msgstr "提供的图像分辨率："
 
-#: bookworm/ocr/ocr_dialogs.py:273
+#: bookworm/ocr/ocr_dialogs.py:261
 msgid "Enable image enhancements"
 msgstr "启用图像增强"
 
-#: bookworm/ocr/ocr_dialogs.py:278
+#: bookworm/ocr/ocr_dialogs.py:266
 msgid "Available image pre-processing filters:"
 msgstr "可用的图像预处理过滤器："
 
 #. Translators: the label of a checkbox
-#: bookworm/ocr/ocr_dialogs.py:293
+#: bookworm/ocr/ocr_dialogs.py:281
 msgid "&Save these options until I close the current book"
 msgstr "保存这些选项，直到我关闭当前文档为止"
 
-#: bookworm/ocr/ocr_dialogs.py:374
+#: bookworm/ocr/ocr_dialogs.py:362
 msgid "Increase image resolution"
 msgstr "提高图像分辨率"
 
-#: bookworm/ocr/ocr_dialogs.py:375
+#: bookworm/ocr/ocr_dialogs.py:363
 msgid "Binarization"
 msgstr "二值化"
 
-#: bookworm/ocr/ocr_dialogs.py:378
+#: bookworm/ocr/ocr_dialogs.py:366
 msgid "Split two-in-one scans to individual pages"
 msgstr "将二合一扫描拆分到单页面"
 
-#: bookworm/ocr/ocr_dialogs.py:381
+#: bookworm/ocr/ocr_dialogs.py:369
 msgid "Combine images"
 msgstr "图像合并"
 
-#: bookworm/ocr/ocr_dialogs.py:382
+#: bookworm/ocr/ocr_dialogs.py:370
 msgid "Blurring"
 msgstr "模糊"
 
-#: bookworm/ocr/ocr_dialogs.py:383
+#: bookworm/ocr/ocr_dialogs.py:371
 msgid "Deskewing"
 msgstr "去偏斜"
 
-#: bookworm/ocr/ocr_dialogs.py:384
+#: bookworm/ocr/ocr_dialogs.py:372
 msgid "Erosion"
 msgstr "腐蚀"
 
-#: bookworm/ocr/ocr_dialogs.py:385
+#: bookworm/ocr/ocr_dialogs.py:373
 msgid "Dilation"
 msgstr "膨胀"
 
-#: bookworm/ocr/ocr_dialogs.py:386
+#: bookworm/ocr/ocr_dialogs.py:374
 msgid "Sharpen image"
 msgstr "锐化图像"
 
-#: bookworm/ocr/ocr_dialogs.py:387
+#: bookworm/ocr/ocr_dialogs.py:375
 msgid "Invert colors"
 msgstr "颜色反转"
 
-#: bookworm/ocr/ocr_dialogs.py:390
+#: bookworm/ocr/ocr_dialogs.py:378
 msgid "Debug"
 msgstr "调试"
 
-#: bookworm/ocr/ocr_dialogs.py:409
+#: bookworm/ocr/ocr_dialogs.py:397
 msgid "Installed Languages"
 msgstr "已安装的语言"
 
-#: bookworm/ocr/ocr_dialogs.py:413
+#: bookworm/ocr/ocr_dialogs.py:401
 msgid "Downloadable Languages"
 msgstr "可供下载的语言"
 
 #. Translators: label of a list control containing bookmarks
-#: bookworm/ocr/ocr_dialogs.py:444
+#: bookworm/ocr/ocr_dialogs.py:432
 msgid "Tesseract Languages"
 msgstr "Tesseract 语言"
 
-#: bookworm/ocr/ocr_dialogs.py:457
+#: bookworm/ocr/ocr_dialogs.py:445
 msgid "Download &Best Model"
 msgstr "下载最佳模型(&B)"
 
-#: bookworm/ocr/ocr_dialogs.py:461
+#: bookworm/ocr/ocr_dialogs.py:449
 msgid "Download &Fast Model"
 msgstr "下载快速模型(&F)"
 
 #. Translators: the title of a column in the Tesseract language list
-#: bookworm/ocr/ocr_dialogs.py:503
+#: bookworm/ocr/ocr_dialogs.py:491
 msgid "Installed"
 msgstr "已安装"
 
-#: bookworm/ocr/ocr_dialogs.py:506
+#: bookworm/ocr/ocr_dialogs.py:494
 msgid "Yes"
 msgstr "是"
 
-#: bookworm/ocr/ocr_dialogs.py:506
+#: bookworm/ocr/ocr_dialogs.py:494
 msgid "No"
 msgstr "否"
 
 #. Translators: content of a messagebox
-#: bookworm/ocr/ocr_dialogs.py:536
+#: bookworm/ocr/ocr_dialogs.py:524
 msgid ""
 "A version of the selected language model already exists.\n"
 "Are you sure you want to replace it?"
@@ -3045,12 +3049,12 @@ msgstr ""
 "您确定要更换吗？"
 
 #. Translators: title of a progress dialog
-#: bookworm/ocr/ocr_dialogs.py:554
+#: bookworm/ocr/ocr_dialogs.py:542
 msgid "Downloading Language"
 msgstr "下载语言"
 
 #. Translators: content of a messagebox
-#: bookworm/ocr/ocr_dialogs.py:579
+#: bookworm/ocr/ocr_dialogs.py:567
 msgid ""
 "Are you sure you want to remove language:\n"
 "{lang}?"
@@ -3059,26 +3063,26 @@ msgstr ""
 "{lang} 吗？"
 
 #. Translators: title of a messagebox
-#: bookworm/ocr/ocr_dialogs.py:604
+#: bookworm/ocr/ocr_dialogs.py:592
 msgid "Language Added"
 msgstr "已添加语言"
 
 #. Translators: content of a message box
-#: bookworm/ocr/ocr_dialogs.py:606
+#: bookworm/ocr/ocr_dialogs.py:594
 msgid "The Language Model was downloaded successfully."
 msgstr "该语言模型已成功下载。"
 
 #. Translators: title of a message box
 #. Translators: title of a messagebox
-#: bookworm/ocr/ocr_dialogs.py:614
+#: bookworm/ocr/ocr_dialogs.py:602
 #: bookworm/platforms/win32/pandoc_download.py:54
-#: bookworm/platforms/win32/tesseract_download.py:85
+#: bookworm/platforms/win32/tesseract_download.py:83
 #: bookworm/webservices/wikiworm.py:135
 msgid "Connection Error"
 msgstr "连接错误"
 
 #. Translators: content of a message box
-#: bookworm/ocr/ocr_dialogs.py:616
+#: bookworm/ocr/ocr_dialogs.py:604
 msgid ""
 "Failed to download language data.\n"
 "Please check your internet connection."
@@ -3087,7 +3091,7 @@ msgstr ""
 "请检查您的互联网连接。"
 
 #. Translators: content of a messagebox
-#: bookworm/ocr/ocr_dialogs.py:627
+#: bookworm/ocr/ocr_dialogs.py:615
 msgid ""
 "Failed to install language data.\n"
 "Please try again later."
@@ -3095,64 +3099,64 @@ msgstr ""
 "安装语言数据失败。\n"
 "请稍后再试。"
 
-#: bookworm/ocr/ocr_menu.py:86
+#: bookworm/ocr/ocr_menu.py:84
 msgid "Recognition Result: {image_name}"
 msgstr "识别结果：{image_name}"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/ocr/ocr_menu.py:121
+#: bookworm/ocr/ocr_menu.py:119
 msgid "&Scan Current Page...\tF4"
 msgstr "扫描当前页(&S)...\tF4"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/ocr/ocr_menu.py:123
+#: bookworm/ocr/ocr_menu.py:121
 msgid "Run OCR on the current page"
 msgstr "扫描当前页"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/ocr/ocr_menu.py:128
+#: bookworm/ocr/ocr_menu.py:126
 msgid "&Automatic OCR\tCtrl-F4"
 msgstr "自动OCR \tCtrl-F4"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/ocr/ocr_menu.py:130
+#: bookworm/ocr/ocr_menu.py:128
 msgid "Auto run  OCR when turning pages."
 msgstr "翻页时自动执行OCR。"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/ocr/ocr_menu.py:136
+#: bookworm/ocr/ocr_menu.py:134
 msgid "&Change OCR Options..."
 msgstr "更改OCR选项..."
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/ocr/ocr_menu.py:138
+#: bookworm/ocr/ocr_menu.py:136
 msgid "Change OCR options"
 msgstr "更改OCR选项"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/ocr/ocr_menu.py:143
+#: bookworm/ocr/ocr_menu.py:141
 msgid "Scan To &Text File..."
 msgstr "扫描到文本文档(&T)..."
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/ocr/ocr_menu.py:145
+#: bookworm/ocr/ocr_menu.py:143
 msgid "Scan pages and save the text to a .txt file."
 msgstr "扫描页面并将文本保存至.txt文件。"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/ocr/ocr_menu.py:150
+#: bookworm/ocr/ocr_menu.py:148
 msgid "Image To Text..."
 msgstr "图片转文字..."
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/ocr/ocr_menu.py:152
+#: bookworm/ocr/ocr_menu.py:150
 msgid "Run OCR on an image."
 msgstr "在图像上运行OCR。"
 
 #. Translators: the label of the OCR menu in the application menubar
 #. Event handlers
 #. Translators: content of a message
-#: bookworm/ocr/ocr_menu.py:199
+#: bookworm/ocr/ocr_menu.py:197
 msgid ""
 "No language for OCR is present.\n"
 "Please checkout Bookworm user manual to learn how to add new languages."
@@ -3161,43 +3165,43 @@ msgstr ""
 "请查看 Bookworm 用户指南以了解如何添加新语言。"
 
 #. Translators: title for a message
-#: bookworm/ocr/ocr_menu.py:203
+#: bookworm/ocr/ocr_menu.py:201
 msgid "No Languages for OCR"
 msgstr "没有可供识别的语言"
 
-#: bookworm/ocr/ocr_menu.py:222
+#: bookworm/ocr/ocr_menu.py:220
 msgid "Canceled"
 msgstr "已取消(&C)"
 
-#: bookworm/ocr/ocr_menu.py:258
+#: bookworm/ocr/ocr_menu.py:256
 msgid "Running OCR, please wait..."
 msgstr "正在扫描，请稍候..."
 
-#: bookworm/ocr/ocr_menu.py:268
+#: bookworm/ocr/ocr_menu.py:266
 msgid "Automatic OCR is enabled"
 msgstr "自动OCR已启用"
 
-#: bookworm/ocr/ocr_menu.py:270
+#: bookworm/ocr/ocr_menu.py:268
 msgid "Automatic OCR is disabled"
 msgstr "自动OCR已停用"
 
 #. Translators: the title of a save file dialog asking the user for a filename
 #. to export notes to
-#: bookworm/ocr/ocr_menu.py:283
+#: bookworm/ocr/ocr_menu.py:281
 msgid "Save as"
 msgstr "另存为"
 
 #. Translators: the title of a progress dialog
-#: bookworm/ocr/ocr_menu.py:300
+#: bookworm/ocr/ocr_menu.py:298
 msgid "Scanning Pages"
 msgstr "扫描页面"
 
 #. Translators: the message of a progress dialog
-#: bookworm/ocr/ocr_menu.py:302
+#: bookworm/ocr/ocr_menu.py:300
 msgid "Preparing book"
 msgstr "准备文档"
 
-#: bookworm/ocr/ocr_menu.py:321
+#: bookworm/ocr/ocr_menu.py:319
 msgid ""
 "Successfully processed {total} pages.\n"
 "Extracted text was written to: {file}"
@@ -3205,37 +3209,37 @@ msgstr ""
 "已成功处理 {total} 页。\n"
 "提取的文本被写入：{file}"
 
-#: bookworm/ocr/ocr_menu.py:324
+#: bookworm/ocr/ocr_menu.py:322
 msgid "OCR Completed"
 msgstr "OCR已完成"
 
-#: bookworm/ocr/ocr_menu.py:341
+#: bookworm/ocr/ocr_menu.py:339
 msgid "Portable Network Graphics"
 msgstr "PNG"
 
-#: bookworm/ocr/ocr_menu.py:342
+#: bookworm/ocr/ocr_menu.py:340
 msgid "JPEG images"
 msgstr "JPEG"
 
-#: bookworm/ocr/ocr_menu.py:343
+#: bookworm/ocr/ocr_menu.py:341
 msgid "Bitmap images"
 msgstr "BMP"
 
-#: bookworm/ocr/ocr_menu.py:344
+#: bookworm/ocr/ocr_menu.py:342
 msgid "Tiff graphics"
 msgstr "Tiff 图像"
 
-#: bookworm/ocr/ocr_menu.py:350
+#: bookworm/ocr/ocr_menu.py:348
 msgid "All supported image formats"
 msgstr "所有支持的图像格式"
 
 #. Translators: the title of a file dialog to browse to an image
-#: bookworm/ocr/ocr_menu.py:354
+#: bookworm/ocr/ocr_menu.py:352
 msgid "Choose image file"
 msgstr "选择图像文件"
 
 #. Translators: content of a message box
-#: bookworm/ocr/ocr_menu.py:369
+#: bookworm/ocr/ocr_menu.py:367
 msgid ""
 "Could not load image from\n"
 "{filename}.\n"
@@ -3245,15 +3249,15 @@ msgstr ""
 "请确保文件存在且其中包含的数据未损坏。"
 
 #. Translators: title of a message box
-#: bookworm/ocr/ocr_menu.py:374
+#: bookworm/ocr/ocr_menu.py:372
 msgid "Could not load image file"
 msgstr "无法加载图像文件"
 
-#: bookworm/ocr/ocr_menu.py:420
+#: bookworm/ocr/ocr_menu.py:418
 msgid "Scan finished."
 msgstr "扫描完成。"
 
-#: bookworm/ocr/ocr_menu.py:426
+#: bookworm/ocr/ocr_menu.py:424
 msgid "OCR canceled"
 msgstr "取消识别"
 
@@ -3282,7 +3286,7 @@ msgid "Windows 10 OCR"
 msgstr "Windows 10 OCR"
 
 #: bookworm/platforms/win32/pandoc_download.py:39
-#: bookworm/platforms/win32/tesseract_download.py:70
+#: bookworm/platforms/win32/tesseract_download.py:68
 msgid "Extracting file..."
 msgstr "正在提取文件..."
 
@@ -3308,11 +3312,11 @@ msgstr ""
 "请再试一次。"
 
 #. Translators: content of a messagebox
-#: bookworm/platforms/win32/tesseract_download.py:78
+#: bookworm/platforms/win32/tesseract_download.py:76
 msgid "Tesseract engine downloaded successfully"
 msgstr "Tesseract 引擎已成功下载"
 
-#: bookworm/platforms/win32/tesseract_download.py:86
+#: bookworm/platforms/win32/tesseract_download.py:84
 msgid ""
 "Could not download Tesseract OCR Engine.\n"
 "Please check your internet and try again."
@@ -3320,7 +3324,7 @@ msgstr ""
 "无法下载 Tesseract 引擎\n"
 "请检查您的互联网连接。"
 
-#: bookworm/platforms/win32/tesseract_download.py:97
+#: bookworm/platforms/win32/tesseract_download.py:95
 msgid ""
 "Could not install the Tesseract OCR engine.\n"
 "Please try again."
@@ -3330,7 +3334,7 @@ msgstr ""
 
 #. Translators: the content of a message indicating the availability of an
 #. update
-#: bookworm/platforms/win32/updater.py:74
+#: bookworm/platforms/win32/updater.py:75
 msgid ""
 "A new update for Bookworm has been released.\n"
 "Would you like to download and install it?\n"
@@ -3343,25 +3347,25 @@ msgstr ""
 "新版本： {new}\n"
 
 #. Translators: the title of a message indicating the availability of an update
-#: bookworm/platforms/win32/updater.py:81
+#: bookworm/platforms/win32/updater.py:82
 msgid "Bookworm Update"
 msgstr "Bookworm 更新"
 
 #. Translators: the title of a message indicating the progress of downloading
 #. an update
-#: bookworm/platforms/win32/updater.py:91
+#: bookworm/platforms/win32/updater.py:92
 msgid "Downloading Update"
 msgstr "下载更新"
 
 #. Translators: a message indicating the progress of downloading an update
 #. bundle
-#: bookworm/platforms/win32/updater.py:93
+#: bookworm/platforms/win32/updater.py:94
 msgid "Downloading update bundle"
 msgstr "下载更新包"
 
 #. Translators: the content of a message indicating a failure in downloading an
 #. update
-#: bookworm/platforms/win32/updater.py:113
+#: bookworm/platforms/win32/updater.py:114
 msgid ""
 "A network error was occured when trying to download the update.\n"
 "Make sure you are connected to the internet, or try again at a later time."
@@ -3370,7 +3374,7 @@ msgstr ""
 "确保您已连接到互联网，或稍后重试。"
 
 #. Translators: the content of a message indicating a corrupted file
-#: bookworm/platforms/win32/updater.py:133
+#: bookworm/platforms/win32/updater.py:134
 msgid ""
 "The update file has been downloaded, but it has been corrupted during "
 "download.\n"
@@ -3380,15 +3384,15 @@ msgstr ""
 "您要重新下载更新吗？"
 
 #. Translators: the title of a message indicating a corrupted file
-#: bookworm/platforms/win32/updater.py:138
+#: bookworm/platforms/win32/updater.py:139
 msgid "Download Error"
 msgstr "下载错误"
 
-#: bookworm/platforms/win32/updater.py:149
+#: bookworm/platforms/win32/updater.py:150
 msgid "Extracting update bundle..."
 msgstr "正在提取更新包..."
 
-#: bookworm/platforms/win32/updater.py:154
+#: bookworm/platforms/win32/updater.py:155
 msgid ""
 "A problem has occured when installing the update.\n"
 "Please check the logs for more info."
@@ -3396,13 +3400,13 @@ msgstr ""
 "安装更新时出现问题。\n"
 "请查看日志以获取更多信息。"
 
-#: bookworm/platforms/win32/updater.py:157
+#: bookworm/platforms/win32/updater.py:158
 msgid "Error installing update"
 msgstr "安装更新时出错"
 
 #. Translators: the content of a message indicating successful download of the
 #. update bundle
-#: bookworm/platforms/win32/updater.py:166
+#: bookworm/platforms/win32/updater.py:167
 msgid ""
 "The update has been downloaded successfully, and it is ready to be "
 "installed.\n"
@@ -3415,7 +3419,7 @@ msgstr ""
 
 #. Translators: the title of a message indicating successful download of the
 #. update bundle
-#: bookworm/platforms/win32/updater.py:172
+#: bookworm/platforms/win32/updater.py:173
 msgid "Download Completed"
 msgstr "下载完成"
 
@@ -3472,56 +3476,56 @@ msgid "Table"
 msgstr "表格"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/text_to_speech/__init__.py:106
+#: bookworm/text_to_speech/__init__.py:94
 msgid "S&peech"
 msgstr "语音(&S)"
 
 #. Translators: the label of a page in the settings dialog
-#: bookworm/text_to_speech/__init__.py:111
+#: bookworm/text_to_speech/__init__.py:99
 msgid "Reading"
 msgstr "阅读"
 
 #. Translators: the label of a page in the settings dialog
 #. Translators: the label of a group of controls in the
 #. speech settings page related to voice selection
-#: bookworm/text_to_speech/__init__.py:113
-#: bookworm/text_to_speech/__init__.py:124
-#: bookworm/text_to_speech/tts_gui.py:140
+#: bookworm/text_to_speech/__init__.py:101
+#: bookworm/text_to_speech/__init__.py:112
+#: bookworm/text_to_speech/tts_gui.py:137
 msgid "Voice"
 msgstr "语音"
 
-#: bookworm/text_to_speech/__init__.py:121
+#: bookworm/text_to_speech/__init__.py:109
 msgid "Back"
 msgstr "返回"
 
-#: bookworm/text_to_speech/__init__.py:122
+#: bookworm/text_to_speech/__init__.py:110
 msgid "Play"
 msgstr "朗读"
 
-#: bookworm/text_to_speech/__init__.py:123
+#: bookworm/text_to_speech/__init__.py:111
 msgid "Forward"
 msgstr "向前"
 
-#: bookworm/text_to_speech/__init__.py:214
+#: bookworm/text_to_speech/__init__.py:202
 msgid "End of document."
 msgstr "文档结束。"
 
-#: bookworm/text_to_speech/__init__.py:235
+#: bookworm/text_to_speech/__init__.py:223
 msgid "End of section: {chapter}."
 msgstr "章节末尾: {chapter}。"
 
 #. Translators: spoken message at the end of the document
-#: bookworm/text_to_speech/__init__.py:268
+#: bookworm/text_to_speech/__init__.py:256
 msgid "End of document"
 msgstr "文档结束"
 
 #. Translators: the title of a message telling the user that no TTS voice found
-#: bookworm/text_to_speech/__init__.py:421
+#: bookworm/text_to_speech/__init__.py:409
 msgid "No TTS Voices"
 msgstr "无TTS引擎"
 
 #. Translators: a message telling the user that no TTS voice found
-#: bookworm/text_to_speech/__init__.py:423
+#: bookworm/text_to_speech/__init__.py:411
 msgid ""
 "A valid Text-to-speech voice was not found for the current speech engine.\n"
 "Text-to-speech functionality will be disabled."
@@ -3530,7 +3534,7 @@ msgstr ""
 "TTS功能将被禁用。"
 
 #. Translators: a message telling the user that the TTS voice has been changed
-#: bookworm/text_to_speech/__init__.py:441
+#: bookworm/text_to_speech/__init__.py:429
 msgid ""
 "Bookworm has noticed that the currently configured Text-to-speech voice "
 "speaks a language different from that of this book.\n"
@@ -3542,7 +3546,7 @@ msgstr ""
 
 #. Translators: the title of a message telling the user that the TTS voice has
 #. been changed
-#: bookworm/text_to_speech/__init__.py:448
+#: bookworm/text_to_speech/__init__.py:436
 msgid "Incompatible TTS Voice Detected"
 msgstr "检测到不兼容的TTS语音引擎"
 
@@ -3562,176 +3566,176 @@ msgid "Express"
 msgstr "Express"
 
 #. Translators: the label of a group of controls in the reading page
-#: bookworm/text_to_speech/tts_gui.py:51
+#: bookworm/text_to_speech/tts_gui.py:48
 msgid "Reading Options"
 msgstr "阅读选项"
 
 #. Translators: the title of a group of radio buttons in the reading page
 #. in the application settings related to how to read.
-#: bookworm/text_to_speech/tts_gui.py:57
+#: bookworm/text_to_speech/tts_gui.py:54
 msgid "When Pressing Play:"
 msgstr "开始朗读时："
 
 #. Translators: the label of a radio button
-#: bookworm/text_to_speech/tts_gui.py:62
+#: bookworm/text_to_speech/tts_gui.py:59
 msgid "Read the entire book"
 msgstr "整本阅读"
 
 #. Translators: the label of a radio button
-#: bookworm/text_to_speech/tts_gui.py:64
+#: bookworm/text_to_speech/tts_gui.py:61
 msgid "Read the current section"
 msgstr "阅读当前章节"
 
 #. Translators: the label of a radio button
-#: bookworm/text_to_speech/tts_gui.py:66
+#: bookworm/text_to_speech/tts_gui.py:63
 msgid "Read the current page"
 msgstr "阅读当前页"
 
 #. Translators: the title of a group of radio buttons in the reading page
 #. in the application settings related to where to start reading from.
-#: bookworm/text_to_speech/tts_gui.py:74
+#: bookworm/text_to_speech/tts_gui.py:71
 msgid "Start reading from:"
 msgstr "从以下位置开始阅读："
 
 #. Translators: the label of a radio button
-#: bookworm/text_to_speech/tts_gui.py:78
+#: bookworm/text_to_speech/tts_gui.py:75
 msgid "Cursor position"
 msgstr "光标位置"
 
-#: bookworm/text_to_speech/tts_gui.py:78
+#: bookworm/text_to_speech/tts_gui.py:75
 msgid "Beginning of page"
 msgstr "页面起始处"
 
 #. Translators: the label of a group of controls in the reading page
 #. of the settings related to behavior during reading  aloud
-#: bookworm/text_to_speech/tts_gui.py:82
+#: bookworm/text_to_speech/tts_gui.py:79
 msgid "During Reading Aloud"
 msgstr "朗读过程中"
 
-#: bookworm/text_to_speech/tts_gui.py:87
+#: bookworm/text_to_speech/tts_gui.py:84
 msgid "Speak page number"
 msgstr "读出页码"
 
 #. Translators: the label of a checkbox
-#: bookworm/text_to_speech/tts_gui.py:94
+#: bookworm/text_to_speech/tts_gui.py:91
 msgid "Announce the end of sections"
 msgstr "读出章节结束"
 
 #. Translators: the label of a checkbox
-#: bookworm/text_to_speech/tts_gui.py:101
+#: bookworm/text_to_speech/tts_gui.py:98
 msgid "Ask to switch to a voice that speaks the language of the current book"
 msgstr "切换到与当前文档语言一致的语音"
 
 #. Translators: the label of a checkbox
-#: bookworm/text_to_speech/tts_gui.py:108
+#: bookworm/text_to_speech/tts_gui.py:105
 msgid "Highlight spoken text"
 msgstr "高亮显示朗读内容"
 
 #. Translators: the label of a checkbox
-#: bookworm/text_to_speech/tts_gui.py:115
+#: bookworm/text_to_speech/tts_gui.py:112
 msgid "Select spoken text"
 msgstr "选中朗读内容"
 
 #. Translators: the label of a combobox containing a list of tts engines
-#: bookworm/text_to_speech/tts_gui.py:143
+#: bookworm/text_to_speech/tts_gui.py:140
 msgid "Speech Engine:"
 msgstr "语音引擎："
 
 #. Translators: the label of a button that opens a dialog to change the speech
 #. engine
-#: bookworm/text_to_speech/tts_gui.py:148
+#: bookworm/text_to_speech/tts_gui.py:145
 msgid "Change..."
 msgstr "更改(&C)..."
 
 #. Translators: the label of a combobox containing a list of tts voices
-#: bookworm/text_to_speech/tts_gui.py:151
+#: bookworm/text_to_speech/tts_gui.py:148
 msgid "Select Voice:"
 msgstr "语音："
 
 #. Translators: the label of the speech rate slider
-#: bookworm/text_to_speech/tts_gui.py:154
+#: bookworm/text_to_speech/tts_gui.py:151
 msgid "Speech Rate:"
 msgstr "语速："
 
 #. Translators: the label of the voice pitch slider
-#: bookworm/text_to_speech/tts_gui.py:160
+#: bookworm/text_to_speech/tts_gui.py:157
 msgid "Voice Pitch:"
 msgstr "音调"
 
 #. Translators: the label of the speech volume slider
-#: bookworm/text_to_speech/tts_gui.py:166
+#: bookworm/text_to_speech/tts_gui.py:163
 msgid "Speech Volume:"
 msgstr "音量："
 
 #. Translators: the label of a group of controls in the speech
 #. settings page related to speech pauses
-#: bookworm/text_to_speech/tts_gui.py:173
+#: bookworm/text_to_speech/tts_gui.py:170
 msgid "Pauses"
 msgstr "停顿"
 
 #. Translators: the label of an edit field
-#: bookworm/text_to_speech/tts_gui.py:176
+#: bookworm/text_to_speech/tts_gui.py:173
 msgid "Additional Pause At Sentence End (Ms)"
 msgstr "句末停顿 （毫秒）"
 
 #. Translators: the label of an edit field
-#: bookworm/text_to_speech/tts_gui.py:181
+#: bookworm/text_to_speech/tts_gui.py:178
 msgid "Additional Pause At Paragraph End (Ms)"
 msgstr "段末停顿 （毫秒）"
 
 #. Translators: the label of an edit field
-#: bookworm/text_to_speech/tts_gui.py:186
+#: bookworm/text_to_speech/tts_gui.py:183
 msgid "End of Page Pause (ms)"
 msgstr "页末停顿 （毫秒）"
 
 #. Translators: the label of an edit field
-#: bookworm/text_to_speech/tts_gui.py:195
+#: bookworm/text_to_speech/tts_gui.py:192
 msgid "End of Section Pause (ms)"
 msgstr "章、节末停顿 （毫秒）"
 
-#: bookworm/text_to_speech/tts_gui.py:239
+#: bookworm/text_to_speech/tts_gui.py:236
 msgid "Speech Engine"
 msgstr "语音引擎"
 
 #. Translators: the title of a dialog to edit a voice profile
-#: bookworm/text_to_speech/tts_gui.py:288
+#: bookworm/text_to_speech/tts_gui.py:285
 msgid "Voice Profile: {profile}"
 msgstr "语音配置{profile}"
 
 #. Translators: the label of a combobox to select a voice profile
-#: bookworm/text_to_speech/tts_gui.py:315
+#: bookworm/text_to_speech/tts_gui.py:312
 msgid "Select Voice Profile:"
 msgstr "选择语音配置："
 
 #. Translators: the label of a button to activate a voice profile
-#: bookworm/text_to_speech/tts_gui.py:321
+#: bookworm/text_to_speech/tts_gui.py:318
 msgid "&Activate"
 msgstr "激活(&A)"
 
 #. Translators: the label of a button to create a new voice profile
-#: bookworm/text_to_speech/tts_gui.py:327
+#: bookworm/text_to_speech/tts_gui.py:324
 msgid "&New Profile..."
 msgstr "新建配置(&N)..."
 
 #. Translators: the entry of the active voice profile in the voice profiles
 #. list
-#: bookworm/text_to_speech/tts_gui.py:361
+#: bookworm/text_to_speech/tts_gui.py:358
 msgid "{profile} (active)"
 msgstr "{profile} (激活)"
 
 #. Translators: the label of an edit field to enter the voice profile name
-#: bookworm/text_to_speech/tts_gui.py:411
+#: bookworm/text_to_speech/tts_gui.py:408
 msgid "Profile Name:"
 msgstr "配置名称："
 
 #. Translators: the title of a dialog to enter the name of a new voice profile
-#: bookworm/text_to_speech/tts_gui.py:413
+#: bookworm/text_to_speech/tts_gui.py:410
 msgid "New Voice Profile"
 msgstr "新语音配置"
 
 #. Translators: the content of a message notifying the user
 #. user of the existence of a voice profile with the same name
-#: bookworm/text_to_speech/tts_gui.py:425
+#: bookworm/text_to_speech/tts_gui.py:422
 msgid ""
 "A voice profile with the same name already exists. Please select another "
 "name."
@@ -3739,7 +3743,7 @@ msgstr "具有相同名称的语音配置已存在。请换一个其他名称。
 
 #. Translators: the content of a message telling the user that the voice
 #. profile he is removing is the active one
-#: bookworm/text_to_speech/tts_gui.py:451
+#: bookworm/text_to_speech/tts_gui.py:448
 msgid ""
 "Voice profile {profile} is the active profile.\n"
 "Please deactivate it first by clicking 'Deactivate Active Voice Profile` "
@@ -3750,13 +3754,13 @@ msgstr ""
 
 #. Translators: the title of a message telling the user that
 #. it is not possible to remove this voice profile
-#: bookworm/text_to_speech/tts_gui.py:458
+#: bookworm/text_to_speech/tts_gui.py:455
 msgid "Cannot Remove Profile"
 msgstr "无法删除配置"
 
 #. Translators: the title of a message to confirm the removal of the voice
 #. profile
-#: bookworm/text_to_speech/tts_gui.py:464
+#: bookworm/text_to_speech/tts_gui.py:461
 msgid ""
 "Are you sure you want to remove voice profile {profile}?\n"
 "This cannot be undone."
@@ -3767,102 +3771,102 @@ msgstr ""
 
 #. Translators: the title of a message to confirm the removal of a voice
 #. profile
-#: bookworm/text_to_speech/tts_gui.py:469
+#: bookworm/text_to_speech/tts_gui.py:466
 msgid "Remove Voice Profile?"
 msgstr "删除语音配置？"
 
 #. Translators: the label of a combobox
-#: bookworm/text_to_speech/tts_gui.py:492
+#: bookworm/text_to_speech/tts_gui.py:489
 msgid "Select Speech Engine:"
 msgstr "选择语音引擎："
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:521
+#: bookworm/text_to_speech/tts_gui.py:518
 msgid "&Play\tF5"
 msgstr "朗读(&P) \tF5"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:523
+#: bookworm/text_to_speech/tts_gui.py:520
 msgid "Start reading aloud"
 msgstr "开始朗读"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:528
+#: bookworm/text_to_speech/tts_gui.py:525
 msgid "Pa&use/Resume\tF6"
 msgstr "暂停/恢复(&U) \tF6"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:530
+#: bookworm/text_to_speech/tts_gui.py:527
 msgid "Pause/Resume reading aloud"
 msgstr "暂停/继续朗读"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:535
+#: bookworm/text_to_speech/tts_gui.py:532
 msgid "&Stop\tF7"
 msgstr "停止(&S) \tF7"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:537
+#: bookworm/text_to_speech/tts_gui.py:534
 msgid "Stop reading aloud"
 msgstr "停止朗读"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:542
+#: bookworm/text_to_speech/tts_gui.py:539
 msgid "&Rewind\tAlt-LeftArrow"
 msgstr "快退(&R) Alt-Left"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:544
+#: bookworm/text_to_speech/tts_gui.py:541
 msgid "Skip to previous paragraph"
 msgstr "跳到上一段"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:549
+#: bookworm/text_to_speech/tts_gui.py:546
 msgid "&Fast Forward\tAlt-RightArrow"
 msgstr "快进(&F) \tAlt-Right"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:551
+#: bookworm/text_to_speech/tts_gui.py:548
 msgid "Skip to next paragraph"
 msgstr "跳到下一段"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:556
+#: bookworm/text_to_speech/tts_gui.py:553
 msgid "&Voice Profiles\tCtrl-Shift-V"
 msgstr "语音配置(&V) \tCtrl-Shift-V"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:558
+#: bookworm/text_to_speech/tts_gui.py:555
 msgid "Manage voice profiles."
 msgstr "管理语音配置。"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:563
+#: bookworm/text_to_speech/tts_gui.py:560
 msgid "&Deactivate Active Voice Profile"
 msgstr "停用语音配置(&D)"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:565
+#: bookworm/text_to_speech/tts_gui.py:562
 msgid "Deactivate the active voice profile."
 msgstr "停用激活的语音配置。"
 
 #. Translators: a message that is announced when the speech is paused
-#: bookworm/text_to_speech/tts_gui.py:627
+#: bookworm/text_to_speech/tts_gui.py:624
 msgid "Paused"
 msgstr "已暂停"
 
 #. Translators: a message that is announced when the speech is resumed
-#: bookworm/text_to_speech/tts_gui.py:631
+#: bookworm/text_to_speech/tts_gui.py:628
 msgid "Resumed"
 msgstr "已恢复"
 
 #. Translators: a message that is announced when the speech is stopped
-#: bookworm/text_to_speech/tts_gui.py:641
+#: bookworm/text_to_speech/tts_gui.py:638
 msgid "Stopped"
 msgstr "已停止"
 
 #. Translators: the title of the voice profiles dialog
-#: bookworm/text_to_speech/tts_gui.py:646
+#: bookworm/text_to_speech/tts_gui.py:643
 msgid "Voice Profiles"
 msgstr "语音配置"
 


### PR DESCRIPTION
## Link to issue number:
Close #218 
### Summary of the issue:
In the element list dialog, labels for "element type" and search result list view cannot be translated.
### Description of how this pull request fixes the issue:
Added translatable flags for these labels in 'core dialogs.py'.
Where "element type" is a new translatable string.
So, I updated this for Simplified Chinese translation as well.
### Testing performed:
manual testing
### Known issues with pull request:
None
