### PR TITLE
Try to fix the bug that the reverse navigation highlight always jumps to the first highlight

### DIFF
--- a/bookworm/annotation/annotator.py
+++ b/bookworm/annotation/annotator.py
@@ -278,6 +278,6 @@ class Quoter(TaggedAnnotator):
             .filter_by(book_id=self.current_book.id)
             .filter(sa.or_(*clauses))
             .order_by(model.page_number.desc())
-            .order_by(model.position.desc())
+            .order_by(model.end_pos.desc())
             .first()
         )


### PR DESCRIPTION
## Link to issue number:
Close #226 
### Summary of the issue:
When you have multiple highlights in a book, jumping backwards from a highlight will always return you to the first highlight.
### Description of how this pull request fixes the issue:
Fix for the "get first before" method of the Quoter class in annotation/annotator.py.
Should be written as `.order by(model.end pos.desc())` instead of `.order by(model.position.desc())`

### Testing performed:
Tested manually with steps from #226, this fixed the issue.
### Known issues with pull request:
None
