### PR TITLE
feat: GLM-OCR engine integration with smart batch processing

### DIFF
--- a/bookworm/document/base.py
+++ b/bookworm/document/base.py
@@ -339,6 +339,8 @@ class BasePage(metaclass=ABCMeta):
 
     @property
     def semantic_structure(self):
+        if hasattr(self, "_injected_semantic_structure"):
+            return self._injected_semantic_structure
         try:
             semantic_structure = self.get_semantic_structure()
         except NotImplementedError:

--- a/bookworm/ocr/__init__.py
+++ b/bookworm/ocr/__init__.py
@@ -32,6 +32,9 @@ OCR_CONFIG_SPEC = {
         baidu_secret_key='string(default="")',
         vivo_nvdacn_user='string(default="")',
         vivo_nvdacn_pass='string(default="")',
+        glm_ocr_api_key='string(default="")',
+        glm_ocr_mode='option("cloud", "ollama", "local", default="cloud")',
+        glm_ocr_ollama_host='string(default="http://localhost:11434")',
     )
 }
 

--- a/bookworm/ocr/ocr_dialogs.py
+++ b/bookworm/ocr/ocr_dialogs.py
@@ -127,6 +127,25 @@ class OcrPanel(SettingsPanel):
         wx.TextCtrl(
             vivoBox, -1, name="ocr.vivo_nvdacn_pass", style=wx.TE_PASSWORD
         ).SetSizerProps(expand=True)
+        # Translators: the label of a group of controls in the OCR page
+        # of the settings related to GLM-OCR engine
+        glmBox = self.make_static_box(_("GLM-OCR Engine (Zhipu)"))
+        # Translators: the label of a combobox for selecting GLM-OCR mode
+        wx.StaticText(glmBox, -1, _("Mode:"))
+        self.glmModeChoice = wx.Choice(
+            glmBox, -1, choices=[_("Cloud API"), _("Ollama (Local)"), _("Self-hosted (GPU)")]
+        )
+        self.glmModeChoice.SetSizerProps(expand=True)
+        # Translators: the label of an edit field for API key
+        wx.StaticText(glmBox, -1, _("API Key (for Cloud mode):"))
+        wx.TextCtrl(
+            glmBox, -1, name="ocr.glm_ocr_api_key", style=wx.TE_PASSWORD
+        ).SetSizerProps(expand=True)
+        # Translators: the label of an edit field for Ollama host
+        wx.StaticText(glmBox, -1, _("Ollama Host (for Ollama mode):"))
+        wx.TextCtrl(glmBox, -1, name="ocr.glm_ocr_ollama_host").SetSizerProps(
+            expand=True
+        )
         # Translators: the label of a group of controls in the reading page
         # of the settings related to image enhancement
         miscBox = self.make_static_box(_("Image processing"))
@@ -139,6 +158,8 @@ class OcrPanel(SettingsPanel):
                 name="ocr.enhance_images",
             )
 
+    _GLM_MODE_MAP = ["cloud", "ollama", "local"]
+
     def reconcile(self, strategy=ReconciliationStrategies.load):
         if not any(self._engines):
             return
@@ -146,11 +167,19 @@ class OcrPanel(SettingsPanel):
             self.ocrEngine.SetSelection(
                 self._engines.index(self._service.get_first_available_ocr_engine())
             )
+            mode_val = self.config.get("glm_ocr_mode", "cloud")
+            try:
+                self.glmModeChoice.SetSelection(self._GLM_MODE_MAP.index(mode_val))
+            except ValueError:
+                self.glmModeChoice.SetSelection(0)
         elif strategy is ReconciliationStrategies.save:
             selected_engine = self._engines[self.ocrEngine.GetSelection()]
             if self.config["engine"] != selected_engine.name:
                 self.config["engine"] = selected_engine.name
                 self._service._init_ocr_engine()
+            self.config["glm_ocr_mode"] = self._GLM_MODE_MAP[
+                self.glmModeChoice.GetSelection()
+            ]
         super().reconcile(strategy=strategy)
         if strategy is ReconciliationStrategies.save:
             self._service._init_ocr_engine()

--- a/bookworm/ocr/ocr_menu.py
+++ b/bookworm/ocr/ocr_menu.py
@@ -19,6 +19,7 @@ from bookworm.document import DocumentCapability as DC
 from bookworm.document import DocumentUri, Section, SinglePageDocument, VirtualDocument
 from bookworm.gui.components import AsyncSnakDialog, RobustProgressDialog, SimpleDialog
 from bookworm.gui.settings import ReconciliationStrategies, SettingsPanel
+from bookworm.i18n import LocaleInfo
 from bookworm.image_io import ImageIO
 from bookworm.logger import logger
 from bookworm.ocr_engines import OcrRequest
