### PR TITLE
chore: update urllib3 in uv.lock to 2.6.3

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -359,7 +359,7 @@ requires-dist = [
     { name = "unidecode", specifier = "==1.4.0" },
     { name = "unrar", specifier = "==0.4" },
     { name = "url-normalize", specifier = "==1.4.3" },
-    { name = "urllib3", specifier = "==2.6.0" },
+    { name = "urllib3", specifier = "==2.6.3" },
     { name = "waitress", specifier = "==3.0.1" },
     { name = "wcwidth", specifier = "==0.2.13" },
     { name = "winpaths", specifier = "==0.2" },
@@ -2042,11 +2042,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.0"
+version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1c/43/554c2569b62f49350597348fc3ac70f786e3c32e7f19d266e19817812dd3/urllib3-2.6.0.tar.gz", hash = "sha256:cb9bcef5a4b345d5da5d145dc3e30834f58e8018828cbc724d30b4cb7d4d49f1", size = 432585, upload-time = "2025-12-05T15:08:47.885Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/1a/9ffe814d317c5224166b23e7c47f606d6e473712a2fad0f704ea9b99f246/urllib3-2.6.0-py3-none-any.whl", hash = "sha256:c90f7a39f716c572c4e3e58509581ebd83f9b59cced005b7db7ad2d22b0db99f", size = 131083, upload-time = "2025-12-05T15:08:45.983Z" },
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Link to issue number:
None

### Summary of the issue:
The `pyproject.toml` specified `urllib3==2.6.3`, but `uv.lock` was pinning an older version (2.6.0).

### Description of how this pull request fixes the issue:
Updated `uv.lock` by running `uv sync` to ensure dependencies match the configuration in `pyproject.toml`.

### Testing performed:
Ran `uv sync` locally to verify resolution is successful.

### Known issues with pull request:
None