### PR TITLE
feat: add CI workflow for pytest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
   build:
     name: Build
     runs-on: windows-latest
+    needs: test
     strategy:
       matrix:
         CI_ARCH: ["x86", "x64"]  # Define architectures to build for

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,39 @@ permissions:
   contents: write
 
 jobs:
+  test:
+    name: Test
+    runs-on: windows-latest
+    steps:
+      - name: Check out sources
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-suffix: ${{ runner.os }}-test
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          uv sync --locked --no-install-project
+          uv run invoke install-local-packages
+
+      - name: Generate resources
+        run: |
+          uv run invoke icons
+
+      - name: Run tests
+        run: |
+          uv run pytest
+
   build:
     name: Build
     runs-on: windows-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,7 @@ dev = [
     "pyinstaller==6.10.0",
     "pyinstaller-hooks-contrib==2024.8",
     "pytest==8.2.1",
+    "pytest-github-actions-annotate-failures",
     "pytest-xdist==3.6.1",
     "wheel==0.43.0",
     "ruff>=0.4.0",

--- a/uv.lock
+++ b/uv.lock
@@ -268,6 +268,7 @@ dev = [
     { name = "pyinstaller" },
     { name = "pyinstaller-hooks-contrib" },
     { name = "pytest" },
+    { name = "pytest-github-actions-annotate-failures" },
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "setuptools" },
@@ -377,6 +378,7 @@ dev = [
     { name = "pyinstaller", specifier = "==6.10.0" },
     { name = "pyinstaller-hooks-contrib", specifier = "==2024.8" },
     { name = "pytest", specifier = "==8.2.1" },
+    { name = "pytest-github-actions-annotate-failures" },
     { name = "pytest-xdist", specifier = "==3.6.1" },
     { name = "ruff", specifier = ">=0.4.0" },
     { name = "setuptools" },
@@ -1570,6 +1572,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cf/4e/0ceea141f0e5d09de4053c5338c62615ae2bd9bd3f013813f5ec62e3cf97/pytest-8.2.1.tar.gz", hash = "sha256:5046e5b46d8e4cac199c373041f26be56fdb81eb4e67dc11d4e10811fc3408fd", size = 1424649, upload-time = "2024-05-19T19:08:03.507Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/c1/27a1274b73712232328cb5115030057b7dec377f36a518c83f2e01d4f305/pytest-8.2.1-py3-none-any.whl", hash = "sha256:faccc5d332b8c3719f40283d0d44aa5cf101cec36f88cde9ed8f2bc0538612b1", size = 339593, upload-time = "2024-05-19T19:07:58.066Z" },
+]
+
+[[package]]
+name = "pytest-github-actions-annotate-failures"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/d4/c54ee6a871eee4a7468e3a8c0dead28e634c0bc2110c694309dcb7563a66/pytest_github_actions_annotate_failures-0.3.0.tar.gz", hash = "sha256:d4c3177c98046c3900a7f8ddebb22ea54b9f6822201b5d3ab8fcdea51e010db7", size = 11248, upload-time = "2025-01-17T22:39:32.722Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/73/7b0b15cb8605ee967b34aa1d949737ab664f94e6b0f1534e8339d9e64ab2/pytest_github_actions_annotate_failures-0.3.0-py3-none-any.whl", hash = "sha256:41ea558ba10c332c0bfc053daeee0c85187507b2034e990f21e4f7e5fef044cf", size = 6030, upload-time = "2025-01-17T22:39:31.701Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Link to issue number:
N/A

### Summary of the issue:
The project currently lacks an automated testing workflow in CI to run unit tests using `pytest`.

### Description of how this pull request fixes the issue:
This PR adds a new `Test` job to the GitHub Actions workflow (`.github/workflows/build.yml`).
It performs the following:
- Sets up Python 3.11 and installs `uv`.
- Installs all dependencies, including local architecture-specific packages (e.g., `pytqsm`).
- Generates necessary resources (app icons) required for GUI tests.
- Runs `pytest` to verify code quality.
- Adds `pytest-github-actions-annotate-failures` to annotates test failures directly in the PR.
- Configures the `Build` job to depend on the `Test` job, ensuring only passing code is built.

### Testing performed:
- Validated locally on Windows environment: all 35 tests passed.
- Verified in CI (on the fork): The workflow correctly installs dependencies, generates resources, and executes tests.

### Known issues with pull request:
None.