### PR TITLE
Add the 'View Change Log' menu item

### DIFF
--- a/bookworm/app.py
+++ b/bookworm/app.py
@@ -13,6 +13,7 @@ version = "2025.1"
 version_ex = "2025.1.0.0"
 url = "https://github.com/blindpandas/bookworm"
 website = "https://github.com/blindpandas/bookworm"
+changelog_url = f"{url}/releases/tag/{version}"
 update_url = (
     "https://raw.githubusercontent.com/blindpandas/bookworm/main/update_info.json"
 )

--- a/bookworm/gui/book_viewer/menu_constants.py
+++ b/bookworm/gui/book_viewer/menu_constants.py
@@ -38,6 +38,7 @@ class ViewerMenuIds(enum.IntEnum):
     preferences = wx.ID_PREFERENCES
     # Help Menu
     documentation = next(ID_GEN)
+    changelog = next(ID_GEN)
     website = next(ID_GEN)
     license = next(ID_GEN)
     contributors = next(ID_GEN)

--- a/bookworm/gui/book_viewer/menubar.py
+++ b/bookworm/gui/book_viewer/menubar.py
@@ -816,6 +816,13 @@ class HelpMenu(BaseMenu):
             _("View Bookworm manuals"),
         )
         self.Append(
+            ViewerMenuIds.changelog,
+            # Translators: the label of an item in the application menubar
+            _("What's &New..."),
+            # Translators: the help text of an item in the application menubar
+            _("View the application's changelog"),
+        )
+        self.Append(
             ViewerMenuIds.website,
             # Translators: the label of an item in the application menubar
             _("Bookworm &website..."),
@@ -859,6 +866,11 @@ class HelpMenu(BaseMenu):
         # Bind menu events
         self.view.Bind(
             wx.EVT_MENU, self.onOpenDocumentation, id=ViewerMenuIds.documentation
+        )
+        self.view.Bind(
+            wx.EVT_MENU,
+            lambda e: webbrowser.open(app.changelog_url),
+            id=ViewerMenuIds.changelog,
         )
         self.view.Bind(
             wx.EVT_MENU,


### PR DESCRIPTION
## Link to issue number:
None
### Summary of the issue:
Added an menu item to view change logs.

### Description of how this pull request fixes the issue:
Just use the default browser to open the corresponding version of the release page on GitHub.
Our workflow provides a change log when new version is released.

### Testing performed:
manual testing
### Known issues with pull request:
None