### PR TITLE
Fix annotation navigation and improve point-based comment behavior

### DIFF
--- a/bookworm/annotation/__init__.py
+++ b/bookworm/annotation/__init__.py
@@ -176,9 +176,8 @@ class AnnotationService(BookwormService):
             self.reader.go_to_page(
                 comment.page_number, comment.position if is_whole_line else end_pos
             )
-            if is_whole_line:
-                self.view.select_text(*self.view.get_containing_line(comment.position))
-            else:
+            # We do not select whole line comments, See issue#332
+            if not is_whole_line:
                 self.view.select_text(start_pos, end_pos)
             reading_position_change.send(
                 self.view,


### PR DESCRIPTION
## Link to issue number:
Closed #332, Fixes #335
### Summary of the issue:
This pull request addresses two related issues with annotation navigation:
1.  A critical bug where using F8/Shift+F8 to navigate between notes would cause navigation to skip notes or get stuck in a loop.
2.  The inconsistent and often confusing highlighting behavior when navigating to point-based (whole-line) notes, as discussed in issue #332.
### Description of how this pull request fixes the issue:

1.  **Corrected Database Query Logic:** The `get_first_after` and `get_first_before` methods in `NoteTaker` have been refactored. They now use `sa.func.coalesce` to create a unified "effective position" for both selection-based and point-based notes. This simplifies the query and ensures correct sorting, fixing the skipping and looping bugs.

2.  **Improved Navigation Behavior for Point-Based Notes:** In response to the discussion in #332, the navigation behavior for point-based notes has been changed. Instead of selecting the entire line, the UI now simply moves the cursor to the exact position where the note was created. This provides a more intuitive and less disruptive user experience, especially when text wrapping is disabled. Selection is now reserved for notes that were explicitly created from a text selection.

These changes result in a more robust, predictable, and user-friendly annotation navigation system.
### Testing performed:
Manual testing using the steps in #335
### Known issues with pull request:

Not yet known
