### PR TITLE
Implement Global and Local Media Key Controls for TTS

### DIFF
--- a/bookworm/gui/book_viewer/__init__.py
+++ b/bookworm/gui/book_viewer/__init__.py
@@ -322,7 +322,7 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
                 tts_service.rewind()
         else:
             event.Skip()
-    
+
     def createControls(self):
         # Now create the Panel to put the other controls on.
         rect = wx.GetClientDisplayRect()

--- a/bookworm/gui/book_viewer/__init__.py
+++ b/bookworm/gui/book_viewer/__init__.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import wx
 
+from bookworm.text_to_speech import TextToSpeechService
 from bookworm import app, config, speech
 from bookworm import typehints as t
 from bookworm.concurrency import CancellationToken, threaded_worker
@@ -241,6 +242,11 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
 
     def __init__(self, parent, title):
         wx.Frame.__init__(self, parent, -1, title, name="main_window")
+        self.wx_key_map = {
+            wx.WXK_MEDIA_PLAY_PAUSE: "play_pause",
+            wx.WXK_MEDIA_NEXT_TRACK: "next",
+            wx.WXK_MEDIA_PREV_TRACK: "prev",
+        }
         self.setFrameIcon()
 
         self.reader = EBookReader(self)
@@ -282,6 +288,8 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
             id=self.readingProgressSlider.GetId(),
         )
 
+        self.Bind(wx.EVT_CHAR_HOOK, self.on_key_press_local)
+
         self.toc_tree_manager = TocTreeManager(self.tocTreeCtrl)
         # Set status bar text
         # Translators: the text of the status bar when no book is currently open.
@@ -293,6 +301,28 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
         StateProvider.__init__(self)
         MenubarProvider.__init__(self)
 
+    def on_key_press_local(self, event):
+        if config.conf["reading"]["enable_global_media_keys"]:
+            event.Skip()
+            return
+
+        keycode = event.GetKeyCode()
+        key_name = self.wx_key_map.get(keycode)
+
+        if key_name:
+            tts_service = wx.GetApp().service_handler.get_service("text_to_speech")
+            if not tts_service:
+                return
+
+            if key_name == "play_pause":
+                tts_service.pause_or_resume()
+            elif key_name == "next":
+                tts_service.fastforward()
+            elif key_name == "prev":
+                tts_service.rewind()
+        else:
+            event.Skip()
+    
     def createControls(self):
         # Now create the Panel to put the other controls on.
         rect = wx.GetClientDisplayRect()

--- a/bookworm/resources/userguide/en/bookworm.md
+++ b/bookworm/resources/userguide/en/bookworm.md
@@ -133,8 +133,8 @@ The media keys are mapped to core TTS actions:
 
 The feature supports two distinct modes for flexibility:
 
-1.  **Global Mode  (Default)**: Users can enable this via a new "**Enable global media keys**" checkbox under `Settings > Reading`. This allows them to control playback from anywhere in the OS, even when Bookworm is running in the background.
-2.  **Local Mode (Opt-in)**: Media keys are handled only when the Bookworm application window has focus.
+1.  **Local Mode (Default)**: Media keys are handled only when the Bookworm application window has focus.
+2.  **Global Mode (Opt-in)**: Users can enable this via a new "**Enable global media keys**" checkbox under `Settings > Reading`. This allows them to control playback from anywhere in the OS, even when Bookworm is running in the background.
 
 This setting can be toggled dynamically without restarting the application.
 

--- a/bookworm/resources/userguide/en/bookworm.md
+++ b/bookworm/resources/userguide/en/bookworm.md
@@ -138,7 +138,7 @@ The feature supports two distinct modes for flexibility:
 
 This setting can be toggled dynamically without restarting the application.
 
-**This feature  may be conflicts with other running media applications (e.g., Spotify, Browser) that also listen for system-wide media keys. This is a platform-level behavior.**
+**Note: Media key functionality can be unreliable when multiple media applications are running simultaneously, regardless of whether global mode is on or off.**
 
 ### Configuring The Reading Style
 

--- a/bookworm/resources/userguide/en/bookworm.md
+++ b/bookworm/resources/userguide/en/bookworm.md
@@ -123,6 +123,22 @@ You can configure the speech in two ways:
 
 During reading aloud, you can skip backward or foreword by paragraph by pressing Alt plus the left and right arrow  keys.
 