@@ -27,6 +28,7 @@ from bookworm.ocr_engines.base import (
     OcrAuthenticationError,
     OcrNetworkError,
     OcrProcessingError,
+    OcrResult,
 )
 from bookworm.resources import sounds
 from bookworm.signals import (
@@ -83,6 +85,165 @@ class _ImageOcrRegonitionResultsDocument(VirtualDocument, SinglePageDocument):
     def toc_tree(self):
         return Section(
             title="",
+            pager=SINGLE_PAGE_DOCUMENT_PAGER,
+        )
+
+    @cached_property
+    def metadata(self):
+        return BookMetadata(
+            title=_("Recognition Result: {image_name}").format(
+                image_name=self.image_name
+            ),
+            author="",
+            publication_year="",
+        )
+
+
+class _MarkdownOcrRecognitionResultsDocument(VirtualDocument, SinglePageDocument):
+    """OCR result document with Markdown semantic parsing for structured navigation."""
+
+    __internal__ = True
+    format = "ocr_markdown_recog"
+    name = "Markdown OCR Recognition Results"
+    extensions = ()
+    capabilities = (
+        DC.TOC_TREE
+        | DC.SINGLE_PAGE
+        | DC.STRUCTURED_NAVIGATION
+        | DC.TEXT_STYLE
+        | DC.LINKS
+        | DC.INTERNAL_ANCHORS
+    )
+
+    def __init__(self, *args, ocr_result, image_name, **kwargs):
+        super(SinglePageDocument, self).__init__(*args, **kwargs)
+        VirtualDocument.__init__(self)
+        self.ocr_result = ocr_result
+        self._language = ocr_result.ocr_request.language
+        self.image_name = image_name
+        self._text = None
+        self._semantic_structure = {}
+        self._style_info = {}
+        self._outline = None
+        self.link_targets = {}
+        self.anchors = {}
+        self.structure = None
+
+    def read(self):
+        super().read()
+        self._parse_markdown_content()
+
+    def _parse_markdown_content(self):
+        from mistune import markdown as mistune_markdown
+        from bookworm.structured_text import HEADING_LEVELS, TextRange
+        from bookworm.structured_text.structured_html_parser import StructuredHtmlParser
+        from bookworm.document import TreeStackBuilder
+        from more_itertools import zip_offset
+
+        md_content = self.ocr_result.recognized_text
+        rendered_html = mistune_markdown(md_content, escape=False)
+        html_string = "\n".join([
+            "<!doctype html>",
+            "<html>",
+            "<head>",
+            '<meta charset="utf-8">',
+            f"<title>{self.image_name}</title>",
+            "</head>",
+            "<body>",
+            rendered_html,
+            "</body>",
+            "</html>",
+        ])
+
+        extracted = StructuredHtmlParser.from_string(html_string)
+        self.structure = extracted
+        self._semantic_structure = extracted.semantic_elements
+        self._style_info = extracted.styled_elements
+        self.link_targets = extracted.link_targets
+        self.anchors = extracted.anchors
+        self._text = text = extracted.get_text()
+
+        heading_poses = sorted(
+            (
+                (rng, h)
+                for h, rngs in extracted.semantic_elements.items()
+                for rng in rngs
+                if h in HEADING_LEVELS
+            ),
+            key=lambda x: x[0],
+        )
+
+        root = Section(
+            pager=SINGLE_PAGE_DOCUMENT_PAGER,
+            text_range=TextRange(0, -1),
+            title=self.image_name,
+            level=1,
+        )
+        stack = TreeStackBuilder(root)
+        for (start_pos, stop_pos), h_element in heading_poses:
+            h_text = text[start_pos:stop_pos].strip()
+            h_level = int(h_element.name[-1])
+            section = Section(
+                pager=SINGLE_PAGE_DOCUMENT_PAGER,
+                title=h_text,
+                level=h_level,
+                text_range=TextRange(start_pos, stop_pos),
+            )
+            stack.push(section)
+        all_sections = tuple(root.iter_children())
+        for this_sect, next_sect in zip_offset(
+            all_sections, all_sections, offsets=(0, 1)
+        ):
+            this_sect.text_range.stop = next_sect.text_range.start - 1
+        last_pos = len(text)
+        if all_sections:
+            all_sections[-1].text_range.stop = last_pos
+        root.text_range = TextRange(0, last_pos)
+        self._outline = root
+
+    def get_content(self):
+        return self._text
+
+    def get_document_semantic_structure(self):
+        return self._semantic_structure
+
+    def get_document_style_info(self):
+        return self._style_info
+
+    def get_document_table_markup(self, table_index):
+        if self.structure is not None:
+            return self.structure.get_table_markup(table_index)
+
+    def resolve_link(self, link_range):
+        from bookworm.document import LinkTarget
+        from bookworm.utils import is_external_url
+
+        href = self.link_targets.get(link_range)
+        if href is None:
+            return None
+        if is_external_url(href):
+            return LinkTarget(url=href, is_external=True)
+        else:
+            _filename, anchor = href.split("#") if "#" in href else (href, None)
+            if anchor := self.anchors.get(anchor, None):
+                return LinkTarget(url=href, is_external=False, position=anchor)
+
+    @cached_property
+    def language(self):
+        return self._language
+
+    def close(self):
+        super().close()
+
+    @cached_property
+    def toc_tree(self):
+        if self._outline is not None:
+            root = self._outline
+            if len(root) == 1:
+                return root[0]
+            return root
+        return Section(
+            title=self.image_name,
             pager=SINGLE_PAGE_DOCUMENT_PAGER,
         )
 
@@ -178,6 +339,9 @@ class OCRMenu(wx.Menu):
             should_auto_navigate_to_next_page.connect(
                 self.on_should_auto_navigate_to_next_page, sender=self.view
             )
+        self._saved_pdf_uri = None
+        self._saved_pdf_page = None
+        self.view.contentTextCtrl.Bind(wx.EVT_KEY_DOWN, self._on_key_down)
 
     def _get_ocr_options(self, from_cache=True, **dlg_kw):
         last_stored_opts = self.service.stored_options
@@ -223,6 +387,118 @@ class OCRMenu(wx.Menu):
         self.service.saved_scanned_pages.clear()
         return dlg.ShowModal()
 
+    @staticmethod
+    def _parse_markdown_for_display(md_content):
+        """Convert Markdown to plain text and extract semantic structure."""
+        from mistune import markdown as mistune_markdown
+        from bookworm.structured_text.structured_html_parser import StructuredHtmlParser
+
+        html = mistune_markdown(md_content, escape=False)
+        html_string = (
+            "<!doctype html><html><head>"
+            '<meta charset="utf-8"></head><body>'
+            f"{html}</body></html>"
+        )
+        extracted = StructuredHtmlParser.from_string(html_string)
+        return extracted.get_text(), extracted.semantic_elements
+
+    @staticmethod
+    def _markdown_to_plain_text(md_content):
+        """Convert Markdown to clean plain text with readable table layout."""
+        text, _ = OCRMenu._parse_markdown_for_display(md_content)
+        return text
+
+    def _display_ocr_markdown(self, page_number, md_content):
+        """Parse Markdown, display plain text, and inject semantic structure."""
+        text, semantic = self._parse_markdown_for_display(md_content)
+        self.service.saved_scanned_pages[page_number] = (text, semantic)
+        if page_number == self.service.reader.current_page:
+            self._set_content_with_semantics(text, semantic)
+
+    def _set_content_with_semantics(self, text, semantic):
+        self.view.set_content(text)
+        page = self.service.reader.document.get_page(
+            self.service.reader.current_page
+        )
+        page._injected_semantic_structure = semantic
+
+    @staticmethod
+    def _try_fitz_extract_markdown(document, page_number):
+        """Try to extract structured Markdown directly from PDF text layer.
+        Returns Markdown string if the page has a text layer, None otherwise.
+        """
+        try:
+            import fitz  # noqa: PLC0415
+        except ImportError:
+            return None
+        fitz_doc = getattr(document, "_ebook", None)
+        if fitz_doc is None or not isinstance(fitz_doc, fitz.Document):
+            return None
+        page = fitz_doc[page_number]
+        plain = page.get_text("text").strip()
+        if len(plain) < 20:
+            return None
+        parts = []
+        tables = page.find_tables()
+        table_rects = [t.bbox for t in tables.tables] if tables.tables else []
+        if table_rects:
+            blocks = page.get_text("dict", sort=True)["blocks"]
+            for block in blocks:
+                if block["type"] != 0:
+                    continue
+                bx0, by0, bx1, by1 = block["bbox"]
+                in_table = any(
+                    bx0 >= tr[0] - 5 and by0 >= tr[1] - 5
+                    and bx1 <= tr[2] + 5 and by1 <= tr[3] + 5
+                    for tr in table_rects
+                )
+                if not in_table:
+                    for line in block["lines"]:
+                        text = "".join(
+                            span["text"] for span in line["spans"]
+                        ).strip()
+                        if text:
+                            max_size = max(
+                                (s["size"] for s in line["spans"]), default=0
+                            )
+                            is_bold = any(
+                                "bold" in s["font"].lower()
+                                for s in line["spans"]
+                            )
+                            if max_size > 16 and is_bold:
+                                parts.append(f"## {text}")
+                            elif max_size > 14 and is_bold:
+                                parts.append(f"### {text}")
+                            else:
+                                parts.append(text)
+            for table in tables.tables:
+                md_table = table.to_markdown()
+                parts.append(md_table)
+        else:
+            blocks = page.get_text("dict", sort=True)["blocks"]
+            for block in blocks:
+                if block["type"] != 0:
+                    continue
+                for line in block["lines"]:
+                    text = "".join(
+                        span["text"] for span in line["spans"]
+                    ).strip()
+                    if text:
+                        max_size = max(
+                            (s["size"] for s in line["spans"]), default=0
+                        )
+                        is_bold = any(
+                            "bold" in s["font"].lower()
+                            for s in line["spans"]
+                        )
+                        if max_size > 16 and is_bold:
+                            parts.append(f"## {text}")
+                        elif max_size > 14 and is_bold:
+                            parts.append(f"### {text}")
+                        else:
+                            parts.append(text)
+        return "\n\n".join(parts) if parts else None
+
     def onScanCurrentPage(self, event):
         self._ocr_cancelled.clear()
         ocr_opts = self._get_ocr_options()
@@ -230,8 +506,33 @@ class OCRMenu(wx.Menu):
             return speech.announce(_("Canceled"), True)
         reader = self.service.reader
         if reader.current_page in self.service.saved_scanned_pages:
-            self.view.set_content(self.service.saved_scanned_pages[reader.current_page])
+            cached = self.service.saved_scanned_pages[reader.current_page]
+            if isinstance(cached, tuple):
+                self._set_content_with_semantics(cached[0], cached[1])
+            else:
+                self.view.set_content(cached)
             return
+
+        # Fast path: try direct text extraction from PDF text layer
+        if self._is_glm_markdown_mode():
+            md_content = self._try_fitz_extract_markdown(
+                reader.document, reader.current_page
+            )
+            if md_content:
+                log.info(
+                    "Fast path: extracted text layer from page %d",
+                    reader.current_page,
+                )
+                self._display_ocr_markdown(reader.current_page, md_content)
+                sounds.ocr_end.play()
+                return
+
+        # Medium path: GLM-OCR Cloud — send single-page PDF directly
+        if self._is_glm_markdown_mode() and self._can_use_cloud_pdf_direct(reader):
+            self._cloud_pdf_single_page(reader.current_page)
+            return
+
+        # Slow path: screenshot-based OCR (Ollama / other engines)
         image = reader.document.get_page_image(
             reader.current_page,
             ocr_opts.zoom_factor,
@@ -247,12 +548,103 @@ class OCRMenu(wx.Menu):
         def _ocr_callback(ocr_result):
             page_number = ocr_result.cookie
             content = ocr_result.recognized_text
-            self.service.saved_scanned_pages[page_number] = content
-            if page_number == self.view.reader.current_page:
-                self.view.set_content(content)
-                self.view.set_text_direction(ocr_request.language.is_rtl)
+            if self._is_glm_markdown_mode():
+                self._display_ocr_markdown(page_number, content)
+            else:
+                self.service.saved_scanned_pages[page_number] = content
+                if page_number == self.view.reader.current_page:
+                    self.view.set_content(content)
+                    self.view.set_text_direction(ocr_request.language.is_rtl)
 
         self._run_ocr(ocr_request, _ocr_callback)
+
+    def _open_ocr_virtual_document(self, recog_document):
+        """Open an OCR virtual document, saving the current PDF state for Escape return."""
+        current_reader = self.service.reader
+        if not getattr(self, "_saved_pdf_uri", None):
+            self._saved_pdf_uri = current_reader.document.uri
+            self._saved_pdf_page = current_reader.current_page
+        wx.CallAfter(self._load_and_focus, recog_document)
+
+    def _load_and_focus(self, recog_document):
+        self.view.load_document(recog_document)
+        self.view.contentTextCtrl.SetFocus()
+
+    def _return_to_pdf(self):
+        """Return to the original PDF after viewing an OCR virtual document."""
+        saved_uri = getattr(self, "_saved_pdf_uri", None)
+        if saved_uri is None:
+            return False
+        saved_page = getattr(self, "_saved_pdf_page", 0)
+        self._saved_pdf_uri = None
+        self._saved_pdf_page = None
+        uri_with_page = saved_uri.create_copy(
+            openner_args={"page": str(saved_page)}
+        )
+        wx.CallAfter(self._open_uri_and_focus, uri_with_page)
+        return True
+
+    def _open_uri_and_focus(self, uri):
+        self.view.open_uri(uri)
+        wx.CallLater(200, self.view.contentTextCtrl.SetFocus)
+
+    def _on_key_down(self, event):
+        if event.GetKeyCode() == wx.WXK_ESCAPE and self._saved_pdf_uri is not None:
+            self._return_to_pdf()
+            return
+        event.Skip()
+
+    def _can_use_cloud_pdf_direct(self, reader):
+        """Check if we can use direct PDF upload for the current document."""
+        engine = self.service.current_ocr_engine
+        if not (hasattr(engine, "_get_mode") and engine._get_mode().value == "cloud"):
+            return False
+        doc = reader.document
+        if not hasattr(doc, "get_file_system_path"):
+            return False
+        try:
+            pdf_path = doc.get_file_system_path()
+            return pdf_path and Path(pdf_path).suffix.lower() == ".pdf"
+        except Exception:
+            return False
+
+    def _cloud_pdf_single_page(self, page_number):
+        """OCR a single page via Cloud: extract page as temp PDF and upload."""
+        sounds.ocr_start.play()
+        ocr_started.send(sender=self.view)
+        reader = self.service.reader
+        pdf_path = reader.document.get_file_system_path()
+
+        def _task():
+            from bookworm.ocr_engines.glm_ocr import GlmOcrEngine  # noqa: PLC0415
+            return GlmOcrEngine.recognize_single_page_pdf(pdf_path, page_number)
+
+        def _done(future):
+            try:
+                md_content = future.result()
+            except Exception:
+                log.exception("Cloud PDF direct OCR failed for page %d.", page_number)
+                ocr_ended.send(sender=self.view, isfaulted=True)
+                wx.CallAfter(
+                    wx.MessageBox,
+                    _("Cloud PDF OCR failed. Falling back may be needed."),
+                    _("OCR Error"),
+                    style=wx.ICON_ERROR,
+                    parent=self.view,
+                )
+                return
+
+            self._display_ocr_markdown(page_number, md_content)
+            sounds.ocr_end.play()
+            ocr_ended.send(sender=self.view, isfaulted=False)
+
+        self._wait_dlg = AsyncSnakDialog(
+            task=_task,
+            done_callback=_done,
+            message=_("Running OCR, please wait..."),
+            dismiss_callback=self._on_ocr_cancelled,
+            parent=self.view,
+        )
 
     def _run_ocr(self, ocr_request, callback):
         ocr_started.send(sender=self.view)
@@ -289,20 +681,31 @@ class OCRMenu(wx.Menu):
         else:
             speech.announce(_("Automatic OCR is disabled"))
 
+    def _is_glm_markdown_mode(self):
+        engine = self.service.current_ocr_engine
+        return (
+            hasattr(engine, "name")
+            and engine.name == "glm_ocr"
+            and (self.service.stored_options is None
+                 or self.service.stored_options.engine_options.get("output_markdown", True))
+        )
+
     def onScanToTextFile(self, event):
         ocr_opts = self._get_ocr_options(from_cache=False, force_save=True)
         if ocr_opts is None:
             return
-        # Get output file path
-        filename = f"{self.view.reader.current_book.title}.txt"
+        use_markdown = self._is_glm_markdown_mode()
+        ext = ".md" if use_markdown else ".txt"
+        ext_label = _("Markdown") if use_markdown else _("Plain Text")
+        filename = f"{self.view.reader.current_book.title}{ext}"
         saveExportedFD = wx.FileDialog(
             self.view,
-            # Translators: the title of a save file dialog asking the user for a filename to export notes to
+            # Translators: the title of a save file dialog asking the user
+            # for a filename to export notes to
             _("Save as"),
             defaultDir=wx.GetUserHome(),
             defaultFile=filename,
-            # Translators: file type in a save as dialog
-            wildcard=_("Plain Text") + "(*.txt)|.txt",
+            wildcard=f"{ext_label} (*{ext})|*{ext}",
             style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
         )
         if saveExportedFD.ShowModal() != wx.ID_OK:
@@ -322,15 +725,66 @@ class OCRMenu(wx.Menu):
             can_hide=True,
             can_abort=True,
         )
-        self._continue_with_text_extraction(ocr_opts, output_file, progress_dlg)
+        self._continue_with_text_extraction(
+            ocr_opts, output_file, progress_dlg, open_after=use_markdown
+        )
 
     @call_threaded
-    def _continue_with_text_extraction(self, ocr_opts, output_file, progress_dlg):
+    def _continue_with_text_extraction(
+        self, ocr_opts, output_file, progress_dlg, open_after=False
+    ):
         doc = self.service.reader.document
         total = len(doc)
+        engine = self.service.current_ocr_engine
+
+        # Smart batch path: GLM-OCR Cloud with text layer detection
+        if (
+            self._is_glm_markdown_mode()
+            and hasattr(engine, "smart_batch_ocr")
+            and hasattr(doc, "get_file_system_path")
+        ):
+            try:
+                pdf_path = doc.get_file_system_path()
+                if pdf_path and Path(pdf_path).suffix.lower() == ".pdf":
+                    from bookworm.ocr_engines.glm_ocr import GlmOcrEngine  # noqa: PLC0415
+
+                    def _progress(current, total_pages, message):
+                        val = min(current + 1, total_pages)
+                        wx.CallAfter(
+                            progress_dlg.Update, val, message
+                        )
+
+                    md_text = GlmOcrEngine.smart_batch_ocr(
+                        pdf_path, progress_callback=_progress
+                    )
+                    with open(output_file, "w", encoding="utf-8") as f:
+                        f.write(md_text)
+                    progress_dlg.Dismiss()
+                    if open_after:
+                        wx.CallAfter(
+                            self._open_ocr_result_file, output_file, total
+                        )
+                    else:
+                        wx.CallAfter(
+                            wx.MessageBox,
+                            message=_(
+                                "Successfully processed {total} pages.\n"
+                                "Extracted text was written to: {file}"
+                            ).format(total=total, file=output_file),
+                            caption=_("OCR Completed"),
+                            style=wx.ICON_INFORMATION | wx.OK,
+                            parent=self.view,
+                        )
+                    return
+            except Exception:
+                log.exception(
+                    "Smart batch OCR failed, falling back to per-page OCR."
+                )
+
+        # Standard path: per-page OCR
         args = (doc, output_file, ocr_opts)
         scan2text_process = QueueProcess(
-            target=self.service.current_ocr_engine.scan_to_text, args=args
+            target=engine.scan_to_text, args=args
         )
         progress_dlg.set_abort_callback(scan2text_process.cancel)
 
@@ -340,18 +794,40 @@ class OCRMenu(wx.Menu):
                     progress + 1,
                     f"Scanning page {progress} of {total}",
                 )
