### PR TITLE
fix: corrected typo in `get_epub_html_item_by_href`

### DIFF
--- a/bookworm/document/formats/epub.py
+++ b/bookworm/document/formats/epub.py
@@ -203,7 +203,7 @@ class EpubDocument(SinglePageDocument):
         return items
 
     def get_epub_html_item_by_href(self, href):
-        if epub_item := self.epub.get_item_with_href("href"):
+        if epub_item := self.epub.get_item_with_href(href):
             return epub_item
         item_name = PurePosixPath(href).name
         return more_itertools.first(


### PR DESCRIPTION
## Link to issue number:
N/A

### Summary of the issue:
There was a typo in `get_epub_html_item_by_href` where the string literal `"href"` was passed to `get_item_with_href` instead of the variable `href`.

### Description of how this pull request fixes the issue:
Corrected `self.epub.get_item_with_href("href")` to `self.epub.get_item_with_href(href)`.

### Testing performed:
Manual verification.

### Known issues with pull request:
None