+### Media keys behavior
+
+The media keys are mapped to core TTS actions:
+
+* **▶️ Play/Pause Key**: Toggles TTS play, pause, and resume.
+* **⏭️ Next Track Key**: Functions as "Fast Forward," jumping to the **next paragraph** (equivalent to `Alt+Right Arrow`).
+* **⏮️ Previous Track Key**: Functions as "Rewind," jumping to the **previous paragraph** (equivalent to `Alt+Left Arrow`).
+
+The feature supports two distinct modes for flexibility:
+
+1.  **Global Mode  (Default)**: Users can enable this via a new "**Enable global media keys**" checkbox under `Settings > Reading`. This allows them to control playback from anywhere in the OS, even when Bookworm is running in the background.
+2.  **Local Mode (Opt-in)**: Media keys are handled only when the Bookworm application window has focus.
+
+This setting can be toggled dynamically without restarting the application.
+
+**This feature  may be conflicts with other running media applications (e.g., Spotify, Browser) that also listen for system-wide media keys. This is a platform-level behavior.**
 
 ### Configuring The Reading Style
 

--- a/bookworm/text_to_speech/__init__.py
+++ b/bookworm/text_to_speech/__init__.py
@@ -63,6 +63,7 @@ UT_PAGE_END = "ge"
 UT_SECTION_BEGIN = "sb"
 UT_SECTION_END = "se"
 
+
 class TextToSpeechService(BookwormService):
     name = "text_to_speech"
     config_spec = tts_config_spec
@@ -131,7 +132,9 @@ class TextToSpeechService(BookwormService):
     def start_global_listener(self):
         if self.pynput_listener is None:
             try:
-                self.pynput_listener = keyboard.Listener(on_press=self.on_key_press_global)
+                self.pynput_listener = keyboard.Listener(
+                    on_press=self.on_key_press_global
+                )
                 self.pynput_listener.start()
             except Exception:
                 self.pynput_listener = None
@@ -149,7 +152,7 @@ class TextToSpeechService(BookwormService):
         action = self.pynput_key_map.get(key)
         if action:
             wx.CallAfter(action)
-    
+
     def process_menubar(self, menubar):
         self.menu = SpeechMenu(self)
         # Translators: the label of an item in the application menubar

--- a/bookworm/text_to_speech/tts_config.py
+++ b/bookworm/text_to_speech/tts_config.py
@@ -105,6 +105,7 @@ tts_config_spec = {
         select_spoken_text="boolean(default=False)",
         notify_on_section_end="boolean(default=True)",
         ask_to_switch_voice_to_current_book_language="boolean(default=True)",
+        enable_global_media_keys="boolean(default=True)",
     ),
     "speech": dict(
         engine="string(default='sapi')",

--- a/bookworm/text_to_speech/tts_config.py
+++ b/bookworm/text_to_speech/tts_config.py
@@ -105,7 +105,7 @@ tts_config_spec = {
         select_spoken_text="boolean(default=False)",
         notify_on_section_end="boolean(default=True)",
         ask_to_switch_voice_to_current_book_language="boolean(default=True)",
-        enable_global_media_keys="boolean(default=True)",
+        enable_global_media_keys="boolean(default=False)",
     ),
     "speech": dict(
         engine="string(default='sapi')",

--- a/bookworm/text_to_speech/tts_gui.py
+++ b/bookworm/text_to_speech/tts_gui.py
@@ -122,6 +122,21 @@ class ReadingPanel(SettingsPanel):
             _("Enable global media keys (Play/Pause, Next, Previous)"),
             name="reading.enable_global_media_keys",
         )
+        # Add a static text warning for the global media key feature.
+        warning_text = wx.StaticText(
+            miscBox,
+            -1,
+            # Translators: A warning message in the settings dialog.
+            _(
+                "Note: Media key functionality can be unreliable when multiple media applications are running simultaneously, regardless of whether global mode is on or off."
+            ),
+        )
+        # Make the font slightly smaller to serve as help text.
+        font = warning_text.GetFont()
+        font.MakeSmaller()
+        warning_text.SetFont(font)
+        # Indent the warning text to visually group it with the checkbox above.
+        warning_text.SetSizerProps(border=(("left",), 15))
 
     def reconcile(self, strategy=ReconciliationStrategies.load):
         if strategy is ReconciliationStrategies.load:

--- a/bookworm/text_to_speech/tts_gui.py
+++ b/bookworm/text_to_speech/tts_gui.py
@@ -115,6 +115,13 @@ class ReadingPanel(SettingsPanel):
             _("Select spoken text"),
             name="reading.select_spoken_text",
         )
