### PR TITLE
fix(epub): Handle missing <head> or <body> tags in EPUB HTML fragments

### DIFF
--- a/bookworm/document/formats/epub.py
+++ b/bookworm/document/formats/epub.py
@@ -341,10 +341,24 @@ class EpubDocument(SinglePageDocument):
             for node in tree.xpath("//*[@id]"):
                 node.set("id", filename + "#" + node.get("id"))
         try:
-            tree.remove(tree.head)
-            tree.body.tag = "section"
-        except:
-            raise e
+            # Attempt to access and remove head
+            head_element = tree.head
+            if head_element is not None:
+                tree.remove(head_element)
+
+            # Attempt to access and modify body tag
+            body_element = tree.body
+            if body_element is not None:
+                body_element.tag = "section"
+
+        except IndexError:
+            # Handle case where xpath lookup for head or body fails
+            log.warning(f"Could not find <head> or <body> element via xpath in {filename}. Skipping removal/modification.")
+        except Exception as exc:
+            # Catch other potential errors during head/body processing
+            log.warning(f"Error processing HTML structure (head/body) in {filename}: {exc}")
+            raise exc # Re-raise other unexpected errors
+
         tree.tag = "div"
         tree.insert(0, tree.makeelement("header", attrib={"id": filename}))
         return lxml_html.tostring(tree, method="html", encoding="unicode")


### PR DESCRIPTION
## Link to issue number:
None
### Summary of the issue:
The `prefix_html_ids` function previously crashed with an `IndexError` when `lxml`'s internal XPath lookup for `tree.head` or `tree.body` failed because the element was missing in the source HTML fragment.
### Description of how this pull request fixes the issue:
Prevent IndexError when parsing EPUB HTML files that lack standard <head> or <body> elements.
This PR wraps the access to `tree.head` and `tree.body` within a `try...except IndexError` block. If the lookup fails, a warning is logged, and the removal/modification of the missing element is skipped,
allowing the parsing process to continue gracefully.
### Testing performed:
Manually testing previously failed-to-open Epub documents can open them as expected.

### Known issues with pull request:

unknown