### PR TITLE
feat(update): Implement robust version comparison for update checks

### DIFF
--- a/tests/test_otau.py
+++ b/tests/test_otau.py
@@ -1,6 +1,6 @@
 import pytest
 
-from bookworm.otau import UpdateChannel
+from bookworm.otau import UpdateChannel, is_newer_version
 
 
 def test_is_not_valid_identifier():
@@ -17,3 +17,38 @@ def test_is_valid_identifier():
 def test_is_major_version():
     c = UpdateChannel('')
     assert c.is_major == True
+
+
+@pytest.mark.parametrize(
+    "current_version,upstream_version,expected",
+    [
+        # Normal version comparisons
+        ("2024.1", "2024.2", True),  # Minor version increment
+        ("2024.1", "2025.1", True),  # Major version increment
+        ("2025.1", "2024.4.2", False),  # Current version newer
+        ("2024.1.0", "2024.1.1", True),  # Patch version increment
+        
+        # Pre-release versions
+        ("2024.1rc1", "2024.1", True),  # Release candidate to final
+        ("2024.1", "2024.1rc1", False),  # Final to release candidate
+        ("2024.1a1", "2024.1b1", True),  # Alpha to beta
+        ("2024.1b1", "2024.1rc1", True),  # Beta to release candidate
+        
+        # Complex versions
+        ("2024.1.0.0", "2024.1.0.1", True),  # Four-part version
+        ("2024.1.post1", "2024.2", True),  # Post-release version
+        ("2024.1.dev1", "2024.1", True),  # Development version
+        
+        # Edge cases
+        ("2024.1", "2024.1", False),  # Same version
+        ("invalid", "2024.1", True),  # Invalid current version (fallback to string comparison)
+        ("2024.1", "invalid", False),  # Invalid upstream version (fallback to string comparison)
+    ],
+)
+def test_version_comparison(current_version, upstream_version, expected):
+    """Test various version comparison scenarios"""
+    result = is_newer_version(current_version, upstream_version)
+    assert result == expected, (
+        f"Version comparison failed for {current_version} vs {upstream_version}. "
+        f"Expected {expected}, got {result}"
+    )


### PR DESCRIPTION
## Link to issue number:
None

### Summary of the issue:

Bookworm incorrectly identifies version "2024.4.2" as newer than "2025.1" due to simple string comparison. This causes the update system to suggest incorrect version updates to users.

### Description of how this pull request fixes the issue:

This PR improves the version comparison functionality in the update checking system:

1. Implements semantic version comparison using `packaging.version`
2. Adds robust handling of invalid version strings:
   - Returns `False` if upstream version is invalid
   - Returns `True` if current version is invalid but upstream version is valid
3. Adds comprehensive test coverage for version comparison:
   - Normal version comparisons (major, minor, patch)
   - Pre-release versions (alpha, beta, rc)
   - Complex versions (four-part, post-release, dev)
   - Edge cases (same version, invalid versions)

### Testing performed:

- Added comprehensive unit tests in `test_otau.py` covering:
  - Normal version comparisons (major, minor, patch)
  - Pre-release versions (alpha, beta, rc)
  - Complex versions (four-part, post-release, dev)
  - Edge cases (same version, invalid versions)
- All test cases pass successfully
- Manually verified correct version comparison behavior with various version formats
- Verified logging behavior for invalid version strings

### Known issues with pull request:

unknown
