### PR TITLE
fix: Add User-Agent to `http_resource` requests

### DIFF
--- a/bookworm/app.py
+++ b/bookworm/app.py
@@ -50,7 +50,7 @@ VERSION_PATTERN = r"""
 """
 
 
-def get_version_info(version_string=version):
+def get_version_info(version_string: str = version) -> dict:
     pattern = re.compile(
         r"^\s*" + VERSION_PATTERN + r"\s*$", re.VERBOSE | re.IGNORECASE
     )
@@ -58,3 +58,8 @@ def get_version_info(version_string=version):
     if not mat:
         raise ValueError
     return mat.groupdict()
+
+def user_agent() -> str:
+    # Wikipedia will reject requests that does not respect their User-Agent policy
+    # see: https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_User-Agent_Policy
+    return f"{name}/{version} ({url}; {author_email})"

--- a/bookworm/http_tools/http_resource.py
+++ b/bookworm/http_tools/http_resource.py
@@ -11,6 +11,7 @@ from tempfile import SpooledTemporaryFile
 import requests
 
 from bookworm import typehints as t
+from bookworm import app
 from bookworm.logger import logger
 
 log = logger.getChild(__name__)
@@ -144,11 +145,16 @@ class ResourceDownloadRequest:
 @dataclass
 class HttpResource:
     url: str
+    headers: dict[str, str] | None = None
 
     def download(self) -> ResourceDownloadRequest:
         try:
+            headers = self.headers or {}
+            headers.update({
+                'User-Agent': app.user_agent(),
+            })
             log.info(f"Requesting resource: {self.url}")
-            requested_resource = requests.get(self.url, stream=True)
+            requested_resource = requests.get(self.url, headers=headers, stream=True)
             requested_resource.raise_for_status()
         except requests.RequestException as e:
             log.exception(f"Faild to get resource from {self.url}", exc_info=True)


### PR DESCRIPTION
## Link to issue number:
closes #346 
### Summary of the issue:
Users were unable to open certain wikipedia pages from bookworm.
### Description of how this pull request fixes the issue:
Wikimedia sites require a HTTP User-Agent header for all requests.
We did not set User-Agents in our request, and this PR fixes the issue by introducing one.
For context, see: https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_User-Agent_Policy
### Testing performed:
Manual
### Known issues with pull request:
None
