### PR TITLE
chore: configure dependabot for automated updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,11 +11,11 @@ updates:
           - "*"
 
   # Maintain Python dependencies (pip/pyproject.toml)
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      dependencies:
-        patterns:
-          - "*"
+  # - package-ecosystem: "pip"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #   groups:
+  #     dependencies:
+  #       patterns:
+  #         - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # Maintain GitHub Actions versions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  # Maintain Python dependencies (pip/pyproject.toml)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Link to issue number:
N/A (Enhancement)

### Summary of the issue:
The project currently relies on manual updates for GitHub Actions versions and Python dependencies, which can lead to using outdated or insecure components.

### Description of how this pull request fixes the issue:
This PR adds a `.github/dependabot.yml` configuration file to enable GitHub Dependabot.
- **Ecosystems**:
  - `github-actions`: Keeps CI/CD workflows up to date (e.g., `actions/checkout@v4`).
  - `pip`: (Temporarily disabled) Keeps Python dependencies in `pyproject.toml` up to date.
- **Schedule**: Weekly updates.
- **Grouping**: Updates are grouped by ecosystem to minimize the number of Pull Requests created.

### Testing performed:
The configuration file syntax follows the standard Dependabot version 2 specification. No code changes were made, so existing tests are unaffected.

### Known issues with pull request:
None.