### PR TITLE
fix: adjust cursor position for footnote navigation

### DIFF
--- a/bookworm/reader.py
+++ b/bookworm/reader.py
@@ -418,8 +418,9 @@ class EBookReader:
             self.view.go_to_webpage(target_info.url)
         else:
             start, end = target_info.position
+            start += 1
             self.perform_wormhole_navigation(
-                page=target_info.page, start=start, end=None, last_position=link_range
+                page=target_info.page, start=start, end=end, last_position=link_range
             )
 
     def get_view_title(self, include_author=False):


### PR DESCRIPTION
## Link to issue number:
Fix#317
### Summary of the issue:
When navigating to a footnote, the cursor was landing on the line before the footnote content.

### Description of how this pull request fixes the issue:

This fix adjusts the start position by adding 1 to ensure the cursor lands on the footnote content line.
### Testing performed:
### Known issues with pull request:

Follow the steps in #317 for testing