### PR TITLE
fix: replace browseable_message's implementation with wx.html2.WebView

### DIFF
--- a/bookworm/gui/browseable_message.py
+++ b/bookworm/gui/browseable_message.py
@@ -1,58 +1,22 @@
-# -*- coding: utf-8 -*-
-# A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2008-2020 NV Access Limited, James Teh, Dinesh Kaushal, Davy Kager, André-Abush Clause,
-# Babbage B.V., Leonard de Ruijter, Michael Curran, Accessolutions, Julien Cochuyt
-# This file may be used under the terms of the GNU General Public License, version 2 or later.
-# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
-
-import os
-from ctypes import POINTER, addressof, byref, c_size_t, windll
-from html import escape
-
 import wx
-from comtypes import IUnknown, automation
+from wx.html2 import WebView, EVT_WEBVIEW_LOADED
 
-from bookworm.paths import resources_path
+class HTMLDialog(wx.Dialog):
+    def __init__(self, parent: wx.Window, title: str, text: str):
+        super().__init__(parent, title=title, id=wx.ID_ANY)
+        self.webview: WebView = WebView.New(self)
+        self.webview.Bind(EVT_WEBVIEW_LOADED, self.OnLoaded)
+        self.webview.SetPage(text, "")
 
-# From urlmon.h
-URL_MK_UNIFORM = 1
+    def OnLoaded(self, e):
+        log.debug(len(self.webview.GetChildren()))
+        robot = wx.UIActionSimulator() 
+        self.webview.SetFocus() 
+        position = self.webview.GetPosition() 
+        position = self.webview.ClientToScreen(position) 
+        robot.MouseMove(position) 
+        robot.MouseClick() 
 
-# Dialog box properties
-DIALOG_OPTIONS = "resizable:yes;help:no"
-
-# dwDialogFlags for ShowHTMLDialogEx from mshtmhst.h
-HTMLDLG_NOUI = 0x0010
-HTMLDLG_MODAL = 0x0020
-HTMLDLG_MODELESS = 0x0040
-HTMLDLG_PRINT_TEMPLATE = 0x0080
-HTMLDLG_VERIFY = 0x0100
-
-
-def browseable_message(message, title=None, is_html=False):
-    """Present a message to the user that can be read in browse mode.
-    The message will be presented in an HTML document.
-    @param message: The message in either html or text.
-    @type message: str
-    @param title: The title for the message.
-    @type title: str
-    @param is_html: Whether the message is html
-    @type is_html: boolean
-    """
-    htmlFileName = os.fspath(resources_path("message.html"))
-    moniker = POINTER(IUnknown)()
-    windll.urlmon.CreateURLMonikerEx(0, htmlFileName, byref(moniker), URL_MK_UNIFORM)
-    if not title:
-        # Translators: The title for the dialog used to present general messages in browse mode.
-        title = _("Message")
-    if not is_html:
-        message = f"<pre>{escape(message)}</pre>"
-    dialogString = f"{title};{message}"
-    dialogArguements = automation.VARIANT(dialogString)
-    windll.mshtml.ShowHTMLDialogEx(
-        wx.GetApp().mainFrame.GetHandle(),
-        moniker,
-        HTMLDLG_MODELESS,
-        c_size_t(addressof(dialogArguements)),
-        DIALOG_OPTIONS,
-        None,
-    )
+def browseable_message(message: str, title: str | None = None, is_html: bool = False) -> None:
+    with HTMLDialog(wx.GetApp().mainFrame, title, message) as dlg:
+        dlg.ShowModal()


### PR DESCRIPTION
## Link to issue number:
fixes #363 
### Summary of the issue:
Documents which have HTML tables without any caption or header may not be represented properly to a screen reader. This seems to be caused by the backend implementation we currently use to display any HTML dialog
### Description of how this pull request fixes the issue:
This PR aims to replace the previous implementation with [wx.html2.WebView](https://docs.wxpython.org/wx.html2.WebView.html)
### Testing performed:
Manual
### Known issues with pull request:
None

cc @cary-rowen 