### PR TITLE
fix: resolve incomplete link text display and footnote navigation issues

### DIFF
--- a/alembic/versions/52e39c4f7494_fix_annotation_position_offset.py
+++ b/alembic/versions/52e39c4f7494_fix_annotation_position_offset.py
@@ -1,0 +1,65 @@
+"""Fix annotation position offset due to initial newline
+
+Revision ID: 52e39c4f7494
+Revises: 35f453946f1e
+Create Date: 2025-07-14 20:04:27.707924
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import bookworm
+
+# revision identifiers, used by Alembic.
+revision: str = '52e39c4f7494'
+down_revision: Union[str, None] = '35f453946f1e'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """
+    Subtracts 1 from all position-related columns in annotation and document position tables.
+    This corrects the +1 offset from old data, aligning it with the new "clean" index logic.
+    """
+    print("Applying data migration to fix all known position offsets...")
+    
+    # --- Fix Last Reading Position ---
+    op.execute("UPDATE document_position_info SET last_position = last_position - 1 WHERE last_position > 0;")
+    
+    # --- Fix Bookmark positions ---
+    op.execute("UPDATE bookmark SET position = position - 1;")
+    
+    # --- Fix Quote positions ---
+    op.execute("UPDATE quote SET start_pos = start_pos - 1, end_pos = end_pos - 1;")
+    
+    # --- Fix Note positions (Robust multi-step update) ---
+    op.execute("UPDATE note SET position = position - 1;")
+    op.execute("UPDATE note SET start_pos = start_pos - 1 WHERE start_pos IS NOT NULL;")
+    op.execute("UPDATE note SET end_pos = end_pos - 1 WHERE end_pos IS NOT NULL;")
+    
+    print("All position offset corrections applied.")
+
+
+def downgrade() -> None:
+    """
+    Adds 1 back to all position-related columns to revert the data to its original offset state.
+    """
+    print("Reverting data migration for all position offsets...")
+    
+    # --- Revert Last Reading Position ---
+    op.execute("UPDATE document_position_info SET last_position = last_position + 1;")
+
+    # --- Revert Bookmark positions ---
+    op.execute("UPDATE bookmark SET position = position + 1;")
+    
+    # --- Revert Quote positions ---
+    op.execute("UPDATE quote SET start_pos = start_pos + 1, end_pos = end_pos + 1;")
+    
+    # --- Revert Note positions (Robust multi-step update) ---
+    op.execute("UPDATE note SET position = position + 1;")
+    op.execute("UPDATE note SET start_pos = start_pos + 1 WHERE start_pos IS NOT NULL;")
+    op.execute("UPDATE note SET end_pos = end_pos + 1 WHERE end_pos IS NOT NULL;")
+    
+    print("All position offset corrections reverted.")

--- a/bookworm/annotation/annotation_dialogs.py
+++ b/bookworm/annotation/annotation_dialogs.py
@@ -180,8 +180,7 @@ class BookmarksViewer(SimpleDialog):
             return
         self.reader.go_to_page(item.page_number)
         self.Close()
-        wx.CallAfter(self.parent.contentTextCtrl.SetFocusFromKbd)
-        wx.CallAfter(self.parent.contentTextCtrl.SetInsertionPoint, item.position)
+        wx.CallAfter(self.parent.set_insertion_point, item.position)
 
     def onKeyDown(self, event):
         item = self.annotationsListCtrl.get_selected()
@@ -579,7 +578,7 @@ class CommentsDialog(AnnotationWithContentDialog):
         start_pos, end_pos = (item.start_pos, item.end_pos)
         if (start_pos, end_pos) != (None, None):
             # We have a selection, let's select the text
-            self.service.view.contentTextCtrl.SetSelection(start_pos, end_pos)
+            self.service.view.select_text(start_pos, end_pos)
 
 
 class QuotesDialog(AnnotationWithContentDialog):

--- a/bookworm/annotation/annotation_gui.py
+++ b/bookworm/annotation/annotation_gui.py
@@ -171,11 +171,11 @@ class AnnotationMenu(wx.Menu):
 
     def _add_bookmark(self, name=""):
         bookmarker = Bookmarker(self.reader)
-        insertionPoint = self.view.contentTextCtrl.GetInsertionPoint()
-        __, __, current_lino = self.view.contentTextCtrl.PositionToXY(insertionPoint)
+        insertionPoint = self.view.get_insertion_point()
+        current_lino = self.view.get_line_number(insertionPoint)
         count = 0
         for bkm in bookmarker.get_for_page(self.reader.current_page):
-            __, __, lino = self.view.contentTextCtrl.PositionToXY(bkm.position)
+            lino = self.view.get_line_number(bkm.position)
             if lino == current_lino:
                 count += 1
                 bookmarker.delete(bkm.id)
@@ -202,8 +202,9 @@ class AnnotationMenu(wx.Menu):
 
     def onAddNote(self, event):
         _with_tags = wx.GetKeyState(wx.WXK_SHIFT)
-        insertionPoint = self.view.contentTextCtrl.GetInsertionPoint()
-        start_pos, end_pos = self.view.contentTextCtrl.GetSelection()
+        insertionPoint = self.view.get_insertion_point()
+        selection_range = self.view.get_selection_range()
+        start_pos, end_pos = selection_range.start, selection_range.stop
         # if start_pos and end_pos are equal, there is no selection
         # see: https://docs.wxpython.org/wx.TextEntry.html#wx.TextEntry.GetSelection
         if start_pos == end_pos:
@@ -251,10 +252,10 @@ class AnnotationMenu(wx.Menu):
     def onQuoteSelection(self, event):
         _with_tags = wx.GetKeyState(wx.WXK_SHIFT)
         quoter = Quoter(self.reader)
-        selected_text = self.view.contentTextCtrl.GetStringSelection()
-        if not selected_text:
-            return speech.announce(_("No selection"))
         x, y = self.view.get_selection_range()
+        if x == y:
+            return speech.announce(_("No selection"))
+        selected_text = self.view.get_text_by_range(x, y)
         for q in quoter.get_for_page():
             q_range = TextRange(q.start_pos, q.end_pos)
             if (q_range.start == x) and (q_range.stop == y):

--- a/bookworm/gui/book_viewer/__init__.py
+++ b/bookworm/gui/book_viewer/__init__.py
@@ -491,8 +491,8 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
             current_font_size = current_style.Font.GetPointSize()
         else:
             current_font_size = None
-        self.contentTextCtrl.SetValue("\n\n")
-        self.contentTextCtrl.SetInsertionPoint(1)
+        self.contentTextCtrl.SetValue("")
+        self.contentTextCtrl.SetInsertionPoint(0)
         self.contentTextCtrl.SetDefaultStyle(
             self.get_content_view_text_style(font_size=current_font_size)
         )

--- a/bookworm/gui/book_viewer/__init__.py
+++ b/bookworm/gui/book_viewer/__init__.py
@@ -67,6 +67,8 @@ STYLE_TO_WX_TEXT_ATTR_STYLES = {
     Style.DISPLAY_4: (wx.TextAttr.SetFontWeight, (200,)),
 }
 
+TEXT_CTRL_OFFSET = 1
+
 
 class ResourceLoader:
     """Loads a document into the view."""
@@ -491,13 +493,13 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
             current_font_size = current_style.Font.GetPointSize()
         else:
             current_font_size = None
-        self.contentTextCtrl.SetValue("")
-        self.contentTextCtrl.SetInsertionPoint(0)
+        self.contentTextCtrl.SetValue("\n\n")
+        self.contentTextCtrl.SetInsertionPoint(1)
         self.contentTextCtrl.SetDefaultStyle(
             self.get_content_view_text_style(font_size=current_font_size)
         )
         self.contentTextCtrl.WriteText(content)
-        self.contentTextCtrl.SetInsertionPoint(0)
+        self.set_insertion_point(0)
         self.contentTextCtrl.Thaw()
 
     def set_title(self, title):
@@ -550,10 +552,10 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
             config.conf["general"]["show_reading_progress_percentage"]
         )
         if self.reader.document.is_single_page_document():
-            char_count = self.contentTextCtrl.GetLastPosition()
+            char_count = self.get_last_position()
             if char_count == 0:
                 return
-            current_ratio = self.contentTextCtrl.GetInsertionPoint() / char_count
+            current_ratio = self.get_insertion_point() / char_count
         else:
             current_ratio = (self.reader.current_page + 1) / len(self.reader.document)
         percentage_ratio = math.ceil(current_ratio * 100)
@@ -650,7 +652,7 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
                 if should_speak_whole_text
                 else (start, stop)
             )
-            text = self.contentTextCtrl.GetRange(text_start, text_stop)
+            text = self.get_text_by_range(text_start, text_stop)  # <--- 修正这一行
             msg = _("{text}: {item_type}").format(text=text, item_type=_(element_label))
             target_position = (
                 start
@@ -706,7 +708,7 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
         target_nav_percentage = event.GetSelection()
         if self.reader.document.is_single_page_document():
             pos_percentage = math.floor(
-                self.contentTextCtrl.GetLastPosition() * (target_nav_percentage / 100)
+                self.get_last_position() * (target_nav_percentage / 100)
             )
             target_position = self.get_start_of_line(
                 self.get_line_number(pos_percentage)
@@ -763,22 +765,23 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
     ):
         line_start = self.get_containing_line(start)[0]
         attr = wx.TextAttr()
-        self.contentTextCtrl.GetStyle(line_start, attr)
+        self.contentTextCtrl.GetStyle(line_start + TEXT_CTRL_OFFSET, attr)
         attr.SetBackgroundColour(wx.YELLOW)
-        self.contentTextCtrl.SetStyle(start, end, attr)
+        self.contentTextCtrl.SetStyle(
+            start + TEXT_CTRL_OFFSET, end + TEXT_CTRL_OFFSET, attr
+        )
 
     def clear_highlight(self, start=0, end=-1):
         textCtrl = self.contentTextCtrl
-        end = end if end >= 0 else textCtrl.LastPosition
+        actual_start = start + TEXT_CTRL_OFFSET
+        actual_end = end if end < 0 else end + TEXT_CTRL_OFFSET
+        if end < 0 or end >= self.get_last_position():
+            actual_end = textCtrl.GetLastPosition()
         attr = wx.TextAttr()
-        textCtrl.GetStyle(self.get_containing_line(start)[0], attr)
+        textCtrl.GetStyle(actual_start, attr)
         attr.SetBackgroundColour(textCtrl.BackgroundColour)
         attr.SetTextColour(textCtrl.ForegroundColour)
-        textCtrl.SetStyle(
-            start,
-            end,
-            attr,
-        )
+        textCtrl.SetStyle(actual_start, actual_end, attr)
 
     def get_statusbar_text(self):
         page = self.reader.get_current_page_object()
@@ -807,14 +810,25 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
         self.contentTextCtrl.SelectNone()
 
     def get_selection_range(self):
-        return TextRange(*self.contentTextCtrl.GetSelection())
+        # WHY: Convert real selection range to a clean range.
+        start, end = self.contentTextCtrl.GetSelection()
+        # If nothing is selected, start can be -1. Handle this gracefully.
+        if start == -1:
+            return TextRange(self.get_insertion_point(), self.get_insertion_point())
+        return TextRange(start - TEXT_CTRL_OFFSET, end - TEXT_CTRL_OFFSET)
 
     def get_containing_line(self, pos):
         """
         Returns the left and right boundaries
         for the line containing the given position.
         """
-        return self.contentTextCtrl.GetContainingLine(pos)
+        # WHY: A double conversion.
+        # 1. Convert clean input position to a real position for the control.
+        # 2. Get the real line boundaries from the control.
+        # 3. Convert the real boundaries back to clean boundaries for the caller.
+        real_pos = pos + TEXT_CTRL_OFFSET
+        real_start, real_end = self.contentTextCtrl.GetContainingLine(real_pos)
+        return real_start - TEXT_CTRL_OFFSET, real_end - TEXT_CTRL_OFFSET
 
     def set_text_direction(self, rtl=False):
         style = self.contentTextCtrl.GetDefaultStyle()
@@ -831,20 +845,29 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
         browseable_message(markup, title=title, is_html=True)
 
     def get_line_number(self, pos=None):
-        pos = pos or self.contentTextCtrl.InsertionPoint
-        __, __, line_number = self.contentTextCtrl.PositionToXY(pos)
+        # WHY: Use our own gatekeeper if pos is not provided.
+        # Convert the clean position to a real one before querying the control.
+        pos = pos or self.get_insertion_point()
+        __, __, line_number = self.contentTextCtrl.PositionToXY(pos + TEXT_CTRL_OFFSET)
         return line_number
 
     def get_start_of_line(self, line_number):
-        return self.contentTextCtrl.XYToPosition(0, line_number)
+        # WHY: Get the real position from the control, then convert to clean.
+        real_pos = self.contentTextCtrl.XYToPosition(0, line_number)
+        return max(0, real_pos - TEXT_CTRL_OFFSET)
 
     def select_text(self, fpos, tpos):
+        # WHY: 必须将“干净”的起止点转换为实际位置
         self.contentTextCtrl.SetFocusFromKbd()
-        self.contentTextCtrl.SetSelection(fpos, tpos)
+        self.contentTextCtrl.SetSelection(
+            fpos + TEXT_CTRL_OFFSET, tpos + TEXT_CTRL_OFFSET
+        )
 
     def set_insertion_point(self, to, set_focus_to_text_ctrl=True):
-        self.contentTextCtrl.ShowPosition(to)
-        self.contentTextCtrl.SetInsertionPoint(to)
+        # WHY: 必须将“干净”位置 'to' 转换为实际位置
+        actual_position = to + TEXT_CTRL_OFFSET
+        self.contentTextCtrl.ShowPosition(actual_position)
+        self.contentTextCtrl.SetInsertionPoint(actual_position)
         if set_focus_to_text_ctrl:
             self.contentTextCtrl.SetFocusFromKbd()
 
@@ -858,15 +881,28 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
                 args = (args(default_style),)
             attr_func(style, *args)
             for start, stop in style_info[style_type]:
-                self.contentTextCtrl.SetStyle(start, stop, style)
+                # WHY: 必须在应用样式时转换位置
+                self.contentTextCtrl.SetStyle(
+                    start + TEXT_CTRL_OFFSET, stop + TEXT_CTRL_OFFSET, style
+                )
 
     def get_insertion_point(self):
-        return self.contentTextCtrl.GetInsertionPoint()
+        return self.contentTextCtrl.GetInsertionPoint() - TEXT_CTRL_OFFSET
+
+    def get_last_position(self):
+        # WHY: The structure is `\n[content]\n`. The real length is `len(content) + 2`.
+        # The clean length is `len(content)`. So we must subtract 2.
+        # We don't use the offset constant here because we are accounting for
+        # the character at the beginning AND the one at the end.
+        return self.contentTextCtrl.GetLastPosition() - 2
 
     def get_text_by_range(self, start, end):
         """Get text by indexes. If end is less than 0 return the text from `start` to the end of the text."""
-        end = end if end >= 0 else self.contentTextCtrl.GetLastPosition()
-        return self.contentTextCtrl.GetRange(start, end)
+        actual_start = start + TEXT_CTRL_OFFSET
+        actual_end = end if end < 0 else end + TEXT_CTRL_OFFSET
+        if end >= self.get_last_position():
+            actual_end = self.contentTextCtrl.GetLastPosition() - TEXT_CTRL_OFFSET
+        return self.contentTextCtrl.GetRange(actual_start, actual_end)
 
     def get_text_from_user(
         self, title, label, style=wx.OK | wx.CANCEL | wx.CENTER, value=""
@@ -884,7 +920,10 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
             start, end = self.get_containing_line(start_pos)
         else:
             start, end = start_pos, end_pos
-        line_text = self.contentTextCtrl.GetRange(start, end)
+        line_text = self.get_text_by_range(start, end)
         self.set_insertion_point(start)
         sounds.navigation.play()
         speech.announce(line_text)
+
+    def is_empty(self):
+        return self.get_last_position() <= 0

--- a/bookworm/gui/book_viewer/menubar.py
+++ b/bookworm/gui/book_viewer/menubar.py
@@ -102,7 +102,7 @@ class FileMenu(BaseMenu):
             # translators, the label of an item in the application menubar
             _("i&mport"),
             # Translators: the help text of an item in the application menubar
-            _("Import a book from an external resource")
+            _("Import a book from an external resource"),
         )
         self.import_menu.Append(ImportMenuIds.qread, _("&Import QRD file"))
         self.AppendSeparator()
@@ -246,20 +246,20 @@ class FileMenu(BaseMenu):
         with wx.FileDialog(
             self.view,
             # translators: the title of a file dialog to import qrd files
-            message = _("Import QRD file"),
+            message=_("Import QRD file"),
             style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST,
-            wildcard=("*.qrd")
+            wildcard=("*.qrd"),
         ) as dlg:
             if dlg.ShowModal() != wx.ID_OK:
                 return
-            
+
             qrd_path = dlg.GetPath()
             book_info = qread.get_book_info(qrd_path)
         if not book_info:
             return self.view.notify_user(
                 _("Failed to import QRD file"),
                 _("The QRD file could not be imported"),
-                icon=wx.ICON_ERROR
+                icon=wx.ICON_ERROR,
             )
         uri = DocumentUri.from_filename(book_info.original_path)
         uri.openner_args = {"position": book_info.current_position}
@@ -657,7 +657,7 @@ class SearchMenu(BaseMenu):
     def onGoToLine(self, event):
         textCtrl = self.view.contentTextCtrl
         if (
-            idx_last_line := self.view.get_line_number(textCtrl.GetLastPosition())
+            idx_last_line := self.view.get_line_number(self.view.get_last_position())
         ) == 0:
             return wx.Bell()
         last_line = idx_last_line + 1

--- a/bookworm/ocr/ocr_menu.py
+++ b/bookworm/ocr/ocr_menu.py
@@ -268,7 +268,7 @@ class OCRMenu(wx.Menu):
             speech.announce(_("Automatic OCR is enabled"))
         else:
             speech.announce(_("Automatic OCR is disabled"))
-        if not self.view.contentTextCtrl.GetValue():
+        if self.view.is_empty():
             self.onScanCurrentPage(event)
 
     def onScanToTextFile(self, event):

--- a/bookworm/reader.py
+++ b/bookworm/reader.py
@@ -418,7 +418,6 @@ class EBookReader:
             self.view.go_to_webpage(target_info.url)
         else:
             start, end = target_info.position
-            start += 1
             self.perform_wormhole_navigation(
                 page=target_info.page, start=start, end=None, last_position=link_range
             )

--- a/bookworm/webservices/wikiworm.py
+++ b/bookworm/webservices/wikiworm.py
@@ -63,25 +63,34 @@ class WikipediaService(BookwormService):
 
     def get_contextmenu_items(self):
         rv = ()
-        if selected_text := self.view.contentTextCtrl.GetStringSelection().strip():
-            rv = [
-                (
-                    2,
-                    _("Define using Wikipedia"),
-                    _("Define the selected text using Wikipedia"),
-                    self.wiki_quick_search_id,
-                )
-            ]
+        # First, get the clean selection range from our gatekeeper method
+        selection_range = self.view.get_selection_range()
+        # Check if there is an actual selection
+        if selection_range.start != selection_range.stop:
+            # Now, safely get the text based on the clean range
+            selected_text = self.view.get_text_by_range(selection_range.start, selection_range.stop).strip()
+            # Only proceed if the stripped text is not empty
+            if selected_text:
+                rv = [
+                    (
+                        2,
+                        _("Define using Wikipedia"),
+                        _("Define the selected text using Wikipedia"),
+                        self.wiki_quick_search_id,
+                    )
+                ]
         return rv
 
     def get_keyboard_shortcuts(self):
         return {self.wiki_quick_search_id: "Ctrl+Shift+W"}
 
     def onQuickWikiSearch(self, event):
-        if selected_text := self.view.contentTextCtrl.GetStringSelection().strip():
-            term = selected_text
-        else:
-            term = ""
+        term = ""
+        selection_range = self.view.get_selection_range()
+        if selection_range.start != selection_range.stop:
+            selected_text = self.view.get_text_by_range(selection_range.start, selection_range.stop).strip()
+            if selected_text:
+                term = selected_text
         language = (
             self.view.reader.document.language
             if self.view.reader.ready


### PR DESCRIPTION
### **Description**

This change fixes two related issues (#321 and #317) by introducing a centralized API to manage the index offset caused by initial newlines in the `TextCtrl`. This robustly resolves truncated link text and incorrect footnote navigation without re-introducing a previous issue (#123).

## Link to issue number:
- Fixes #321 (Incomplete Link Text Display in Bookworm)
- Fixes #317 (Ctrl+Enter Jumps to the Wrong Footnote)
- Makes PR #318 obsolete by addressing the root cause.

### Summary of the issue:
Bookworm has two issues related to text index positioning:
1.  When navigating to links in a document using the "k" key, link text displays incompletely, typically missing the last character. For example, "Google" displays as "Googl", and "Hello World" displays as "Hello Worl".
2.  When using `Ctrl+Enter` to navigate from a footnote number to its corresponding explanation, it incorrectly jumps to the previous footnote's explanation. For example, pressing `Ctrl+Enter` on footnote "" navigates to the explanation for footnote "".

### Description of how this pull request fixes the issue:
The root cause is an index mismatch. The `book_viewer/__init__.py` file's `set_content` method deliberately adds initial newlines to the `TextCtrl` widget (`\n[content]\n`) to work around issue #123. This creates a permanent +1 offset between the "clean" indices from the document parser and the "real" indices used by the `TextCtrl` widget. This discrepancy caused text ranges to be retrieved incorrectly.

The initial approach was to remove these newlines. However, based on review discussions, this would reintroduce issue #123.

This PR now implements a more robust, encapsulated solution. Instead of removing the newlines, it introduces a "gatekeeper" API within the `BookViewerWindow` class. All interactions with the `contentTextCtrl` that involve position or range (e.g., getting/setting the insertion point, getting text ranges, selections) are now routed through these new methods. These methods are responsible for transparently converting between "clean" and "real" indices.

**Key changes:**

1.  A `TEXT_CTRL_OFFSET` constant is defined in `book_viewer/__init__.py`.
2.  Gatekeeper methods like `get_insertion_point()`, `set_insertion_point()`, `get_text_by_range()`, `get_selection_range()`, etc., have been implemented in `BookViewerWindow` to handle the offset.
3.  All other modules, including **Annotation**, **Text-to-Speech**, **Navigation**, and **Web Services**, have been refactored to use this new, safe API instead of accessing `contentTextCtrl` directly.

This ensures that the rest of the application operates on consistent, "clean" indices, while the `BookViewerWindow` correctly manages the offset internally. This solves the navigation bugs without creating regressions.

### Testing performed:
1.  Opened HTML documents containing links, navigated to links using the "k" key, and verified **complete** link text display.
2.  Opened documents with footnotes, used `Ctrl+Enter` on footnote numbers, and confirmed **correct** navigation to the corresponding footnote explanations.
3.  Verified that annotations (bookmarks, highlights, comments) are created and navigated to at the correct positions.
4.  Verified that Text-to-Speech functions (Play, Fast-Forward, Rewind) start from and highlight the correct text.
5.  Confirmed that issue #123 (blank first line reported by screen readers) is not reintroduced.
6.  Tested various link text types (English, Chinese, with spaces, etc.) to ensure proper display.

### Known issues with pull request:
No known issues.