+        wx.CheckBox(
+            miscBox,
+            -1,
+            # Translators: the label of a checkbox
+            _("Enable global media keys (Play/Pause, Next, Previous)"),
+            name="reading.enable_global_media_keys",
+        )
 
     def reconcile(self, strategy=ReconciliationStrategies.load):
         if strategy is ReconciliationStrategies.load:
@@ -602,44 +609,16 @@ class SpeechMenu(wx.Menu):
         )
 
     def onPlay(self, event):
-        if not self.service.is_engine_ready:
-            self.service.initialize_engine()
-        elif self.service.engine.state is SynthState.busy:
-            return wx.Bell()
-        setattr(self.service, "_requested_play", True)
-        if self.service.engine.state is SynthState.paused:
-            return self.onPauseToggle(event)
-        self.service.speak_page()
+        self.service.play_or_resume()
 
     def onPlayToggle(self, event):
-        if (not self.service.is_engine_ready) or (
-            self.service.engine.state is SynthState.ready
-        ):
-            self.onPlay(event)
-        else:
-            self.onPauseToggle(event)
+        self.service.pause_or_resume()
 
     def onPauseToggle(self, event):
-        if self.service.is_engine_ready:
-            if self.service.engine.state is SynthState.busy:
-                self.service.engine.pause()
-                # Translators: a message that is announced when the speech is paused
-                return speech.announce(_("Paused"))
-            elif self.service.engine.state is SynthState.paused:
-                self.service.engine.resume()
-                # Translators: a message that is announced when the speech is resumed
-                return speech.announce(_("Resumed"))
-        wx.Bell()
+        self.service.pause_or_resume()
 
     def onStop(self, event):
-        if (
-            self.service.is_engine_ready
-            and self.service.engine.state is not SynthState.ready
-        ):
-            self.service.stop_speech(user_requested=True)
-            # Translators: a message that is announced when the speech is stopped
-            return speech.announce(_("Stopped"))
-        wx.Bell()
+        self.service.stop_playback()
 
     def onVoiceProfiles(self, event):
         # Translators: the title of the voice profiles dialog

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -62,3 +62,4 @@ waitress==3.0.1
 winpaths==0.2
 wxPython==4.2.1
 yarl==1.9.4
+pynput==1.8.1


### PR DESCRIPTION
## Link to issue number:
closed #256 
### Summary of the issue:
This pull request introduces full media key support for the TTS feature, which was previously unavailable. Users can now control playback using their keyboard's dedicated media keys.

### Description of how this pull request fixes the issue:
The media keys are mapped to core TTS actions:

*   **▶️ Play/Pause Key**: Toggles TTS play, pause, and resume.
*   **⏭️ Next Track Key**: Functions as "Fast Forward," jumping to the **next paragraph** (equivalent to `Alt+Right Arrow`).
*   **⏮️ Previous Track Key**: Functions as "Rewind," jumping to the **previous paragraph** (equivalent to `Alt+Left Arrow`).

The feature supports two distinct modes for flexibility:

1.  **Local Mode (Default)**: Media keys are handled only when the Bookworm application window has focus.
2.  **Global Mode (Opt-in)**: Users can enable this via a new "**Enable global media keys**" checkbox under `Settings > Reading`. This allows them to control playback from anywhere in the OS, even when Bookworm is running in the background.

This setting can be toggled dynamically without restarting the application.


### Testing performed:

*   Tested in both global and local modes; functionality is as expected.
*   Verified that media keys control playback correctly when the application is in the foreground and background (for global mode).
*   Confirmed that global hotkeys are properly unregistered upon application exit.


### Known issues with pull request:

This feature  may be conflicts with other running media applications (e.g., Spotify, Browser) that also listen for system-wide media keys. This is a platform-level behavior.
