### PR TITLE
feat: add automated winget publishing workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,3 +256,15 @@ jobs:
           body: 'This Pull Request updates update_info.json after the release is published.'
           labels: 'automation'
           base: main
+
+  publish_winget:
+    name: Publish to Winget
+    runs-on: windows-latest
+    if: github.event_name == 'release' && github.event.action == 'published' && !github.event.release.prerelease
+    steps:
+      - name: Publish to Winget
+        uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: BlindPandasTeam.Bookworm
+          installers-regex: 'Bookworm-.*-setup.exe$'
+          token: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
## Link to issue number:
Fixes #294

### Summary of the issue:
The project currently lacks an automated process to publish new releases to the Windows Package Manager (Winget).

### Description of how this pull request fixes the issue:
This PR adds a new job `publish_winget` to the GitHub Actions workflow (`build.yml`). 
It utilizes the `vedantmgoyal2009/winget-releaser` action to automatically submit a Pull Request to the `microsoft/winget-pkgs` repository whenever a new stable release is published.
- **Package ID**: `BlindPandasTeam.Bookworm`
- **Trigger**: Published releases (excluding pre-releases).

### Testing performed:
The configuration has been validated against the documentation and common usage patterns. Full end-to-end testing requires a live release, but the action is designed to fail safely (by creating an invalid PR or logging an error) if configuration issues exist.

### Known issues with pull request:
None.