-            wx.CallAfter(
-                wx.MessageBox,
-                message=_(
-                    "Successfully processed {total} pages.\nExtracted text was written to: {file}"
-                ).format(total=total, file=output_file),
-                caption=_("OCR Completed"),
-                style=wx.ICON_INFORMATION | wx.OK,
-                parent=self.view,
-            )
+            if open_after and Path(output_file).exists():
+                wx.CallAfter(self._open_ocr_result_file, output_file, total)
+            else:
+                wx.CallAfter(
+                    wx.MessageBox,
+                    message=_(
+                        "Successfully processed {total} pages.\n"
+                        "Extracted text was written to: {file}"
+                    ).format(total=total, file=output_file),
+                    caption=_("OCR Completed"),
+                    style=wx.ICON_INFORMATION | wx.OK,
+                    parent=self.view,
+                )
         finally:
             progress_dlg.Dismiss()
             wx.CallAfter(self.view.contentTextCtrl.SetFocus)
+
+    def _open_ocr_result_file(self, output_file, total):
+        retval = wx.MessageBox(
+            _(
+                "Successfully processed {total} pages.\n"
+                "Open the result in Bookworm for structured navigation?"
+            ).format(total=total),
+            _("OCR Completed"),
+            style=wx.YES_NO | wx.ICON_INFORMATION,
+            parent=self.view,
+        )
+        if retval == wx.YES:
+            uri = DocumentUri(
+                format="markdown",
+                path=output_file,
+                openner_args={},
+            )
+            self.view.open_uri(uri)
 
     def onChangeOCROptions(self, event):
         self._get_ocr_options(from_cache=False)
