### PR TITLE
Fix KeyError due to play sound for comments being deprecated

### DIFF
--- a/bookworm/annotation/__init__.py
+++ b/bookworm/annotation/__init__.py
@@ -272,6 +272,7 @@ class AnnotationService(BookwormService):
     def comments_page_handler(cls, sender, current, prev):
         comments = NoteTaker(sender).get_for_page()
         if comments.count():
+            # 'play sound for comments' is deprecated
             if config.conf["annotation"]["audable_indication_of_annotations_when_navigating_text"]:
                 wx.CallLater(150, lambda: sounds.has_note.play())
         for comment in comments:

--- a/bookworm/annotation/__init__.py
+++ b/bookworm/annotation/__init__.py
@@ -272,7 +272,7 @@ class AnnotationService(BookwormService):
     def comments_page_handler(cls, sender, current, prev):
         comments = NoteTaker(sender).get_for_page()
         if comments.count():
-            if config.conf["annotation"]["play_sound_for_comments"]:
+            if config.conf["annotation"]["audable_indication_of_annotations_when_navigating_text"]:
                 wx.CallLater(150, lambda: sounds.has_note.play())
         for comment in comments:
             cls.style_comment(sender.view, comment.position)


### PR DESCRIPTION
## Link to issue number:
None
### Summary of the issue:
I noticed that 'play sound for comments' has been replaced by 'audable indication of annotations when navigating text'.
However, we still have a check for the Key in the `comments page handler`, which will cause a `KeyError`, which will cause the document containing the comment to not be opened.
### Description of how this pull request fixes the issue:
I updated it to check 'audable indication of annotations when navigating text' instead of 'play sound for comments'.
### Testing performed:
manual testing
### Known issues with pull request:
None