@@ -401,16 +877,29 @@ class OCRMenu(wx.Menu):
                 return
 
             def _ocr_callback(ocr_result):
+                engine = self.service.current_ocr_engine
+                use_markdown = (
+                    hasattr(engine, "name")
+                    and engine.name == "glm_ocr"
+                    and ocr_request.engine_options.get("output_markdown", False)
+                )
+                if use_markdown:
+                    doc_cls = _MarkdownOcrRecognitionResultsDocument
+                    doc_format = _MarkdownOcrRecognitionResultsDocument.format
+                else:
+                    doc_cls = _ImageOcrRegonitionResultsDocument
+                    doc_format = _ImageOcrRegonitionResultsDocument.format
                 recog_uri = DocumentUri(
-                    format=_ImageOcrRegonitionResultsDocument.format,
+                    format=doc_format,
                     path=filename,
                     openner_args={},
                 )
-                recog_document = _ImageOcrRegonitionResultsDocument(
+                recog_document = doc_cls(
                     recog_uri,
                     ocr_result=ocr_result,
                     image_name=Path(filename).stem,
                 )
+                recog_document.read()
                 wx.CallAfter(self.view.load_document, recog_document)
 
             factor = options.zoom_factor
@@ -485,7 +974,14 @@ class OCRMenu(wx.Menu):
         self.auto_scan_item.Check(False)
 
     def _on_reader_page_changed(self, sender, current, prev):
-        if self.auto_scan_item.IsChecked():
+        page_index = current.index if hasattr(current, "index") else current
+        if page_index in self.service.saved_scanned_pages:
+            cached = self.service.saved_scanned_pages[page_index]
+            if isinstance(cached, tuple):
+                self._set_content_with_semantics(cached[0], cached[1])
+            else:
+                self.view.set_content(cached)
+        elif self.auto_scan_item.IsChecked():
             self.onScanCurrentPage(None)
 
     def on_should_auto_navigate_to_next_page(self, sender):

--- a/bookworm/ocr_engines/__init__.py
+++ b/bookworm/ocr_engines/__init__.py
@@ -12,10 +12,12 @@ from .base import (
 from .tesseract_ocr_engine import TesseractOcrEngine
 from .baidu_ocr import BaiduGeneralOcrEngine, BaiduAccurateOcrEngine
 from .vivo_ocr import VivoOcrEngine
+from .glm_ocr import GlmOcrEngine
 
 GENERIC_OCR_ENGINES = [
     TesseractOcrEngine,
     BaiduGeneralOcrEngine,
     BaiduAccurateOcrEngine,
     VivoOcrEngine,
+    GlmOcrEngine,
 ]

--- a/bookworm/ocr_engines/glm_ocr.py
+++ b/bookworm/ocr_engines/glm_ocr.py
@@ -1,0 +1,668 @@
+"""
+GLM-OCR Engine integration.
+
+Supports three deployment modes:
+  - cloud:  Zhipu layout_parsing API ($0.03/M tokens, no GPU needed)
+  - ollama: Local Ollama server (free, no GPU required, ~1.6GB model)
+  - local:  glmocr Python package with self-hosted model (needs CUDA GPU)
+
+Cloud mode supports direct PDF upload (up to 100 pages, 50MB) for
+batch processing in a single request — no per-page image rendering needed.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+import time
+from enum import Enum
+from pathlib import Path
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+from bookworm import config
+from bookworm.i18n import LocaleInfo
+from bookworm.logger import logger
+
+from ._shared import StrictRateLimiter
+from .base import (
+    BaseOcrEngine,
+    EngineOption,
+    OcrAuthenticationError,
+    OcrNetworkError,
+    OcrProcessingError,
+    OcrRequest,
+    OcrResult,
+)
+
+log = logger.getChild(__name__)
+
+GLM_OCR_API_KEY_CONFIG_KEY = "glm_ocr_api_key"
+GLM_OCR_MODE_CONFIG_KEY = "glm_ocr_mode"
+GLM_OCR_OLLAMA_HOST_CONFIG_KEY = "glm_ocr_ollama_host"
+
+GLM_OCR_LAYOUT_PARSING_URL = "https://open.bigmodel.cn/api/paas/v4/layout_parsing"
+GLM_OCR_MODEL_NAME = "glm-ocr"
+GLM_OCR_DEFAULT_OLLAMA_HOST = "http://localhost:11434"
+
+# ── Post-processing pipeline (inspired by 42md) ──
+
+_POSTPROCESS_RULES = [
+    (re.compile(r"(&nbsp;){3,}"), " "),
+    (re.compile(r"(?m)^\[(\d+)\](:\s*.+)$"), r"[^\1]\2"),
+    (re.compile(r"\$\s*\^\{(\d+)\}\s*\$"), r"[^\1]"),
+    (re.compile(r"\n{4,}"), "\n\n\n"),
+    (re.compile(r"[ \t]+$", re.MULTILINE), ""),
+    (re.compile(r"^(#{1,6})\s*\*{1,2}(.+?)\*{1,2}\s*$", re.MULTILINE), r"\1 \2"),
+]
+
+
+def postprocess_markdown(text: str) -> str:
+    """Clean up raw OCR Markdown output."""
+    for pattern, replacement in _POSTPROCESS_RULES:
+        text = pattern.sub(replacement, text)
+    lines = text.split("\n")
+    cleaned = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped in ("```", "```markdown"):
+            continue
+        cleaned.append(line)
+    return "\n".join(cleaned).strip()
+
+
+class GlmOcrMode(str, Enum):
+    CLOUD = "cloud"
+    OLLAMA = "ollama"
+    LOCAL = "local"
+
+class GlmOcrEngine(BaseOcrEngine):
+    """GLM-OCR engine with table, formula, and layout recognition."""
+
+    name = "glm_ocr"
+    display_name = _("GLM-OCR (Zhipu)")
+    __supports_more_than_one_recognition_language__ = False
+    __requires_rate_limiting__ = True
+
+    rate_limiter = StrictRateLimiter(qps=0.5)
+    session = requests.Session()
+    session.trust_env = False
+    _retry_adapter = HTTPAdapter(max_retries=Retry(
+        total=3,
+        backoff_factor=1.0,
+        status_forcelist=[500, 502, 503, 504],
+        allowed_methods=["POST"],
+    ))
+    session.mount("https://", _retry_adapter)
+    session.mount("http://", _retry_adapter)
+
+    @classmethod
+    def check(cls) -> bool:
+        return True
+
+    @classmethod
+    def get_recognition_languages(cls) -> list[LocaleInfo]:
+        return [
+            LocaleInfo("zh-CN"),
+            LocaleInfo("en"),
+            LocaleInfo("ja"),
+            LocaleInfo("ko"),
+            LocaleInfo("fr"),
+            LocaleInfo("de"),
+            LocaleInfo("es"),
+            LocaleInfo("ru"),
+        ]
+
+    @classmethod
+    def get_engine_options(cls) -> list[EngineOption]:
+        return [
+            EngineOption(
+                key="output_markdown",
+                label=_("Output structured Markdown (tables, formulas)"),
+                default=True,
+            ),
+        ]
+
+    @classmethod
+    def _get_mode(cls) -> GlmOcrMode:
+        conf = config.conf["ocr"]
+        mode = conf.get(GLM_OCR_MODE_CONFIG_KEY, GlmOcrMode.CLOUD.value)
+        try:
+            return GlmOcrMode(mode)
+        except ValueError:
+            return GlmOcrMode.CLOUD
+
+    @classmethod
+    def _get_api_key(cls) -> str:
+        conf = config.conf["ocr"]
+        api_key = conf.get(GLM_OCR_API_KEY_CONFIG_KEY, "")
+        if not api_key:
+            raise OcrAuthenticationError(
+                _("GLM-OCR API key is not configured. Please set it in OCR settings.")
+            )
+        return api_key
+
+    @classmethod
+    def _get_ollama_host(cls) -> str:
+        conf = config.conf["ocr"]
+        return (
+            conf.get(GLM_OCR_OLLAMA_HOST_CONFIG_KEY, "")
+            or GLM_OCR_DEFAULT_OLLAMA_HOST
+        )
+
+    # ── Cloud mode: single image ──
+
+    @classmethod
+    def _recognize_cloud(cls, ocr_request: OcrRequest) -> str:
+        """Call Zhipu layout_parsing with a single page image."""
+        api_key = cls._get_api_key()
+        image_bytes = ocr_request.image.as_bytes(format="PNG")
+        b64_image = base64.b64encode(image_bytes).decode("utf-8")
+
+        payload = {
+            "model": GLM_OCR_MODEL_NAME,
+            "file": f"data:image/png;base64,{b64_image}",
+        }
+        return cls._cloud_request(api_key, payload)
+
+    @classmethod
+    def recognize_single_page_pdf(cls, pdf_path: str | Path, page_number: int) -> str:
+        """Extract one page as a temp PDF and upload it. No size limit issues."""
+        import tempfile  # noqa: PLC0415
+
+        import fitz  # noqa: PLC0415
+
+        api_key = cls._get_api_key()
+        src = fitz.open(str(pdf_path))
+        tmp = fitz.open()
+        tmp.insert_pdf(src, from_page=page_number, to_page=page_number)
+
+        with tempfile.NamedTemporaryFile(
+            suffix=".pdf", delete=False
+        ) as f:
+            tmp_path = f.name
+        tmp.save(tmp_path)
+        tmp.close()
+        src.close()
+
+        try:
+            pdf_bytes = Path(tmp_path).read_bytes()
+            b64_pdf = base64.b64encode(pdf_bytes).decode("utf-8")
+            payload = {
+                "model": GLM_OCR_MODEL_NAME,
+                "file": f"data:application/pdf;base64,{b64_pdf}",
+            }
+            log.info(
+                "GLM-OCR single-page PDF: page %d, %d bytes",
+                page_number,
+                len(pdf_bytes),
+            )
+            return cls._cloud_request(api_key, payload)
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+
+    # ── Cloud mode: direct PDF upload (batch, up to 100 pages) ──
+
+    MAX_PDF_SIZE = 50 * 1024 * 1024
+
+    @classmethod
+    def recognize_pdf_file(
+        cls,
+        pdf_path: str | Path,
+        start_page: int | None = None,
+        end_page: int | None = None,
+    ) -> str:
+        """Upload entire PDF to Zhipu for batch OCR. Returns full Markdown."""
+        api_key = cls._get_api_key()
+        pdf_path = Path(pdf_path)
+        if pdf_path.stat().st_size > cls.MAX_PDF_SIZE:
+            raise OcrProcessingError(
+                _("PDF file exceeds 50MB limit for direct upload.")
+            )
+        pdf_bytes = pdf_path.read_bytes()
+        b64_pdf = base64.b64encode(pdf_bytes).decode("utf-8")
+
+        payload = {
+            "model": GLM_OCR_MODEL_NAME,
+            "file": f"data:application/pdf;base64,{b64_pdf}",
+        }
+        if start_page is not None:
+            payload["start_page_id"] = start_page
+        if end_page is not None:
+            payload["end_page_id"] = end_page
+
+        log.info(
+            "GLM-OCR PDF upload: %d bytes, pages %s-%s",
+            len(pdf_bytes),
+            start_page or 1,
+            end_page or "end",
+        )
+        return cls._cloud_request(api_key, payload)
+
+    # ── Smart batch OCR for large PDFs ──
+
+    BATCH_CHUNK_SIZE = 50
+    TEXT_LAYER_MIN_CHARS = 50
+
+    @classmethod
+    def smart_batch_ocr(cls, pdf_path: str | Path, progress_callback=None):
+        """Fast batch OCR: detect text layers locally, OCR only scanned pages.
+
+        Yields nothing; calls progress_callback(current, total, message).
+        Returns full Markdown string with all pages merged.
+        """
+        import fitz  # noqa: PLC0415
+
+        pdf_path = Path(pdf_path)
+        src = fitz.open(str(pdf_path))
+        total = len(src)
+        results = {}
+        ocr_needed = []
+
+        for i in range(total):
+            page = src[i]
+            text = page.get_text("text").strip()
+            if len(text) >= cls.TEXT_LAYER_MIN_CHARS:
+                extracted = cls._fitz_page_to_markdown(page, text)
+                if len(extracted.strip()) >= cls.TEXT_LAYER_MIN_CHARS:
+                    results[i] = extracted
+                else:
+                    ocr_needed.append(i)
+            else:
+                ocr_needed.append(i)
+            if progress_callback:
+                progress_callback(
+                    i, total, _("Analyzing page {n}/{total}").format(
+                        n=i + 1, total=total
+                    )
+                )
+
+        log.info(
+            "Smart batch: %d pages with text layer, %d need OCR",
+            len(results), len(ocr_needed),
+        )
+
+        if not ocr_needed:
+            src.close()
+            return cls._merge_results(results, total)
+
+        cls._parallel_ocr_chunks(
+            src, ocr_needed, results, total, len(results), progress_callback
+        )
+        src.close()
+        return cls._merge_results(results, total)
+
+    @classmethod
+    def _parallel_ocr_chunks(
+        cls, src, ocr_needed, results, total, base_done, progress_callback
+    ):
+        from concurrent.futures import ThreadPoolExecutor, as_completed  # noqa: PLC0415
+
+        chunks = [
+            ocr_needed[i:i + cls.BATCH_CHUNK_SIZE]
+            for i in range(0, len(ocr_needed), cls.BATCH_CHUNK_SIZE)
+        ]
+        completed_pages = base_done
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            futures = {}
+            for chunk_idx, chunk_pages in enumerate(chunks):
+                future = pool.submit(cls._ocr_chunk, src, chunk_pages)
+                futures[future] = (chunk_idx, chunk_pages)
+                time.sleep(1.5)
+
+            for future in as_completed(futures):
+                chunk_idx, chunk_pages = futures[future]
+                try:
+                    chunk_md = future.result()
+                    page_texts = cls._split_chunk_result(
+                        chunk_md, len(chunk_pages)
+                    )
+                    for j, page_idx in enumerate(chunk_pages):
+                        results[page_idx] = (
+                            page_texts[j] if j < len(page_texts) else ""
+                        )
+                except Exception:
+                    log.exception(
+                        "Batch chunk %d failed, skipping %d pages.",
+                        chunk_idx, len(chunk_pages),
+                    )
+                    for page_idx in chunk_pages:
+                        results[page_idx] = ""
+
+                completed_pages += len(chunk_pages)
+                if progress_callback:
+                    progress_callback(
+                        min(completed_pages, total - 1), total,
+                        _("OCR: {done}/{total} pages").format(
+                            done=completed_pages, total=total
+                        ),
+                    )
+
+    @classmethod
+    def _fitz_page_to_markdown(cls, page, plain_text: str) -> str:
+        parts = []
+        tables = page.find_tables()
+        table_rects = [t.bbox for t in tables.tables] if tables.tables else []
+        blocks = page.get_text("dict", sort=True)["blocks"]
+        for block in blocks:
+            if block["type"] != 0:
+                continue
+            bx0, by0, bx1, by1 = block["bbox"]
+            in_table = any(
+                bx0 >= tr[0] - 5 and by0 >= tr[1] - 5
+                and bx1 <= tr[2] + 5 and by1 <= tr[3] + 5
+                for tr in table_rects
+            )
+            if not in_table:
+                for line in block["lines"]:
+                    text = "".join(
+                        span["text"] for span in line["spans"]
+                    ).strip()
+                    if not text:
+                        continue
+                    max_size = max(
+                        (s["size"] for s in line["spans"]), default=0
+                    )
+                    is_bold = any(
+                        "bold" in s["font"].lower() for s in line["spans"]
+                    )
+                    if max_size > 16 and is_bold:
+                        parts.append(f"## {text}")
+                    elif max_size > 14 and is_bold:
+                        parts.append(f"### {text}")
+                    else:
+                        parts.append(text)
+        if tables.tables:
+            parts.extend(t.to_markdown() for t in tables.tables)
+        return postprocess_markdown("\n\n".join(parts)) if parts else plain_text
+
+    @classmethod
+    def _ocr_chunk(cls, src_doc, page_indices: list[int]) -> str:
+        import tempfile  # noqa: PLC0415
+
+        import fitz  # noqa: PLC0415
+
+        api_key = cls._get_api_key()
+        tmp_doc = fitz.open()
+        for idx in page_indices:
+            tmp_doc.insert_pdf(src_doc, from_page=idx, to_page=idx)
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            tmp_path = f.name
+        tmp_doc.save(tmp_path)
+        tmp_doc.close()
+
+        try:
+            pdf_bytes = Path(tmp_path).read_bytes()
+            if len(pdf_bytes) > cls.MAX_PDF_SIZE:
+                Path(tmp_path).unlink(missing_ok=True)
+                mid = len(page_indices) // 2
+                left = cls._ocr_chunk(src_doc, page_indices[:mid])
+                right = cls._ocr_chunk(src_doc, page_indices[mid:])
+                return left + "\n\n" + right
+
+            b64_pdf = base64.b64encode(pdf_bytes).decode("utf-8")
+            payload = {
+                "model": GLM_OCR_MODEL_NAME,
+                "file": f"data:application/pdf;base64,{b64_pdf}",
+            }
+            log.info(
+                "Smart batch chunk: %d pages, %d bytes",
+                len(page_indices), len(pdf_bytes),
+            )
+            return cls._cloud_request(api_key, payload)
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+
+    @staticmethod
+    def _split_chunk_result(md_text: str, expected_pages: int) -> list[str]:
+        import re as _re  # noqa: PLC0415
+        parts = _re.split(r"<!--\s*page\s+\d+\s*-->", md_text)
+        parts = [postprocess_markdown(p) for p in parts if p.strip()]
+        if len(parts) == expected_pages:
+            return parts
+        if len(parts) == 1 and expected_pages > 1:
+            return [postprocess_markdown(md_text)]
+        return parts
+
+    @staticmethod
+    def _merge_results(results: dict[int, str], total: int) -> str:
+        sections = []
+        for i in range(total):
+            text = results.get(i, "")
+            sections.append(f"<!-- page {i + 1} -->\n\n{text}")
+        return "\n\n".join(sections)
+
+    MAX_RETRIES_429 = 5
+
+    @classmethod
+    def _cloud_request(cls, api_key: str, payload: dict) -> str:
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        }
+        for attempt in range(cls.MAX_RETRIES_429 + 1):
+            cls.rate_limiter.wait_for_permission()
+            try:
+                response = cls.session.post(
+                    GLM_OCR_LAYOUT_PARSING_URL,
+                    headers=headers,
+                    json=payload,
+                    timeout=300,
+                )
+                if response.status_code == 429:
+                    wait = min(2 ** attempt * 2, 30)
+                    log.warning(
+                        "GLM-OCR 429 rate limited, waiting %ds (attempt %d/%d)",
+                        wait, attempt + 1, cls.MAX_RETRIES_429,
+                    )
+                    time.sleep(wait)
+                    continue
+                response.raise_for_status()
+                return cls._parse_layout_response(response)
+            except Exception as e:
+                if attempt < cls.MAX_RETRIES_429:
+                    resp = getattr(e, "response", None)
+                    if resp is not None and resp.status_code == 429:
+                        wait = min(2 ** attempt * 2, 30)
+                        log.warning("GLM-OCR 429, backoff %ds", wait)
+                        time.sleep(wait)
+                        continue
+                log.exception("GLM-OCR cloud request failed.")
+                cls._raise_network_error(e)
+        cls._raise_network_error(
+            OcrProcessingError("Max retries exceeded for 429")
+        )
+        return ""  # unreachable, _raise_network_error always raises
+
+    # PLACEHOLDER_PARSE_AND_MODES
+
+    @classmethod
+    def _parse_layout_response(cls, response) -> str:
+        try:
+            data = response.json()
+        except json.JSONDecodeError as e:
+            log.exception("Failed to decode GLM-OCR response.")
+            raise OcrProcessingError(
+                _("Failed to parse GLM-OCR API response.")
+            ) from e
+
+        if "error" in data or "code" in data:
+            msg = (
+                data.get("error", {}).get("message", "")
+                or data.get("message", "")
+            )
+            log.error("GLM-OCR API error: %s", msg)
+            raise OcrProcessingError(_("GLM-OCR API error: ") + msg)
+
+        md_results = data.get("md_results", "")
+        if md_results:
+            return postprocess_markdown(md_results)
+
+        details = data.get("layout_details", [])
+        if details:
+            raw = "\n\n".join(
+                item.get("content", "")
+                for item in details
+                if item.get("content")
+            )
+            return postprocess_markdown(raw)
+
+        log.warning("GLM-OCR returned empty result: %s", data)
+        return ""
+
+    # ── Ollama mode ──
+
+    @classmethod
+    def _recognize_ollama(cls, ocr_request: OcrRequest) -> str:
+        host = cls._get_ollama_host()
+        image_bytes = ocr_request.image.as_bytes(format="PNG")
+        b64_image = base64.b64encode(image_bytes).decode("utf-8")
+
+        payload = {
+            "model": GLM_OCR_MODEL_NAME,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Perform OCR on this image. "
+                    "Output Markdown with tables and formulas preserved.",
+                    "images": [b64_image],
+                }
+            ],
+            "stream": False,
+        }
+
+        api_url = f"{host.rstrip('/')}/api/chat"
+        try:
+            response = cls.session.post(api_url, json=payload, timeout=180)
+            response.raise_for_status()
+        except Exception as e:
+            if "Connection" in type(e).__name__:
+                raise OcrNetworkError(
+                    _(
+                        "Cannot connect to Ollama at {host}. "
+                        "Please ensure Ollama is running (ollama serve) "
+                        "and the glm-ocr model is pulled (ollama pull glm-ocr)."
+                    ).format(host=host)
+                ) from e
+            raise OcrNetworkError(
+                _("Error communicating with Ollama: {error}").format(
+                    error=str(e)
+                )
+            ) from e
+
+        try:
+            data = response.json()
+        except json.JSONDecodeError as e:
+            log.exception("Failed to decode Ollama response.")
+            raise OcrProcessingError(
+                _("Failed to parse Ollama response.")
+            ) from e
+
+        if "error" in data:
+            error_msg = data["error"]
+            if "not found" in error_msg.lower():
+                raise OcrProcessingError(
+                    _(
+                        "Model glm-ocr not found in Ollama. "
+                        "Please run: ollama pull glm-ocr"
+                    )
+                )
+            raise OcrProcessingError(
+                _("Ollama error: {error}").format(error=error_msg)
+            )
+
+        try:
+            return postprocess_markdown(data["message"]["content"])
+        except KeyError as e:
+            log.exception("Unexpected Ollama response: %s", data)
+            raise OcrProcessingError(
+                _("Failed to parse Ollama response.")
+            ) from e
+
+    # ── Local mode ──
+
+    @classmethod
+    def _recognize_local(cls, ocr_request: OcrRequest) -> str:
+        try:
+            from glmocr import GlmOcr  # noqa: PLC0415
+        except ImportError as exc:
+            raise OcrProcessingError(
+                _(
+                    "The glmocr package is not installed. "
+                    "Please install it with: pip install glmocr[selfhosted]"
+                )
+            ) from exc
+
+        image_pil = ocr_request.image.to_pil()
+        try:
+            with GlmOcr() as parser:
+                result = parser.parse(image_pil)
+                raw = (
+                    result.markdown
+                    if hasattr(result, "markdown")
+                    else str(result)
+                )
+                return postprocess_markdown(raw)
+        except Exception as e:
+            log.exception("GLM-OCR local recognition failed.")
+            raise OcrProcessingError(
+                _("GLM-OCR local recognition failed: {error}").format(
+                    error=str(e)
+                )
+            ) from e
+
+    # ── Shared helpers ──
+
+    @classmethod
+    def _raise_network_error(cls, exc: Exception):
+        if hasattr(exc, "response") and exc.response is not None:
+            status = exc.response.status_code
+            if status == 401:
+                raise OcrAuthenticationError(
+                    _("GLM-OCR API key is invalid or expired.")
+                ) from exc
+            if status == 429:
+                raise OcrProcessingError(
+                    _(
+                        "GLM-OCR API quota exceeded. "
+                        "Please top up your Zhipu account."
+                    )
+                ) from exc
+            try:
+                data = exc.response.json()
+                msg = (
+                    data.get("error", {}).get("message", "")
+                    or data.get("message", "")
+                )
+                if msg:
+                    raise OcrProcessingError(
+                        _("GLM-OCR API error: ") + msg
+                    ) from exc
+            except (ValueError, AttributeError):
+                pass
+        raise OcrNetworkError(
+            _("A network error occurred while calling the GLM-OCR API.")
+        ) from exc
+
+    @classmethod
+    def recognize(cls, ocr_request: OcrRequest) -> OcrResult:
+        """Perform OCR using GLM-OCR in the configured mode."""
+        cls.rate_limiter.wait_for_permission()
+        mode = cls._get_mode()
+
+        if mode == GlmOcrMode.OLLAMA:
+            recognized_text = cls._recognize_ollama(ocr_request)
+        elif mode == GlmOcrMode.LOCAL:
+            recognized_text = cls._recognize_local(ocr_request)
+        else:
+            recognized_text = cls._recognize_cloud(ocr_request)
+
+        return OcrResult(
+            recognized_text=recognized_text,
+            ocr_request=ocr_request,
+        )


### PR DESCRIPTION
## Summary

- Add GLM-OCR (Zhipu) as a new OCR engine with three deployment modes: Cloud API, Ollama local, and self-hosted
- Smart batch OCR for large PDFs: detect text layers locally (milliseconds), only OCR scanned pages
- Inline semantic navigation on OCR'd pages (H/T/K keys for headings/tables/links)
- Markdown post-processing pipeline inspired by 42md architecture
- Single-page PDF extraction for Cloud API (no full-file upload needed)
- 2 parallel workers with staggered start and 429 exponential backoff

## Changes

### New files
- `bookworm/ocr_engines/glm_ocr.py` — GLM-OCR engine with cloud/Ollama/local modes, smart batch OCR, post-processing pipeline

### Modified files
- `bookworm/ocr_engines/__init__.py` — Register GlmOcrEngine
- `bookworm/ocr/__init__.py` — Add config keys (API key, mode, Ollama host)
- `bookworm/ocr/ocr_dialogs.py` — Settings UI for GLM-OCR
- `bookworm/ocr/ocr_menu.py` — Inline OCR display with semantic navigation, page cache, smart batch for full-document OCR
- `bookworm/document/base.py` — Allow injecting semantic structure into page objects

## Test plan

- [ ] Select GLM-OCR engine in OCR settings
- [ ] Cloud mode: fill API key, press F4 on a PDF page
- [ ] Ollama mode: `ollama pull glm-ocr && ollama serve`, press F4
- [ ] Verify tables display as aligned columns, headings without # markers
- [ ] Verify H/T keys navigate headings/tables on OCR'd pages
- [ ] Verify page cache: flip away and back, content restores instantly
- [ ] Full-document OCR: Scan To Text File outputs .md with all pages
- [ ] Large PDF (>50MB): smart batch detects text layers, chunks OCR pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)