### PR TITLE
Add embedded image navigation and viewer support

### DIFF
--- a/alembic/versions/b743b2dbd3a1_add_text_model_version_columns.py
+++ b/alembic/versions/b743b2dbd3a1_add_text_model_version_columns.py
@@ -1,0 +1,56 @@
+"""add_text_model_version_columns
+
+Revision ID: b743b2dbd3a1
+Revises: 707543f03b6d
+Create Date: 2026-05-19 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b743b2dbd3a1"
+down_revision: str | None = "707543f03b6d"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    for table_name in (
+        "book",
+        "document_position_info",
+        "recent_document",
+        "pinned_document",
+    ):
+        op.add_column(
+            table_name,
+            sa.Column("content_hash_version", sa.Integer(), nullable=True),
+        )
+
+    op.add_column(
+        "document_position_info",
+        sa.Column("position_version", sa.Integer(), nullable=True),
+    )
+    for table_name in ("bookmark", "note", "quote"):
+        op.add_column(
+            table_name,
+            sa.Column("position_version", sa.Integer(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    for table_name in ("quote", "note", "bookmark"):
+        op.drop_column(table_name, "position_version")
+    op.drop_column("document_position_info", "position_version")
+
+    for table_name in (
+        "pinned_document",
+        "recent_document",
+        "document_position_info",
+        "book",
+    ):
+        op.drop_column(table_name, "content_hash_version")

--- a/bookworm/annotation/__init__.py
+++ b/bookworm/annotation/__init__.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 
 import wx
 
@@ -45,23 +44,17 @@ class AnnotationService(BookwormService):
 
     def __post_init__(self):
         self.__state = {}
-        self.view.contentTextCtrl.Bind(
-            wx.EVT_KEY_UP, self.onKeyUp, self.view.contentTextCtrl
-        )
+        self.view.contentTextCtrl.Bind(wx.EVT_KEY_UP, self.onKeyUp, self.view.contentTextCtrl)
         self.view.Bind(
             self.view.contentTextCtrl.EVT_CARET,
             self.onCaretMoved,
             id=self.view.contentTextCtrl.GetId(),
         )
-        self.view.add_load_handler(
-            lambda red: wx.CallAfter(self._check_is_virtual, red)
-        )
+        self.view.add_load_handler(lambda red: wx.CallAfter(self._check_is_virtual, red))
         reader_book_loaded.connect(self.on_book_load, sender=self.reader)
         reader_book_unloaded.connect(self.on_book_unload, sender=self.reader)
         reader_page_changed.connect(self.comments_page_handler, sender=self.reader)
-        reader_page_changed.connect(
-            self.highlight_bookmarked_positions, sender=self.reader
-        )
+        reader_page_changed.connect(self.highlight_bookmarked_positions, sender=self.reader)
         reader_page_changed.connect(self.highlight_highlighted_text, sender=self.reader)
 
     def process_menubar(self, menubar):
@@ -142,9 +135,12 @@ class AnnotationService(BookwormService):
                 speech.announce(no_annotation_msg)
                 sounds.invalid.play()
                 return
-            self.reader.go_to_page(bookmark.page_number, bookmark.position)
+            bookmark_position = self.reader.storage_to_view_position(
+                bookmark.position, bookmark.page_number
+            )
+            self.reader.go_to_page(bookmark.page_number, bookmark_position)
             if config.conf["annotation"]["select_bookmarked_line_on_jumping"]:
-                self.view.select_text(*self.view.get_containing_line(bookmark.position))
+                self.view.select_text(*self.view.get_containing_line(bookmark_position))
             # Translators: spoken message when jumping to a bookmark
             msg = _("Bookmark")
             if bookmark.title:
@@ -154,7 +150,7 @@ class AnnotationService(BookwormService):
             )
             reading_position_change.send(
                 self.view,
-                position=bookmark.position,
+                position=bookmark_position,
                 text_to_announce=text_to_announce,
                 tts_speech_prefix=msg,
             )
@@ -174,19 +170,32 @@ class AnnotationService(BookwormService):
                 return
             start_pos, end_pos = (comment.start_pos, comment.end_pos)
             is_whole_line = (start_pos, end_pos) == (None, None)
+            if is_whole_line:
+                comment_position = self.reader.storage_to_view_position(
+                    comment.position, comment.page_number
+                )
+                target_position = comment_position
+                display_range = None
+            else:
+                display_range = self.reader.storage_to_view_range(
+                    start_pos,
+                    end_pos,
+                    comment.page_number,
+                )
+                comment_position = display_range.stop
+                target_position = comment_position
             self.reader.go_to_page(
-                comment.page_number, comment.position if is_whole_line else end_pos
+                comment.page_number,
+                target_position,
             )
             # We do not select whole line comments, See issue#332
             if not is_whole_line:
-                self.view.select_text(start_pos, end_pos)
+                self.view.select_text(display_range.start, display_range.stop)
             reading_position_change.send(
                 self.view,
-                position=comment.position if is_whole_line else end_pos,
+                position=target_position,
                 # Translators: spoken message when jumping to a comment
-                text_to_announce=_("Comment: {comment}").format(
-                    comment=comment.content
-                ),
+                text_to_announce=_("Comment: {comment}").format(comment=comment.content),
             )
             sounds.navigation.play()
         elif event.KeyCode == wx.WXK_F9:
@@ -205,11 +214,16 @@ class AnnotationService(BookwormService):
                 speech.announce(no_annotation_msg)
                 sounds.invalid.play()
                 return
-            self.reader.go_to_page(highlight.page_number, highlight.start_pos)
-            self.view.select_text(highlight.start_pos, highlight.end_pos)
+            display_range = self.reader.storage_to_view_range(
+                highlight.start_pos,
+                highlight.end_pos,
+                highlight.page_number,
+            )
+            self.reader.go_to_page(highlight.page_number, display_range.start)
+            self.view.select_text(display_range.start, display_range.stop)
             reading_position_change.send(
                 self.view,
-                position=highlight.start_pos,
+                position=display_range.start,
                 text_to_announce=_("Highlight"),
             )
             sounds.navigation.play()
@@ -224,31 +238,49 @@ class AnnotationService(BookwormService):
         if not self.reader.ready:
             return
         # Convert the real position from the event to a clean position.
-        # We assume TEXT_CTRL_OFFSET is 1. Using a hardcoded 1 is robust here.
-        clean_position = event.Position - 1
+        clean_position = (
+            self.view.control_to_view_position(event.Position)
+            if hasattr(self.view, "control_to_view_position")
+            else event.Position - 1
+        )
         if clean_position < 0:
             return
         evtdata = {}
         start, end = self.view.get_containing_line(clean_position)
         pos_range = range(start, end)
         for bookmark in Bookmarker(self.reader).get_for_page():
-            if bookmark.position in pos_range:
+            bookmark_position = self.reader.storage_to_view_position(
+                bookmark.position, bookmark.page_number
+            )
+            if bookmark_position in pos_range:
                 evtdata["bookmark"] = True
                 break
         for highlight in Quoter(self.reader).get_for_page():
-            if highlight.start_pos <= clean_position < highlight.end_pos:
+            display_range = self.reader.storage_to_view_range(
+                highlight.start_pos,
+                highlight.end_pos,
+                highlight.page_number,
+            )
+            if display_range.start <= clean_position < display_range.stop:
                 evtdata["highlight"] = True
                 break
-            elif highlight.start_pos in pos_range:
+            if display_range.start in pos_range:
                 evtdata["line_contains_highlight"] = True
                 break
         for comment in NoteTaker(self.reader).get_for_page():
             start_pos, end_pos = (comment.start_pos, comment.end_pos)
-            condition = (
-                (start_pos <= clean_position < end_pos)
-                if (start_pos, end_pos) != (None, None)
-                else comment.position in pos_range
-            )
+            if (start_pos, end_pos) != (None, None):
+                display_range = self.reader.storage_to_view_range(
+                    start_pos,
+                    end_pos,
+                    comment.page_number,
+                )
+                condition = display_range.start <= clean_position < display_range.stop
+            else:
+                condition = (
+                    self.reader.storage_to_view_position(comment.position, comment.page_number)
+                    in pos_range
+                )
             if condition:
                 evtdata["comment"] = True
         wx.CallAfter(self._process_caret_move, evtdata)
@@ -256,13 +288,9 @@ class AnnotationService(BookwormService):
     def _process_caret_move(self, evtdata):
         if not any(evtdata.values()):
             return
-        if config.conf["annotation"][
-            "audable_indication_of_annotations_when_navigating_text"
-        ]:
+        if config.conf["annotation"]["audable_indication_of_annotations_when_navigating_text"]:
             sounds.navigation.play()
-        if config.conf["annotation"][
-            "spoken_indication_of_annotations_when_navigating_text"
-        ]:
+        if config.conf["annotation"]["spoken_indication_of_annotations_when_navigating_text"]:
             to_speak = []
             if "bookmark" in evtdata:
                 # Translators: spoken message indicating the presence of an annotation when the user navigates the text
@@ -281,17 +309,14 @@ class AnnotationService(BookwormService):
 
     def get_annotation(self, annotator_cls, *, foreword):
         if not (annotator := self.__state.get(annotator_cls.__name__)):
-            annotator = self.__state.setdefault(
-                annotator_cls.__name__, annotator_cls(self.reader)
-            )
+            annotator = self.__state.setdefault(annotator_cls.__name__, annotator_cls(self.reader))
         page_number = self.reader.current_page
-        # start, end = self.view.get_containing_line(self.view.get_insertion_point())
         start = self.view.get_insertion_point()
-        end = start
+        storage_start = self.reader.view_to_storage_position(start, page_number)
         if foreword:
-            annot = annotator.get_first_after(page_number, end)
+            annot = annotator.get_first_after(page_number, storage_start)
         else:
-            annot = annotator.get_first_before(page_number, start)
+            annot = annotator.get_first_before(page_number, storage_start)
         return annot
 
     def _check_is_virtual(self, sender):
@@ -314,12 +339,13 @@ class AnnotationService(BookwormService):
         comments = NoteTaker(sender)
         comments = comments.get_for_page()
         if comments.count():
-            if config.conf["annotation"][
-                "audable_indication_of_annotations_when_navigating_text"
-            ]:
+            if config.conf["annotation"]["audable_indication_of_annotations_when_navigating_text"]:
                 wx.CallLater(150, lambda: sounds.has_note.play())
         for comment in comments:
-            cls.style_comment(sender.view, comment.position)
+            comment_position = sender.storage_to_view_position(
+                comment.position, comment.page_number
+            )
+            cls.style_comment(sender.view, comment_position)
 
     @classmethod
     def highlight_bookmarked_positions(cls, sender, current, prev):
@@ -331,7 +357,10 @@ class AnnotationService(BookwormService):
         if not bookmarks.count():
             return
         for bookmark in bookmarks:
-            cls.style_bookmark(sender.view, bookmark.position)
+            bookmark_position = sender.storage_to_view_position(
+                bookmark.position, bookmark.page_number
+            )
+            cls.style_bookmark(sender.view, bookmark_position)
 
     @classmethod
     def highlight_highlighted_text(cls, sender, current, prev):
@@ -344,7 +373,12 @@ class AnnotationService(BookwormService):
         if not for_page.count():
             return
         for quote in for_page:
-            cls.style_highlight(sender.view, quote.start_pos, quote.end_pos)
+            display_range = sender.storage_to_view_range(
+                quote.start_pos,
+                quote.end_pos,
+                quote.page_number,
+            )
+            cls.style_highlight(sender.view, display_range.start, display_range.stop)
 
     @staticmethod
     @gui_thread_safe
@@ -359,11 +393,20 @@ class AnnotationService(BookwormService):
         # We need a new TextAttr object to avoid modifying a shared default style.
         new_attr = wx.TextAttr()
         # We must get the existing style from the REAL position to preserve other attributes.
-        # We assume TEXT_CTRL_OFFSET is 1.
-        view.contentTextCtrl.GetStyle(start + 1, new_attr)
+        real_start = (
+            view.view_to_control_position(start)
+            if hasattr(view, "view_to_control_position")
+            else start + 1
+        )
+        real_end = (
+            view.view_to_control_position(end)
+            if hasattr(view, "view_to_control_position")
+            else end + 1
+        )
+        view.contentTextCtrl.GetStyle(real_start, new_attr)
         new_attr.SetFontUnderlined(enable)
         # We must apply the new style to the REAL, offset positions.
-        view.contentTextCtrl.SetStyle(start + 1, end + 1, new_attr)
+        view.contentTextCtrl.SetStyle(real_start, real_end, new_attr)
 
     @staticmethod
     @gui_thread_safe

--- a/bookworm/annotation/__init__.py
+++ b/bookworm/annotation/__init__.py
@@ -26,13 +26,13 @@ log = logger.getChild(__name__)
 
 
 ANNOTATION_CONFIG_SPEC = {
-    "annotation": dict(
-        use_visuals="boolean(default=True)",
-        select_bookmarked_line_on_jumping="boolean(default=True)",
-        speak_bookmarks_on_jumping="boolean(default=True)",
-        audable_indication_of_annotations_when_navigating_text="boolean(default=True)",
-        spoken_indication_of_annotations_when_navigating_text="boolean(default=True)",
-    )
+    "annotation": {
+        "use_visuals": "boolean(default=True)",
+        "select_bookmarked_line_on_jumping": "boolean(default=True)",
+        "speak_bookmarks_on_jumping": "boolean(default=True)",
+        "audable_indication_of_annotations_when_navigating_text": "boolean(default=True)",
+        "spoken_indication_of_annotations_when_navigating_text": "boolean(default=True)",
+    }
 }
 
 

--- a/bookworm/annotation/annotation_dialogs.py
+++ b/bookworm/annotation/annotation_dialogs.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 
 from dataclasses import dataclass
 
@@ -69,15 +68,11 @@ class ViewAndEditAnnotationDialog(SimpleDialog):
         if not self.editable:
             # Translators: label of an edit control in a dialog to view/edit comments/highlights
             wx.StaticText(metadataBox, -1, _("Date Created"))
-            self.createdText = wx.TextCtrl(
-                metadataBox, -1, style=wx.TE_READONLY | wx.TE_MULTILINE
-            )
+            self.createdText = wx.TextCtrl(metadataBox, -1, style=wx.TE_READONLY | wx.TE_MULTILINE)
             self.createdText.SetSizerProps(expand=True)
             # Translators: label of an edit control in a dialog to view/edit comments/highlights
             wx.StaticText(metadataBox, -1, _("Last updated"))
-            self.updatedText = wx.TextCtrl(
-                metadataBox, -1, style=wx.TE_READONLY | wx.TE_MULTILINE
-            )
+            self.updatedText = wx.TextCtrl(metadataBox, -1, style=wx.TE_READONLY | wx.TE_MULTILINE)
             self.updatedText.SetSizerProps(expand=True)
         if self.editable:
             self.Bind(wx.EVT_BUTTON, self.onOk, id=wx.ID_OK)
@@ -131,13 +126,9 @@ class BookmarksViewer(SimpleDialog):
         self.annotationsListCtrl = ImmutableObjectListView(parent, wx.ID_ANY)
         # Translators: text of a button to remove bookmarks
         wx.Button(parent, wx.ID_DELETE, _("&Remove"))
-        self.Bind(
-            wx.EVT_LIST_ITEM_ACTIVATED, self.onItemClick, self.annotationsListCtrl
-        )
+        self.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self.onItemClick, self.annotationsListCtrl)
         self.Bind(wx.EVT_LIST_KEY_DOWN, self.onKeyDown, self.annotationsListCtrl)
-        self.Bind(
-            wx.EVT_LIST_END_LABEL_EDIT, self.onEndLabelEdit, self.annotationsListCtrl
-        )
+        self.Bind(wx.EVT_LIST_END_LABEL_EDIT, self.onEndLabelEdit, self.annotationsListCtrl)
         self.Bind(wx.EVT_BUTTON, self.onDelete, id=wx.ID_DELETE)
         wx.FindWindowById(wx.ID_DELETE).Enable(False)
         self._populate_list()
@@ -180,7 +171,8 @@ class BookmarksViewer(SimpleDialog):
             return
         self.reader.go_to_page(item.page_number)
         self.Close()
-        wx.CallAfter(self.parent.set_insertion_point, item.position)
+        display_position = self.reader.storage_to_view_position(item.position, item.page_number)
+        wx.CallAfter(self.parent.set_insertion_point, display_position)
 
     def onKeyDown(self, event):
         item = self.annotationsListCtrl.get_selected()
@@ -190,10 +182,7 @@ class BookmarksViewer(SimpleDialog):
         kcode = event.GetKeyCode()
         if kcode == wx.WXK_F2:
             editCtrl = self.annotationsListCtrl.EditLabel(selected_idx)
-            if (
-                self.annotationsListCtrl.GetItemText(selected_idx)
-                == self._unamed_bookmark_title
-            ):
+            if self.annotationsListCtrl.GetItemText(selected_idx) == self._unamed_bookmark_title:
                 editCtrl.SetValue("")
         elif kcode == wx.WXK_DELETE:
             self.onDelete(event)
@@ -229,15 +218,14 @@ class BookmarksViewer(SimpleDialog):
             self.annotator.delete(item.id)
             self._populate_list()
             if page_number == self.reader.current_page:
-                AnnotationService.style_bookmark(self.Parent, pos, enable=False)
+                display_position = self.reader.storage_to_view_position(pos, page_number)
+                AnnotationService.style_bookmark(self.Parent, display_position, enable=False)
 
 
 class AnnotationFilterPanel(sc.SizedPanel):
     """Filter by several criteria."""
 
-    def __init__(
-        self, *args, annotator, filter_callback, filter_by_book=False, **kwargs
-    ):
+    def __init__(self, *args, annotator, filter_callback, filter_by_book=False, **kwargs):
         super().__init__(*args, **kwargs)
         self.SetSizerProps(expand=True)
         self.SetSizerType("horizontal")
@@ -278,9 +266,7 @@ class AnnotationFilterPanel(sc.SizedPanel):
                 self.bookChoice.Append(book.title, book.id)
         else:
             self.sectionChoice.Clear()
-            self.sectionChoice.AppendItems(
-                [s[0] for s in self.annotator.get_sections()]
-            )
+            self.sectionChoice.AppendItems([s[0] for s in self.annotator.get_sections()])
         self.tagsCombo.Clear()
         self.tagsCombo.AppendItems(self.annotator.get_tags())
 
@@ -317,9 +303,7 @@ class AnnotationWithContentDialog(SimpleDialog):
             # Translators: the title of a column in the comments/highlights list
             ColumnDefn("Page", "center", 150, lambda anot: anot.page_number + 1),
             # Translators: the title of a column in the comments/highlights list
-            ColumnDefn(
-                "Added", "right", 200, lambda a: format_datetime(a.date_created)
-            ),
+            ColumnDefn("Added", "right", 200, lambda a: format_datetime(a.date_created)),
         )
 
     def __init__(self, reader, annotator_cls, *args, can_edit=False, **kwargs):
@@ -391,9 +375,7 @@ class AnnotationWithContentDialog(SimpleDialog):
         self.set_items()
 
     def get_items(self):
-        getter_func = (
-            self.annotator.get_for_book if self.reader.ready else self.annotator.get_all
-        )
+        getter_func = self.annotator.get_for_book if self.reader.ready else self.annotator.get_all
         return getter_func(
             self._filter_and_sort_state.filter_criteria,
             self._filter_and_sort_state.sort_criteria,
@@ -426,9 +408,7 @@ class AnnotationWithContentDialog(SimpleDialog):
     def onSortToggle(self, event):
         if event.IsChecked():
             event.GetEventObject().SetValue(False)
-            self._filter_and_sort_state.sort_criteria = self._sort_toggles[
-                event.GetEventObject()
-            ]
+            self._filter_and_sort_state.sort_criteria = self._sort_toggles[event.GetEventObject()]
         self.on_filter_and_sort_state_changed()
 
     def onSortMethodToggle(self, event):
@@ -469,9 +449,7 @@ class AnnotationWithContentDialog(SimpleDialog):
         if (
             wx.MessageBox(
                 # Translators: content of a message asking the user if they want to delete a comment/highlight
-                _(
-                    "This action can not be reverted.\nAre you sure you want to remove this item?"
-                ),
+                _("This action can not be reverted.\nAre you sure you want to remove this item?"),
                 # Translators: title of a message asking the user if they want to delete a bookmark
                 _("Delete Annotation?"),
                 parent=self,
@@ -510,9 +488,7 @@ class AnnotationWithContentDialog(SimpleDialog):
                     copy_to_clipboard(item.content)
                     sounds.clipboard.play()
             except:
-                log.exception(
-                    "Failed to copy annotation text to the clipboard", evc_info=True
-                )
+                log.exception("Failed to copy annotation text to the clipboard", evc_info=True)
         event.Skip()
 
     def edit_tags(self, item):
@@ -539,9 +515,7 @@ class AnnotationWithContentDialog(SimpleDialog):
             self.export_items(renderer_cls, items, export_options, open_after_export)
 
     def export_items(self, renderer_cls, items, export_options, open_after_export):
-        renderer = renderer_cls(
-            items, export_options, self._filter_and_sort_state.filter_criteria
-        )
+        renderer = renderer_cls(items, export_options, self._filter_and_sort_state.filter_criteria)
         resulting_file = renderer.render_to_file()
         if open_after_export:
             wx.LaunchDefaultApplication(resulting_file)
@@ -552,9 +526,7 @@ class GenericAnnotationWithContentDialog(AnnotationWithContentDialog):
     def column_defn(cls):
         column_defn = list(super().column_defn())
         # Translators: the title of a column in the comments/highlights list
-        column_defn.insert(
-            1, ColumnDefn(_("Book"), "left", 300, lambda a: a.book.title)
-        )
+        column_defn.insert(1, ColumnDefn(_("Book"), "left", 300, lambda a: a.book.title))
         return column_defn
 
     def set_default_state(self):
@@ -563,11 +535,21 @@ class GenericAnnotationWithContentDialog(AnnotationWithContentDialog):
 
     def go_to_item(self, item):
         def book_load_callback():
-            super(GenericAnnotationWithContentDialog, self).go_to_item(item)
+            loaded_item = self.annotator_cls(self.service.reader).get(item.id) or item
+            super(GenericAnnotationWithContentDialog, self).go_to_item(loaded_item)
             if isinstance(self.annotator, NoteTaker):
-                self.service.view.set_insertion_point(item.position)
+                self.service.view.set_insertion_point(
+                    self.service.reader.storage_to_view_position(
+                        loaded_item.position, loaded_item.page_number
+                    )
+                )
             else:
-                self.service.view.select_text(item.start_pos, item.end_pos)
+                display_range = self.service.reader.storage_to_view_range(
+                    loaded_item.start_pos,
+                    loaded_item.end_pos,
+                    loaded_item.page_number,
+                )
+                self.service.view.select_text(display_range.start, display_range.stop)
 
         new_uri = item.book.uri.create_copy(view_args={"add_to_recents": False})
         self.service.view.open_uri(new_uri, callback=book_load_callback)
@@ -576,17 +558,25 @@ class GenericAnnotationWithContentDialog(AnnotationWithContentDialog):
 class CommentsDialog(AnnotationWithContentDialog):
     def go_to_item(self, item):
         super().go_to_item(item)
-        self.service.view.set_insertion_point(item.position)
+        self.service.view.set_insertion_point(
+            self.service.reader.storage_to_view_position(item.position, item.page_number)
+        )
         start_pos, end_pos = (item.start_pos, item.end_pos)
         if (start_pos, end_pos) != (None, None):
             # We have a selection, let's select the text
-            self.service.view.select_text(start_pos, end_pos)
+            display_range = self.service.reader.storage_to_view_range(
+                start_pos, end_pos, item.page_number
+            )
+            self.service.view.select_text(display_range.start, display_range.stop)
 
 
 class QuotesDialog(AnnotationWithContentDialog):
     def go_to_item(self, item):
         super().go_to_item(item)
-        self.service.view.select_text(item.start_pos, item.end_pos)
+        display_range = self.service.reader.storage_to_view_range(
+            item.start_pos, item.end_pos, item.page_number
+        )
+        self.service.view.select_text(display_range.start, display_range.stop)
 
 
 class ExportNotesDialog(SimpleDialog):
@@ -612,14 +602,10 @@ class ExportNotesDialog(SimpleDialog):
         self.includeTagsCheckbox = wx.CheckBox(parent, -1, _("Include tags"))
         # Translators: label of a choice control in a dialog to set export options for comments/highlights
         wx.StaticText(parent, -1, _("Output format:"))
-        self.formatChoice = wx.Choice(
-            parent, -1, choices=[r.display_name for r in renderers]
-        )
+        self.formatChoice = wx.Choice(parent, -1, choices=[r.display_name for r in renderers])
         # Translators: label of an edit control in a dialog to set export options for comments/highlights
         wx.StaticText(parent, -1, _("Output File"))
-        self.outputFileTextCtrl = wx.TextCtrl(
-            parent, -1, style=wx.TE_READONLY | wx.TE_MULTILINE
-        )
+        self.outputFileTextCtrl = wx.TextCtrl(parent, -1, style=wx.TE_READONLY | wx.TE_MULTILINE)
         # Translators: text of a button in a dialog to set export options for comments/highlights
         browseButton = wx.Button(parent, -1, _("&Browse"))
         self.openAfterExportCheckBox = wx.CheckBox(

--- a/bookworm/annotation/annotation_dialogs.py
+++ b/bookworm/annotation/annotation_dialogs.py
@@ -96,7 +96,7 @@ class ViewAndEditAnnotationDialog(SimpleDialog):
 
     def get_values(self):
         tags = [t.strip() for t in self.tagsText.GetValue().split()]
-        return dict(content=self.contentText.GetValue().strip(), tags=tags)
+        return {"content": self.contentText.GetValue().strip(), "tags": tags}
 
     def onOk(self, event):
         self.__saving = True

--- a/bookworm/annotation/annotation_gui.py
+++ b/bookworm/annotation/annotation_gui.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 
 from enum import IntEnum
 
@@ -7,7 +6,7 @@ import wx
 from bookworm import speech
 from bookworm.gui.settings import SettingsPanel
 from bookworm.logger import logger
-from bookworm.structured_text import TextRange
+from bookworm.structured_text import CURRENT_POSITION_MODEL_VERSION
 
 from .annotation_dialogs import (
     BookmarksViewer,
@@ -149,40 +148,30 @@ class AnnotationMenu(wx.Menu):
         # Translators: the label of an item in the application menubar
 
         # EventHandlers
-        self.view.Bind(
-            wx.EVT_MENU, self.onAddBookmark, id=AnnotationsMenuIds.addBookmark
-        )
-        self.view.Bind(
-            wx.EVT_MENU, self.onAddNamedBookmark, id=AnnotationsMenuIds.addNamedBookmark
-        )
+        self.view.Bind(wx.EVT_MENU, self.onAddBookmark, id=AnnotationsMenuIds.addBookmark)
+        self.view.Bind(wx.EVT_MENU, self.onAddNamedBookmark, id=AnnotationsMenuIds.addNamedBookmark)
         self.view.Bind(wx.EVT_MENU, self.onAddNote, id=AnnotationsMenuIds.addNote)
-        self.view.Bind(
-            wx.EVT_MENU, self.onQuoteSelection, id=AnnotationsMenuIds.quoteSelection
-        )
-        self.view.Bind(
-            wx.EVT_MENU, self.onViewBookmarks, id=AnnotationsMenuIds.viewBookmarks
-        )
-        self.view.Bind(
-            wx.EVT_MENU, self.onViewNotes, id=StatelessAnnotationsMenuIds.viewNotes
-        )
-        self.view.Bind(
-            wx.EVT_MENU, self.onViewQuotes, id=StatelessAnnotationsMenuIds.viewQuotes
-        )
+        self.view.Bind(wx.EVT_MENU, self.onQuoteSelection, id=AnnotationsMenuIds.quoteSelection)
+        self.view.Bind(wx.EVT_MENU, self.onViewBookmarks, id=AnnotationsMenuIds.viewBookmarks)
+        self.view.Bind(wx.EVT_MENU, self.onViewNotes, id=StatelessAnnotationsMenuIds.viewNotes)
+        self.view.Bind(wx.EVT_MENU, self.onViewQuotes, id=StatelessAnnotationsMenuIds.viewQuotes)
 
     def _add_bookmark(self, name=""):
         bookmarker = Bookmarker(self.reader)
         insertionPoint = self.view.get_insertion_point()
+        storage_insertion_point = self.reader.view_to_storage_position(insertionPoint)
         current_lino = self.view.get_line_number(insertionPoint)
         count = 0
         for bkm in bookmarker.get_for_page(self.reader.current_page):
-            lino = self.view.get_line_number(bkm.position)
+            bookmark_position = self.reader.storage_to_view_position(bkm.position, bkm.page_number)
+            lino = self.view.get_line_number(bookmark_position)
             if lino == current_lino:
                 count += 1
                 bookmarker.delete(bkm.id)
-                self.service.style_bookmark(self.view, bkm.position, enable=False)
+                self.service.style_bookmark(self.view, bookmark_position, enable=False)
         if count and not name:
             return speech.announce(_("Bookmark removed"))
-        Bookmarker(self.reader).create(title=name, position=insertionPoint)
+        Bookmarker(self.reader).create(title=name, position=storage_insertion_point)
         # Translators: spoken message
         speech.announce(_("Bookmark Added"))
         self.service.style_bookmark(self.view, insertionPoint)
@@ -203,15 +192,27 @@ class AnnotationMenu(wx.Menu):
     def onAddNote(self, event):
         _with_tags = wx.GetKeyState(wx.WXK_SHIFT)
         insertionPoint = self.view.get_insertion_point()
+        storage_insertion_point = self.reader.view_to_storage_position(insertionPoint)
         selection_range = self.view.get_selection_range()
         start_pos, end_pos = selection_range.start, selection_range.stop
         # if start_pos and end_pos are equal, there is no selection
         # see: https://docs.wxpython.org/wx.TextEntry.html#wx.TextEntry.GetSelection
+        storage_start_pos = None
+        storage_end_pos = None
         if start_pos == end_pos:
             start_pos, end_pos = (None, None)
+        else:
+            storage_start_pos, storage_end_pos = self.reader.view_to_storage_range(
+                start_pos,
+                end_pos,
+                self.reader.current_page,
+            ).astuple()
         comments = NoteTaker(self.reader)
         if comments.overlaps(
-            start_pos, end_pos, self.reader.current_page, insertionPoint
+            storage_start_pos,
+            storage_end_pos,
+            self.reader.current_page,
+            storage_insertion_point,
         ):
             return self.view.notify_user(
                 _("Error"),
@@ -226,13 +227,13 @@ class AnnotationMenu(wx.Menu):
             style=wx.OK | wx.CANCEL | wx.TE_MULTILINE | wx.CENTER,
         )
         if not comment_text:
-            return
+            return None
         note = comments.create(
             title="",
             content=comment_text,
-            position=insertionPoint,
-            start_pos=start_pos,
-            end_pos=end_pos,
+            position=storage_insertion_point,
+            start_pos=storage_start_pos,
+            end_pos=storage_end_pos,
         )
 
         self.service.style_comment(self.view, insertionPoint)
@@ -256,30 +257,44 @@ class AnnotationMenu(wx.Menu):
         if x == y:
             return speech.announce(_("No selection"))
         selected_text = self.view.get_text_by_range(x, y)
+        storage_range = self.reader.view_to_storage_range(x, y, self.reader.current_page)
         for q in quoter.get_for_page():
-            q_range = TextRange(q.start_pos, q.end_pos)
+            q_range = self.reader.storage_to_view_range(q.start_pos, q.end_pos, q.page_number)
             if (q_range.start == x) and (q_range.stop == y):
                 quoter.delete(q.id)
                 self.service.style_highlight(self.view, x, y, enable=False)
                 # Translators: spoken message
                 return speech.announce(_("Highlight removed"))
-            elif (q.start_pos < x) and (q.end_pos > y):
+            if (q_range.start < x) and (q_range.stop > y):
                 # Translators: spoken message
                 speech.announce(_("Already highlighted"))
                 return wx.Bell()
-            if (x in q_range) or (y in q_range):
-                if x not in q_range:
-                    q.start_pos = x
+            if (q_range.start <= x < q_range.stop) or (q_range.start <= y < q_range.stop):
+                if not (q_range.start <= x < q_range.stop):
+                    q.start_pos = self.reader.view_to_storage_position(
+                        x, q.page_number, affinity="before"
+                    )
+                    q.position_version = CURRENT_POSITION_MODEL_VERSION
                     q.session.commit()
                     self.service.style_highlight(self.view, x, q_range.stop)
                     return speech.announce(_("Highlight extended"))
-                elif y not in q_range:
-                    q.end_pos = y
+                if not (q_range.start <= y < q_range.stop):
+                    q.end_pos = self.reader.view_to_storage_range(
+                        q_range.start,
+                        y,
+                        q.page_number,
+                    ).stop
+                    q.position_version = CURRENT_POSITION_MODEL_VERSION
                     q.session.commit()
                     self.service.style_highlight(self.view, q_range.start, y)
                     # Translators: spoken message
                     return speech.announce(_("Highlight extended"))
-        quote = quoter.create(title="", content=selected_text, start_pos=x, end_pos=y)
+        quote = quoter.create(
+            title="",
+            content=selected_text,
+            start_pos=storage_range.start,
+            end_pos=storage_range.stop,
+        )
         # Translators: spoken message
         speech.announce(_("Selection highlighted"))
         self.service.style_highlight(self.view, x, y)
@@ -307,9 +322,7 @@ class AnnotationMenu(wx.Menu):
             dlg.ShowModal()
 
     def onViewNotes(self, event):
-        Dialog = (
-            CommentsDialog if self.reader.ready else GenericAnnotationWithContentDialog
-        )
+        Dialog = CommentsDialog if self.reader.ready else GenericAnnotationWithContentDialog
         with Dialog(
             parent=self.view,
             title=_("Comments"),
@@ -320,9 +333,7 @@ class AnnotationMenu(wx.Menu):
             dlg.ShowModal()
 
     def onViewQuotes(self, event):
-        Dialog = (
-            QuotesDialog if self.reader.ready else GenericAnnotationWithContentDialog
-        )
+        Dialog = QuotesDialog if self.reader.ready else GenericAnnotationWithContentDialog
         with Dialog(
             parent=self.view,
             title=_("Highlights"),

--- a/bookworm/annotation/annotation_gui.py
+++ b/bookworm/annotation/annotation_gui.py
@@ -171,7 +171,7 @@ class AnnotationMenu(wx.Menu):
                 self.service.style_bookmark(self.view, bookmark_position, enable=False)
         if count and not name:
             return speech.announce(_("Bookmark removed"))
-        Bookmarker(self.reader).create(title=name, position=storage_insertion_point)
+        bookmarker.create(title=name, position=storage_insertion_point)
         # Translators: spoken message
         speech.announce(_("Bookmark Added"))
         self.service.style_bookmark(self.view, insertionPoint)

--- a/bookworm/annotation/annotator.py
+++ b/bookworm/annotation/annotator.py
@@ -124,7 +124,7 @@ class Annotator:
         )
 
     def get(self, item_id):
-        return self.model.query.get(item_id)
+        return self.session.get(self.model, item_id)
 
     def get_first_after(self, page_number, pos):
         model = self.model

--- a/bookworm/annotation/annotator.py
+++ b/bookworm/annotation/annotator.py
@@ -1,14 +1,12 @@
-# coding: utf-8
 
 from dataclasses import astuple, dataclass
 from enum import IntEnum, auto
-from typing import Optional
 
 import sqlalchemy as sa
 
-from bookworm import config
 from bookworm.database.models import Book, Bookmark, Note, Quote
 from bookworm.logger import logger
+from bookworm.structured_text import CURRENT_POSITION_MODEL_VERSION
 
 log = logger.getChild(__name__)
 # The bakery caches query objects to avoid recompiling them into strings in every call
@@ -51,14 +49,12 @@ class AnnotationSortCriteria(IntEnum):
             return query
         sort_fn = sa.asc if asc else sa.desc
         if self is AnnotationSortCriteria.Date:
-            return query.order_by(
-                sort_fn(sa.func.coalesce(model.date_updated, model.date_created))
-            )
-        elif self is AnnotationSortCriteria.Page:
+            return query.order_by(sort_fn(sa.func.coalesce(model.date_updated, model.date_created)))
+        if self is AnnotationSortCriteria.Page:
             return query.order_by(sort_fn(model.page_number))
-        elif self is AnnotationSortCriteria.Book:
+        if self is AnnotationSortCriteria.Book:
             return query.order_by(sort_fn(model.book_id))
-        elif self is AnnotationSortCriteria.Position:
+        if self is AnnotationSortCriteria.Position:
             return query.order_by(sort_fn(model.position))
 
 
@@ -75,7 +71,7 @@ class Annotator:
     @property
     def current_book(self):
         if not self.reader.ready:
-            return
+            return None
         return self.reader.get_or_create_current_book_record()
 
     @classmethod
@@ -113,9 +109,7 @@ class Annotator:
     ):
         filter_criteria = filter_criteria or AnnotationFilterCriteria()
         filter_criteria.book_id = self.current_book.id
-        return self.get_all(
-            filter_criteria=filter_criteria, sort_criteria=sort_criteria, asc=asc
-        )
+        return self.get_all(filter_criteria=filter_criteria, sort_criteria=sort_criteria, asc=asc)
 
     def get_for_page(self, page_number=None, asc=False):
         return self.model.query.filter_by(
@@ -180,6 +174,7 @@ class Annotator:
                 page_number=self.reader.current_page,
                 section_title=section_title,
                 section_identifier=self.reader.active_section.unique_identifier,
+                position_version=CURRENT_POSITION_MODEL_VERSION,
             )
         )
         annot = self.model(**kwargs)
@@ -193,6 +188,8 @@ class Annotator:
             raise LookupError(f"There is no record with id={item_id}.")
         for attr, value in kwargs.items():
             setattr(item, attr, value)
+        if {"position", "start_pos", "end_pos"}.intersection(kwargs):
+            item.position_version = CURRENT_POSITION_MODEL_VERSION
         self.session.add(item)
         self.session.commit()
 
@@ -213,9 +210,7 @@ class TaggedAnnotator(Annotator):
     @classmethod
     def get_tags(cls):
         cls.delete_orphan_tags()
-        return [
-            tag.title for tag in cls.model.Tag.query.order_by(cls.model.Tag.title).all()
-        ]
+        return [tag.title for tag in cls.model.Tag.query.order_by(cls.model.Tag.title).all()]
 
     @classmethod
     def delete_orphan_tags(cls):
@@ -230,7 +225,7 @@ class PositionedAnnotator(TaggedAnnotator):
     """Annotations which are positioned on a specific text range"""
 
     def overlaps(
-        self, start: Optional[int], end: Optional[int], page_number: int, position: int
+        self, start: int | None, end: int | None, page_number: int, position: int
     ) -> bool:
         """
         Determines whether an annotation overlaps with  a given position

--- a/bookworm/annotation/annotator.py
+++ b/bookworm/annotation/annotator.py
@@ -169,13 +169,13 @@ class Annotator:
                 self.reader.view.get_insertion_point()
             ).title
         kwargs.update(
-            dict(
-                book_id=self.current_book.id,
-                page_number=self.reader.current_page,
-                section_title=section_title,
-                section_identifier=self.reader.active_section.unique_identifier,
-                position_version=CURRENT_POSITION_MODEL_VERSION,
-            )
+            {
+                "book_id": self.current_book.id,
+                "page_number": self.reader.current_page,
+                "section_title": section_title,
+                "section_identifier": self.reader.active_section.unique_identifier,
+                "position_version": CURRENT_POSITION_MODEL_VERSION,
+            }
         )
         annot = self.model(**kwargs)
         self.session.add(annot)

--- a/bookworm/bookshelf/local_bookshelf/models.py
+++ b/bookworm/bookshelf/local_bookshelf/models.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 
 import os
 from datetime import datetime
@@ -19,7 +18,6 @@ from bookworm.i18n import LocaleInfo
 from bookworm.paths import db_path
 
 from .database import (
-    AutoCalculatedField,
     AutoOptimizedAPSWDatabase,
     BooleanField,
     DateTimeField,
@@ -94,12 +92,10 @@ class BaseModel(Model):
     @classmethod
     def perform_migrations(cls):
         database = cls._meta.database
-        user_version = (
-            database.connection().cursor().execute("pragma user_version").fetchone()[0]
-        )
+        user_version = database.connection().cursor().execute("pragma user_version").fetchone()[0]
         if user_version == BOOKWORM_BOOKSHELF_SCHEMA_VERSION:
             return
-        elif user_version == 0:
+        if user_version == 0:
             database.connection().cursor().execute(
                 f"PRAGMA user_version={BOOKWORM_BOOKSHELF_SCHEMA_VERSION}"
             )
@@ -113,7 +109,7 @@ class BaseModel(Model):
                 cursor.execute(
                     'ALTER TABLE "document" ADD COLUMN "is_currently_reading" INTEGER DEFAULT  0;'
                 )
-                cursor.execute(f"PRAGMA user_version=2")
+                cursor.execute("PRAGMA user_version=2")
         cls.perform_migrations()
 
 
@@ -200,9 +196,7 @@ class Document(BaseModel):
         backref="documents",
         null=True,
     )
-    metadata = JSONField(
-        json_dumps=ujson.dumps, json_loads=ujson.loads, null=True, default={}
-    )
+    metadata = JSONField(json_dumps=ujson.dumps, json_loads=ujson.loads, null=True, default={})
     in_reading_list = BooleanField(default=False)
     is_currently_reading = BooleanField(default=False)
 
@@ -223,9 +217,7 @@ class Document(BaseModel):
             else:
                 self.category = None
         if tags_names is not None:
-            DocumentTag.delete().where(
-                DocumentTag.document_id == self.get_id()
-            ).execute()
+            DocumentTag.delete().where(DocumentTag.document_id == self.get_id()).execute()
             for tag_name in (t.strip() for t in tags_names if t.strip()):
                 tag, is_tag_created = Tag.get_or_create(name=tag_name)
                 DocumentTag.create(document_id=self.get_id(), tag_id=tag.get_id())
@@ -246,9 +238,10 @@ class Page(BaseModel):
 
     @classmethod
     def get_text_start_position(cls, page_id, text):
-        return (
+        position = (
             cls.select(fn.ABS(fn.INSTR(cls.content, text))).where(cls.id == page_id)
         ).scalar()
+        return max(0, (position or 0) - 1)
 
 
 class DocumentAuthor(BaseModel):
@@ -359,9 +352,7 @@ class DocumentFTSIndex(BaseModel, FTS5Model):
                 cls.page_number,
                 cls.document_id,
                 cls.document_title,
-                column.snippet(
-                    left="", right="", over_length="", max_tokens=snip_length
-                ),
+                column.snippet(left="", right="", over_length="", max_tokens=snip_length),
             )
             .where(column.match(term))
             .order_by(fn.bm25(cls._meta.entity))
@@ -374,9 +365,7 @@ class DocumentFTSIndex(BaseModel, FTS5Model):
         connection = cls._meta.database.connection()
         with connection:
             cursor = connection.cursor()
-            content_matches = cursor.execute(
-                str(cls.perform_search(field_column, term))
-            )
+            content_matches = cursor.execute(str(cls.perform_search(field_column, term)))
             yielded_docs = set()
             for (
                 page_id,

--- a/bookworm/database/models.py
+++ b/bookworm/database/models.py
@@ -1,30 +1,30 @@
-# coding: utf-8
 
 """
 Database models for `Bookworm`.
 """
 
-from datetime import datetime
 import re
+from datetime import datetime
 
 import sqlalchemy as sa
 from sqlalchemy import types
 from sqlalchemy.ext.associationproxy import association_proxy
-from sqlalchemy.ext.hybrid import hybrid_method, hybrid_property
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import (
+    Query,
+    class_mapper,
+    declarative_base,
     deferred,
     relationship,
     synonym,
-    class_mapper,
-    mapper,
-    Query,
-    scoped_session,
-    declarative_base,
 )
 
 from bookworm.document.uri import DocumentUri
 from bookworm.logger import logger
+from bookworm.structured_text import (
+    CURRENT_CONTENT_HASH_VERSION,
+    CURRENT_POSITION_MODEL_VERSION,
+)
 
 log = logger.getChild(__name__)
 
@@ -54,7 +54,7 @@ class GetOrCreateMixin:
         return cls(**kwargs)
 
 
-class _QueryProperty(object):
+class _QueryProperty:
     """Convenience property to query a model."""
 
     def __get__(self, obj, type):
@@ -76,9 +76,7 @@ class Model:
         """Convert CamelCase class name to underscores_between_words 
         table name."""
         name = cls.__name__
-        return name[0].lower() + re.sub(
-            r"([A-Z])", lambda m: "_" + m.group(0).lower(), name[1:]
-        )
+        return name[0].lower() + re.sub(r"([A-Z])", lambda m: "_" + m.group(0).lower(), name[1:])
 
 
 Base = declarative_base(cls=Model)
@@ -91,6 +89,9 @@ class DocumentBase(Base, GetOrCreateMixin):
     title = sa.Column(sa.String(512), nullable=False)
     uri = sa.Column(DocumentUriDBType(1024), nullable=False, unique=True, index=True)
     content_hash = sa.Column(sa.TEXT, nullable=True)
+    content_hash_version = sa.Column(
+        sa.Integer, nullable=True, default=CURRENT_CONTENT_HASH_VERSION
+    )
 
     @classmethod
     def get_or_create(cls, *args, **kwargs):
@@ -113,6 +114,7 @@ class DocumentPositionInfo(DocumentBase):
     __tablename__ = "document_position_info"
     last_page = sa.Column(sa.Integer, default=0)
     last_position = sa.Column(sa.Integer, default=0)
+    position_version = sa.Column(sa.Integer, nullable=True, default=CURRENT_POSITION_MODEL_VERSION)
 
     def get_last_position(self):
         return (self.last_page, self.last_position)
@@ -120,14 +122,13 @@ class DocumentPositionInfo(DocumentBase):
     def save_position(self, page, pos):
         self.last_page = page
         self.last_position = pos
+        self.position_version = CURRENT_POSITION_MODEL_VERSION
         self.session.commit()
 
 
 class RecentDocument(DocumentBase):
     __tablename__ = "recent_document"
-    last_opened_on = sa.Column(
-        sa.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
-    )
+    last_opened_on = sa.Column(sa.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
     def record_open(self):
         self.last_opened_on = datetime.utcnow()
@@ -147,9 +148,7 @@ class RecentDocument(DocumentBase):
 
 class PinnedDocument(DocumentBase):
     __tablename__ = "pinned_document"
-    last_opened_on = sa.Column(
-        sa.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
-    )
+    last_opened_on = sa.Column(sa.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
     is_pinned = sa.Column(sa.Boolean, default=False)
     pinning_order = sa.Column(sa.Integer, default=0)
 
@@ -213,9 +212,7 @@ class TaggedMixin:
             # Create the Tag model
             tag_attrs = {
                 "id": sa.Column(sa.Integer, primary_key=True),
-                "title": sa.Column(
-                    sa.String(512), nullable=False, unique=True, index=True
-                ),
+                "title": sa.Column(sa.String(512), nullable=False, unique=True, index=True),
                 "items": relationship(
                     cls,
                     secondary=lambda: cls.__tags_association_table__,
@@ -243,6 +240,7 @@ class AnnotationBase(Base):
     title = sa.Column(sa.String(255), nullable=False)
     page_number = sa.Column(sa.Integer, nullable=False)
     position = sa.Column(sa.Integer, nullable=False, default=0)
+    position_version = sa.Column(sa.Integer, nullable=True, default=CURRENT_POSITION_MODEL_VERSION)
     section_title = sa.Column(sa.String(1024), nullable=False)
     section_identifier = sa.Column(sa.String(1024), nullable=False)
     date_created = sa.Column(sa.DateTime, default=datetime.utcnow)

--- a/bookworm/document/base.py
+++ b/bookworm/document/base.py
@@ -1,33 +1,37 @@
-# coding: utf-8
 
 from __future__ import annotations
 
 import gc
 from abc import ABCMeta, abstractmethod
 from collections.abc import Iterable, Sequence
-from functools import cached_property, lru_cache, wraps
+from functools import cached_property, lru_cache
 from pathlib import Path
 
-from blake3 import blake3
 import pywhatlang
+from blake3 import blake3
 from more_itertools import flatten
 from selectolax.parser import HTMLParser
 
 from bookworm import typehints as t
-from bookworm.concurrency import QueueProcess, call_threaded
+from bookworm.concurrency import QueueProcess
 from bookworm.i18n import LocaleInfo
 from bookworm.image_io import ImageIO
 from bookworm.logger import logger
-from bookworm.structured_text import SemanticElementType, Style, TextRange
+from bookworm.structured_text import (
+    CURRENT_CONTENT_HASH_VERSION,
+    SemanticElementType,
+    TEXT_OBJECT_REPLACEMENT_CHAR,
+    TextPositionMap,
+    TextRange,
+)
 from bookworm.utils import (
     get_url_spans,
-    normalize_line_breaks,
     remove_excess_blank_lines,
 )
 
 from . import operations as doctools
 from .elements import *
-from .exceptions import DocumentIOError, PaginationError, UnsupportedDocumentFormatError
+from .exceptions import DocumentIOError
 from .features import DocumentCapability, ReadingMode
 
 log = logger.getChild(__name__)
@@ -115,9 +119,7 @@ class BaseDocument(Sequence, Iterable, metaclass=ABCMeta):
 
     @cached_property
     def reading_options(self) -> ReadingOptions:
-        reading_mode = int(
-            self.uri.openner_args.get("reading_mode", ReadingMode.DEFAULT)
-        )
+        reading_mode = int(self.uri.openner_args.get("reading_mode", ReadingMode.DEFAULT))
         return ReadingOptions(
             reading_mode=ReadingMode(reading_mode),
         )
@@ -136,25 +138,95 @@ class BaseDocument(Sequence, Iterable, metaclass=ABCMeta):
         self._is_read = True
 
     @staticmethod
+    def _has_hashable_text(text: str) -> bool:
+        return bool(text.replace(TEXT_OBJECT_REPLACEMENT_CHAR, "").strip())
+
+    def iter_content_hash_images(self):
+        return ()
+
+    @staticmethod
     def _hash_document_text(text: str) -> str | None:
         normalized_text = text.strip()
-        if not normalized_text:
+        if not BaseDocument._has_hashable_text(normalized_text):
             return None
         return blake3(normalized_text.encode()).hexdigest()
 
     @staticmethod
-    def _hash_document_pages(page_texts: t.Iterable[str]) -> str | None:
+    def _update_content_hash_segment(hasher, kind: str, payload: bytes) -> None:
+        encoded_kind = kind.encode()
+        hasher.update(len(encoded_kind).to_bytes(2, "big"))
+        hasher.update(encoded_kind)
+        hasher.update(len(payload).to_bytes(8, "big"))
+        hasher.update(payload)
+
+    @classmethod
+    def _hash_document_pages_with_images(cls, pages) -> tuple[str | None, bool]:
         has_meaningful_text = False
-        hasher = blake3()
-        for page_text in page_texts:
-            encoded_text = page_text.encode()
-            if page_text.strip():
+        has_images = False
+        legacy_hasher = blake3()
+        page_records = []
+        for page_index, page in enumerate(pages):
+            storage_text = page.get_storage_text() or ""
+            encoded_text = storage_text.encode()
+            if cls._has_hashable_text(storage_text):
                 has_meaningful_text = True
-            hasher.update(len(encoded_text).to_bytes(8, "big"))
-            hasher.update(encoded_text)
+            legacy_hasher.update(len(encoded_text).to_bytes(8, "big"))
+            legacy_hasher.update(encoded_text)
+            page_records.append((page_index, storage_text, page))
         if not has_meaningful_text:
-            return None
-        return hasher.hexdigest()
+            return None, False
+        structured_hasher = blake3()
+        structured_hasher.update(
+            f"bookworm-content-hash-v{CURRENT_CONTENT_HASH_VERSION}".encode()
+        )
+        has_unresolved_images = False
+        for page_index, storage_text, page in page_records:
+            encoded_text = storage_text.encode()
+            cls._update_content_hash_segment(
+                structured_hasher,
+                "page",
+                page_index.to_bytes(8, "big"),
+            )
+            image_segments = sorted(
+                tuple(page.iter_content_hash_images()),
+                key=lambda segment: (segment[0].start, segment[0].stop),
+            )
+            if not image_segments:
+                cls._update_content_hash_segment(structured_hasher, "text", encoded_text)
+                continue
+            has_images = True
+            cursor = 0
+            text_length = len(storage_text)
+            for storage_range, image_identity in image_segments:
+                start = min(max(storage_range.start, 0), text_length)
+                stop = min(max(storage_range.stop, start), text_length)
+                if start < cursor:
+                    continue
+                cls._update_content_hash_segment(
+                    structured_hasher,
+                    "text",
+                    storage_text[cursor:start].encode(),
+                )
+                if image_identity is None:
+                    has_unresolved_images = True
+                else:
+                    kind, payload = image_identity
+                    cls._update_content_hash_segment(
+                        structured_hasher,
+                        f"image:{kind}",
+                        payload,
+                    )
+                cursor = stop
+            cls._update_content_hash_segment(
+                structured_hasher,
+                "text",
+                storage_text[cursor:].encode(),
+            )
+        if has_unresolved_images:
+            return None, has_images
+        if not has_images:
+            return legacy_hasher.hexdigest(), False
+        return structured_hasher.hexdigest(), True
 
     def get_content_hash(self) -> str | None:
         """
@@ -165,10 +237,48 @@ class BaseDocument(Sequence, Iterable, metaclass=ABCMeta):
             return self._content_hash
         if not self._is_read:
             self.read()
-        self._content_hash = self._hash_document_pages(
-            page.get_text() for page in self
-        )
+        content_hash, has_images = self._hash_document_pages_with_images(self)
+        self._content_hash = content_hash
+        self._content_hash_has_images = has_images
+        if not has_images:
+            self._legacy_content_hash = content_hash
         return self._content_hash
+
+    def _cache_legacy_content_hash_if_possible(self) -> bool:
+        if hasattr(self, "_legacy_content_hash"):
+            return True
+        if (
+            hasattr(self, "_content_hash")
+            and getattr(self, "_content_hash_has_images", None) is False
+        ):
+            self._legacy_content_hash = self._content_hash
+            return True
+        return False
+
+    @classmethod
+    def _hash_legacy_document_pages(cls, pages) -> str | None:
+        """Hash the pre-image-navigation visible text used by older records."""
+        has_meaningful_text = False
+        hasher = blake3()
+        for page in pages:
+            display_text = page.get_legacy_text() or ""
+            if cls._has_hashable_text(display_text):
+                has_meaningful_text = True
+            encoded_text = display_text.encode()
+            hasher.update(len(encoded_text).to_bytes(8, "big"))
+            hasher.update(encoded_text)
+        if not has_meaningful_text:
+            return None
+        return hasher.hexdigest()
+
+    def get_legacy_content_hash(self) -> str | None:
+        """Return the pre-storage-map hash used by older database records."""
+        if self._cache_legacy_content_hash_if_possible():
+            return self._legacy_content_hash
+        if not self._is_read:
+            self.read()
+        self._legacy_content_hash = self._hash_legacy_document_pages(self)
+        return self._legacy_content_hash
 
     def close(self) -> None:
         """Perform the actual IO operations for unloading the ebook.
@@ -183,9 +293,7 @@ class BaseDocument(Sequence, Iterable, metaclass=ABCMeta):
 
     def get_page_number_from_page_label(self, page_label):
         if DocumentCapability.PAGE_LABELS not in self.capabilities:
-            raise NotImplementedError(
-                "This feature is not enabled for this class of documents"
-            )
+            raise NotImplementedError("This feature is not enabled for this class of documents")
         for page in self:
             page_label = page_label.lower()
             if page.get_label().lower() == page_label:
@@ -270,7 +378,7 @@ class BaseDocument(Sequence, Iterable, metaclass=ABCMeta):
         try:
             lang_code, confidence, is_reliable = pywhatlang.detect_lang(samples)
         except:
-            log.error(f"Failed to recognize document language", exc_info=True)
+            log.error("Failed to recognize document language", exc_info=True)
         else:
             return LocaleInfo(lang_code).parent
         return LocaleInfo(hint_language)
@@ -303,6 +411,52 @@ class BasePage(metaclass=ABCMeta):
     @abstractmethod
     def get_text(self) -> str:
         """Return the text content or raise NotImplementedError."""
+
+    def get_storage_text(self) -> str:
+        """Return stable text for hashes and persisted positions."""
+        return self.get_text()
+
+    def get_legacy_text(self) -> str:
+        """Return the visible text model used before embedded image placeholders."""
+        return self.get_text()
+
+    def get_text_position_map(self) -> TextPositionMap:
+        return TextPositionMap.identity(len(self.get_text()))
+
+    def get_legacy_text_position_map(self) -> TextPositionMap:
+        if hasattr(self, "_legacy_text_position_map"):
+            return self._legacy_text_position_map
+        legacy_text = self.get_legacy_text()
+        storage_text = self.get_storage_text()
+        self._legacy_text_position_map = TextPositionMap.from_texts(
+            legacy_text,
+            storage_text,
+        )
+        return self._legacy_text_position_map
+
+    def iter_content_hash_images(self):
+        return ()
+
+    def display_to_storage_position(self, pos: int, affinity="before") -> int:
+        return self.get_text_position_map().display_to_storage_position(pos, affinity=affinity)
+
+    def storage_to_display_position(self, pos: int, affinity="before") -> int:
+        return self.get_text_position_map().storage_to_display_position(pos, affinity=affinity)
+
+    def display_to_storage_range(self, start: int, stop: int) -> TextRange:
+        return self.get_text_position_map().display_to_storage_range(start, stop)
+
+    def storage_to_display_range(self, start: int, stop: int) -> TextRange:
+        return self.get_text_position_map().storage_to_display_range(start, stop)
+
+    def legacy_to_storage_position(self, pos: int, affinity="before") -> int:
+        return self.get_legacy_text_position_map().display_to_storage_position(
+            pos,
+            affinity=affinity,
+        )
+
+    def legacy_to_storage_range(self, start: int, stop: int) -> TextRange:
+        return self.get_legacy_text_position_map().display_to_storage_range(start, stop)
 
     def get_image(self, zoom_factor: float) -> ImageIO:
         """
@@ -351,9 +505,7 @@ class BasePage(metaclass=ABCMeta):
             semantic_structure = self.get_semantic_structure()
         except NotImplementedError:
             semantic_structure = {}
-        semantic_link_ranges = semantic_structure.setdefault(
-            SemanticElementType.LINK, []
-        )
+        semantic_link_ranges = semantic_structure.setdefault(SemanticElementType.LINK, [])
         all_link_ranges = [
             *semantic_link_ranges,
             *(
@@ -411,6 +563,39 @@ class SinglePage(BasePage):
     def get_text(self):
         return self.document.get_content()
 
+    def get_storage_text(self):
+        return self.document.get_storage_content()
+
+    def get_legacy_text(self):
+        return self.document.get_legacy_content()
+
+    def get_text_position_map(self):
+        return self.document.get_text_position_map()
+
+    def get_legacy_text_position_map(self):
+        return self.document.get_legacy_text_position_map()
+
+    def iter_content_hash_images(self):
+        return self.document.iter_content_hash_images()
+
+    def display_to_storage_position(self, pos, affinity="before"):
+        return self.document.display_to_storage_position(pos, affinity=affinity)
+
+    def storage_to_display_position(self, pos, affinity="before"):
+        return self.document.storage_to_display_position(pos, affinity=affinity)
+
+    def display_to_storage_range(self, start, stop):
+        return self.document.display_to_storage_range(start, stop)
+
+    def storage_to_display_range(self, start, stop):
+        return self.document.storage_to_display_range(start, stop)
+
+    def legacy_to_storage_position(self, pos, affinity="before"):
+        return self.document.legacy_to_storage_position(pos, affinity=affinity)
+
+    def legacy_to_storage_range(self, start, stop):
+        return self.document.legacy_to_storage_range(start, stop)
+
     def get_semantic_structure(self):
         return self.document.get_document_semantic_structure()
 
@@ -440,11 +625,52 @@ class SinglePageDocument(BaseDocument):
     def get_content(self) -> str:
         """Get the content of this document."""
 
-    def get_content_hash(self) -> str | None:
-        if hasattr(self, "_content_hash"):
-            return self._content_hash
-        self._content_hash = self._hash_document_text(self.get_content())
-        return self._content_hash
+    def get_storage_content(self) -> str:
+        return self.get_content()
+
+    def get_legacy_content(self) -> str:
+        return self.get_content()
+
+    def get_text_position_map(self) -> TextPositionMap:
+        return TextPositionMap.identity(len(self.get_content()))
+
+    def get_legacy_text_position_map(self) -> TextPositionMap:
+        if hasattr(self, "_legacy_text_position_map"):
+            return self._legacy_text_position_map
+        self._legacy_text_position_map = TextPositionMap.from_texts(
+            self.get_legacy_content(),
+            self.get_storage_content(),
+        )
+        return self._legacy_text_position_map
+
+    def display_to_storage_position(self, pos: int, affinity="before") -> int:
+        return self.get_text_position_map().display_to_storage_position(pos, affinity=affinity)
+
+    def storage_to_display_position(self, pos: int, affinity="before") -> int:
+        return self.get_text_position_map().storage_to_display_position(pos, affinity=affinity)
+
+    def display_to_storage_range(self, start: int, stop: int) -> TextRange:
+        return self.get_text_position_map().display_to_storage_range(start, stop)
+
+    def storage_to_display_range(self, start: int, stop: int) -> TextRange:
+        return self.get_text_position_map().storage_to_display_range(start, stop)
+
+    def legacy_to_storage_position(self, pos: int, affinity="before") -> int:
+        return self.get_legacy_text_position_map().display_to_storage_position(
+            pos,
+            affinity=affinity,
+        )
+
+    def legacy_to_storage_range(self, start: int, stop: int) -> TextRange:
+        return self.get_legacy_text_position_map().display_to_storage_range(start, stop)
+
+    def get_legacy_content_hash(self) -> str | None:
+        if self._cache_legacy_content_hash_if_possible():
+            return self._legacy_content_hash
+        if not self._is_read:
+            self.read()
+        self._legacy_content_hash = self._hash_document_text(self.get_legacy_content())
+        return self._legacy_content_hash
 
     def get_page(self, index: int) -> SinglePage:
         return SinglePage(self, index)

--- a/bookworm/document/base.py
+++ b/bookworm/document/base.py
@@ -311,6 +311,14 @@ class BasePage(metaclass=ABCMeta):
         """
         raise NotImplementedError
 
+    def get_embedded_image(self, image_index: int) -> ImageIO:
+        """Return an image embedded in the page content."""
+        raise NotImplementedError
+
+    def get_embedded_image_info(self, image_index: int):
+        """Return metadata for an image embedded in the page content."""
+        raise NotImplementedError
+
     def get_label(self) -> str:
         """Return the page label string (commonly found on PDFs)."""
         return ""
@@ -409,6 +417,12 @@ class SinglePage(BasePage):
     def get_table_markup(self, table_index):
         return self.document.get_document_table_markup(table_index)
 
+    def get_embedded_image(self, image_index: int) -> ImageIO:
+        return self.document.get_document_embedded_image(image_index)
+
+    def get_embedded_image_info(self, image_index: int):
+        return self.document.get_document_embedded_image_info(image_index)
+
     def get_style_info(self):
         return self.document.get_document_style_info()
 
@@ -456,6 +470,12 @@ class SinglePageDocument(BaseDocument):
         raise NotImplementedError
 
     def get_document_table_markup(self, table_index):
+        raise NotImplementedError
+
+    def get_document_embedded_image(self, image_index: int) -> ImageIO:
+        raise NotImplementedError
+
+    def get_document_embedded_image_info(self, image_index: int):
         raise NotImplementedError
 
     def resolve_link(self, text_range):

--- a/bookworm/document/base.py
+++ b/bookworm/document/base.py
@@ -101,7 +101,7 @@ class BaseDocument(Sequence, Iterable, metaclass=ABCMeta):
 
     def __getstate__(self) -> dict:
         """Support for pickling."""
-        return dict(uri=self.uri)
+        return {"uri": self.uri}
 
     def __setstate__(self, state: dict) -> None:
         """Support for unpickling."""
@@ -577,24 +577,6 @@ class SinglePage(BasePage):
 
     def iter_content_hash_images(self):
         return self.document.iter_content_hash_images()
-
-    def display_to_storage_position(self, pos, affinity="before"):
-        return self.document.display_to_storage_position(pos, affinity=affinity)
-
-    def storage_to_display_position(self, pos, affinity="before"):
-        return self.document.storage_to_display_position(pos, affinity=affinity)
-
-    def display_to_storage_range(self, start, stop):
-        return self.document.display_to_storage_range(start, stop)
-
-    def storage_to_display_range(self, start, stop):
-        return self.document.storage_to_display_range(start, stop)
-
-    def legacy_to_storage_position(self, pos, affinity="before"):
-        return self.document.legacy_to_storage_position(pos, affinity=affinity)
-
-    def legacy_to_storage_range(self, start, stop):
-        return self.document.legacy_to_storage_range(start, stop)
 
     def get_semantic_structure(self):
         return self.document.get_document_semantic_structure()

--- a/bookworm/document/base.py
+++ b/bookworm/document/base.py
@@ -240,16 +240,19 @@ class BaseDocument(Sequence, Iterable, metaclass=ABCMeta):
         content_hash, has_images = self._hash_document_pages_with_images(self)
         self._content_hash = content_hash
         self._content_hash_has_images = has_images
-        if not has_images:
+        if self._can_reuse_content_hash_as_legacy_hash():
             self._legacy_content_hash = content_hash
         return self._content_hash
+
+    def _can_reuse_content_hash_as_legacy_hash(self) -> bool:
+        return getattr(self, "_content_hash_has_images", None) is False
 
     def _cache_legacy_content_hash_if_possible(self) -> bool:
         if hasattr(self, "_legacy_content_hash"):
             return True
         if (
             hasattr(self, "_content_hash")
-            and getattr(self, "_content_hash_has_images", None) is False
+            and self._can_reuse_content_hash_as_legacy_hash()
         ):
             self._legacy_content_hash = self._content_hash
             return True
@@ -653,6 +656,9 @@ class SinglePageDocument(BaseDocument):
             self.read()
         self._legacy_content_hash = self._hash_document_text(self.get_legacy_content())
         return self._legacy_content_hash
+
+    def _can_reuse_content_hash_as_legacy_hash(self) -> bool:
+        return False
 
     def get_page(self, index: int) -> SinglePage:
         return SinglePage(self, index)

--- a/bookworm/document/formats/epub.py
+++ b/bookworm/document/formats/epub.py
@@ -33,7 +33,14 @@ from bookworm.utils import format_datetime, is_external_url
 
 from .. import SINGLE_PAGE_DOCUMENT_PAGER, BookMetadata, ChangeDocument
 from .. import DocumentCapability as DC
-from .. import DocumentError, LinkTarget, Section, SinglePageDocument, TreeStackBuilder
+from .. import (
+    DocumentError,
+    DocumentIOError,
+    LinkTarget,
+    Section,
+    SinglePageDocument,
+    TreeStackBuilder,
+)
 
 log = logger.getChild(__name__)
 HTML_FILE_EXTS = {
@@ -134,6 +141,62 @@ class EpubDocument(SinglePageDocument):
 
     def get_document_table_markup(self, table_index):
         return self.structure.get_table_markup(table_index)
+
+    def get_document_embedded_image_info(self, image_index):
+        return self.structure.get_image_info(image_index)
+
+    def get_document_embedded_image(self, image_index) -> ImageIO:
+        image_info = self.get_document_embedded_image_info(image_index)
+        if image_info.src.lower().startswith("data:image/"):
+            try:
+                return ImageIO.from_data_uri(image_info.src)
+            except Exception as e:
+                raise DocumentIOError("Failed to decode embedded image") from e
+        parsed_src = urllib_parse.urlsplit(image_info.src)
+        if parsed_src.scheme or parsed_src.netloc:
+            raise DocumentIOError("Remote images are not supported")
+        href = urllib_parse.unquote(parsed_src.path)
+        if image_item := self.get_epub_image_item_by_href(href):
+            try:
+                return ImageIO.from_bytes(image_item.content)
+            except Exception as e:
+                raise DocumentIOError("Failed to decode embedded image") from e
+        raise DocumentIOError(f"Could not resolve embedded image: {href}")
+
+    def get_epub_image_item_by_href(self, href):
+        candidate_hrefs = (
+            href,
+            href.lstrip("./"),
+            PurePosixPath(href).as_posix(),
+            PurePosixPath(href.lstrip("./")).as_posix(),
+        )
+        for candidate in candidate_hrefs:
+            if image_item := self.epub.get_item_with_href(candidate):
+                return image_item
+        image_name = PurePosixPath(href).name
+        fallback_matches = []
+        for item in self.epub.get_items_of_type(ebooklib.ITEM_IMAGE):
+            item_path = PurePosixPath(item.file_name)
+            if (
+                self._item_path_has_href_suffix(item_path, href)
+                or item_path.name == image_name
+            ):
+                fallback_matches.append(item)
+        if len(fallback_matches) == 1:
+            return fallback_matches[0]
+
+    @staticmethod
+    def _item_path_has_href_suffix(item_path, href):
+        href_parts = tuple(
+            part for part in PurePosixPath(href).parts if part not in {"", "."}
+        )
+        if not href_parts or ".." in href_parts:
+            return False
+        item_parts = PurePosixPath(item_path).parts
+        return (
+            len(href_parts) <= len(item_parts)
+            and item_parts[-len(href_parts) :] == href_parts
+        )
 
     def resolve_link(self, link_range) -> LinkTarget:
         href = urllib_parse.unquote(self.structure.link_targets[link_range])

--- a/bookworm/document/formats/epub.py
+++ b/bookworm/document/formats/epub.py
@@ -1,15 +1,12 @@
-# coding: utf-8
 
 from __future__ import annotations
 
 import collections.abc
-import itertools
 import os
 import string
-from contextlib import suppress
 from functools import cached_property, lru_cache
 from io import StringIO
-from pathlib import Path, PurePosixPath
+from pathlib import PurePosixPath
 from urllib import parse as urllib_parse
 
 import dateparser
@@ -29,18 +26,18 @@ from bookworm.logger import logger
 from bookworm.paths import home_data_path
 from bookworm.structured_text import TextRange
 from bookworm.structured_text.structured_html_parser import StructuredHtmlParser
-from bookworm.utils import format_datetime, is_external_url
+from bookworm.utils import is_external_url
 
-from .. import SINGLE_PAGE_DOCUMENT_PAGER, BookMetadata, ChangeDocument
-from .. import DocumentCapability as DC
 from .. import (
-    DocumentError,
+    SINGLE_PAGE_DOCUMENT_PAGER,
+    BookMetadata,
     DocumentIOError,
     LinkTarget,
     Section,
     SinglePageDocument,
     TreeStackBuilder,
 )
+from .. import DocumentCapability as DC
 
 log = logger.getChild(__name__)
 HTML_FILE_EXTS = {
@@ -70,6 +67,8 @@ class EpubDocument(SinglePageDocument):
         self.epub = ebooklib.epub.read_epub(self.get_file_system_path())
         self.html_content = self.html_content
         self.structure = StructuredHtmlParser.from_string(self.html_content)
+        self._storage_text = self.structure.get_storage_text()
+        self._text_position_map = self.structure.text_position_map
         self.toc = self.parse_epub()
 
     @property
@@ -93,9 +92,7 @@ class EpubDocument(SinglePageDocument):
             desc = None
         date_value = info.get("date", "")
         if not isinstance(date_value, str):
-            log.warning(
-                f"Unexpected date format: {type(date_value)}. Converting to string."
-            )
+            log.warning(f"Unexpected date format: {type(date_value)}. Converting to string.")
             if isinstance(date_value, (int, float)):
                 date_value = str(date_value)
             else:
@@ -125,13 +122,37 @@ class EpubDocument(SinglePageDocument):
             try:
                 return LocaleInfo(epub_lang)
             except:
-                log.exception(
-                    "Failed to parse epub language `{epub_lang}`", exc_info=True
-                )
+                log.exception("Failed to parse epub language `{epub_lang}`", exc_info=True)
         return self.get_language(self.html_content, is_html=True) or LocaleInfo("en")
 
     def get_content(self):
         return self.structure.get_text()
+
+    def get_storage_content(self):
+        return self._storage_text
+
+    def get_legacy_content(self):
+        if hasattr(self, "_legacy_content"):
+            return self._legacy_content
+        self._legacy_content = StructuredHtmlParser.from_string(
+            self.html_content,
+            include_images=False,
+        ).get_text()
+        return self._legacy_content
+
+    def get_text_position_map(self):
+        return self._text_position_map
+
+    def iter_content_hash_images(self):
+        if not getattr(self, "structure", None):
+            return ()
+        return tuple(
+            (
+                storage_range,
+                self._get_embedded_image_content_hash_identity(image_info),
+            )
+            for image_info, storage_range in self.structure.iter_image_storage_ranges()
+        )
 
     def get_document_semantic_structure(self):
         return self.structure.semantic_elements
@@ -163,6 +184,22 @@ class EpubDocument(SinglePageDocument):
                 raise DocumentIOError("Failed to decode embedded image") from e
         raise DocumentIOError(f"Could not resolve embedded image: {href}")
 
+    def _get_embedded_image_content_hash_identity(self, image_info):
+        src = image_info.src
+        if src.lower().startswith("data:image/"):
+            try:
+                return ("bytes", ImageIO.data_uri_to_bytes(src))
+            except Exception:
+                log.warning("Failed to hash embedded data URI image.", exc_info=True)
+                return None
+        parsed_src = urllib_parse.urlsplit(src)
+        if parsed_src.scheme or parsed_src.netloc:
+            return ("src", src.strip().encode())
+        href = urllib_parse.unquote(parsed_src.path)
+        if image_item := self.get_epub_image_item_by_href(href):
+            return ("bytes", image_item.content)
+        return None
+
     def get_epub_image_item_by_href(self, href):
         candidate_hrefs = (
             href,
@@ -173,47 +210,33 @@ class EpubDocument(SinglePageDocument):
         for candidate in candidate_hrefs:
             if image_item := self.epub.get_item_with_href(candidate):
                 return image_item
-        image_name = PurePosixPath(href).name
-        fallback_matches = []
+        suffix_matches = []
         for item in self.epub.get_items_of_type(ebooklib.ITEM_IMAGE):
             item_path = PurePosixPath(item.file_name)
-            if (
-                self._item_path_has_href_suffix(item_path, href)
-                or item_path.name == image_name
-            ):
-                fallback_matches.append(item)
-        if len(fallback_matches) == 1:
-            return fallback_matches[0]
+            if self._item_path_has_href_suffix(item_path, href):
+                suffix_matches.append(item)
+        if len(suffix_matches) == 1:
+            return suffix_matches[0]
 
     @staticmethod
     def _item_path_has_href_suffix(item_path, href):
-        href_parts = tuple(
-            part for part in PurePosixPath(href).parts if part not in {"", "."}
-        )
+        href_parts = tuple(part for part in PurePosixPath(href).parts if part not in {"", "."})
         if not href_parts or ".." in href_parts:
             return False
         item_parts = PurePosixPath(item_path).parts
-        return (
-            len(href_parts) <= len(item_parts)
-            and item_parts[-len(href_parts) :] == href_parts
-        )
+        return len(href_parts) <= len(item_parts) and item_parts[-len(href_parts) :] == href_parts
 
     def resolve_link(self, link_range) -> LinkTarget:
         href = urllib_parse.unquote(self.structure.link_targets[link_range])
         if is_external_url(href):
             return LinkTarget(url=href, is_external=True)
-        else:
-            for html_id, text_range in self.structure.html_id_ranges.items():
-                if html_id.endswith(href):
-                    return LinkTarget(
-                        url=href, is_external=False, page=None, position=text_range
-                    )
+        for html_id, text_range in self.structure.html_id_ranges.items():
+            if html_id.endswith(href):
+                return LinkTarget(url=href, is_external=False, page=None, position=text_range)
 
     def get_cover_image(self):
         if not (
-            cover := more_itertools.first(
-                self.epub.get_items_of_type(ebooklib.ITEM_COVER), None
-            )
+            cover := more_itertools.first(self.epub.get_items_of_type(ebooklib.ITEM_COVER), None)
         ):
             cover = more_itertools.first(
                 filter(
@@ -228,9 +251,7 @@ class EpubDocument(SinglePageDocument):
             with fitz.open(self.get_file_system_path()) as fitz_document:
                 return ImageIO.from_fitz_pixmap(fitz_document.get_page_pixmap(0))
         except:
-            log.warning(
-                "Failed to obtain the cover image for epub document.", exc_info=True
-            )
+            log.warning("Failed to obtain the cover image for epub document.", exc_info=True)
 
     @lru_cache(maxsize=10)
     def get_section_at_position(self, pos):
@@ -307,9 +328,7 @@ class EpubDocument(SinglePageDocument):
                 text_range = None
                 # Strip  punctuation as ebooklib, for some reason, strips those from html_ids
                 for h_id, t_range in id_ranges.items():
-                    if (href == h_id.strip("/")) or (
-                        href == h_id.strip(string.punctuation)
-                    ):
+                    if (href == h_id.strip("/")) or (href == h_id.strip(string.punctuation)):
                         text_range = t_range
                         break
                 if text_range is None and "#" in href:
@@ -319,11 +338,7 @@ class EpubDocument(SinglePageDocument):
                     log.warning(
                         f"Could not determine the starting position for href: {href} and section: {sect!r}"
                     )
-                    text_range = (
-                        stack.top.text_range.astuple()
-                        if stack.top is not root
-                        else (0, 0)
-                    )
+                    text_range = stack.top.text_range.astuple() if stack.top is not root else (0, 0)
                 sect.text_range = TextRange(*text_range)
             stack.push(sect)
         return root
@@ -356,10 +371,8 @@ class EpubDocument(SinglePageDocument):
                 yield sect
             else:
                 epub_sect, children = entry
-                num_pages = len(children)
                 sect = Section(
-                    title=epub_sect.title
-                    or self._get_title_for_section(epub_sect.href),
+                    title=epub_sect.title or self._get_title_for_section(epub_sect.href),
                     level=current_level,
                     pager=SINGLE_PAGE_DOCUMENT_PAGER,
                     parent=parent,
@@ -373,34 +386,26 @@ class EpubDocument(SinglePageDocument):
 
     @cached_property
     def html_content(self):
-        cache = Cache(
-            self._get_cache_directory(), eviction_policy="least-frequently-used"
-        )
+        cache = Cache(self._get_cache_directory(), eviction_policy="least-frequently-used")
         cache_key = self.uri.to_uri_string()
         document_path = self.get_file_system_path()
-        if (
-            cached_html_content := cache.get(cache_key)
-        ) and not cache_utils.is_document_modified(cache_key, document_path, cache):
+        if (cached_html_content := cache.get(cache_key)) and not cache_utils.is_document_modified(
+            cache_key, document_path, cache
+        ):
             return cached_html_content.decode("utf-8")
-        html_content_gen = (
-            (item.file_name, item.content) for item in self.epub_html_items
-        )
+        html_content_gen = ((item.file_name, item.content) for item in self.epub_html_items)
         buf = StringIO()
         for filename, html_content in html_content_gen:
             buf.write(self.prefix_html_ids(filename, html_content))
             buf.write("\n<br/>\n")
-        html_content = self.build_html(
-            title=self.epub.title, body_content=buf.getvalue()
-        )
+        html_content = self.build_html(title=self.epub.title, body_content=buf.getvalue())
         cache.set(cache_key, html_content.encode("utf-8"))
         cache_utils.set_document_modified_time(cache_key, document_path, cache)
         return html_content
 
     def prefix_html_ids(self, filename, html):
         tree = lxml_html.fromstring(html)
-        tree.make_links_absolute(
-            filename, resolve_base_href=False, handle_failures="ignore"
-        )
+        tree.make_links_absolute(filename, resolve_base_href=False, handle_failures="ignore")
         if os.path.splitext(filename)[1] in HTML_FILE_EXTS:
             for node in tree.xpath("//*[@id]"):
                 node.set("id", filename + "#" + node.get("id"))
@@ -422,9 +427,7 @@ class EpubDocument(SinglePageDocument):
             )
         except Exception as exc:
             # Catch other potential errors during head/body processing
-            log.warning(
-                f"Error processing HTML structure (head/body) in {filename}: {exc}"
-            )
+            log.warning(f"Error processing HTML structure (head/body) in {filename}: {exc}")
             raise exc  # Re-raise other unexpected errors
 
         tree.tag = "div"

--- a/bookworm/document/formats/epub.py
+++ b/bookworm/document/formats/epub.py
@@ -65,7 +65,6 @@ class EpubDocument(SinglePageDocument):
     def read(self):
         super().read()
         self.epub = ebooklib.epub.read_epub(self.get_file_system_path())
-        self.html_content = self.html_content
         self.structure = StructuredHtmlParser.from_string(self.html_content)
         self._storage_text = self.structure.get_storage_text()
         self._text_position_map = self.structure.text_position_map
@@ -262,7 +261,7 @@ class EpubDocument(SinglePageDocument):
 
     @cached_property
     def epub_html_items(self) -> tuple[str]:
-        items = tuple()
+        items = ()
         if html_items := tuple(self.epub.get_items_of_type(ebooklib.ITEM_DOCUMENT)):
             items = html_items
         else:
@@ -366,7 +365,7 @@ class EpubDocument(SinglePageDocument):
                     pager=SINGLE_PAGE_DOCUMENT_PAGER,
                     level=current_level,
                     parent=parent,
-                    data=dict(href=entry.href.lstrip("./")),
+                    data={"href": entry.href.lstrip("./")},
                 )
                 yield sect
             else:
@@ -376,7 +375,7 @@ class EpubDocument(SinglePageDocument):
                     level=current_level,
                     pager=SINGLE_PAGE_DOCUMENT_PAGER,
                     parent=parent,
-                    data=dict(href=epub_sect.href.lstrip("./")),
+                    data={"href": epub_sect.href.lstrip("./")},
                 )
                 yield sect
                 yield from self.add_toc_entry(

--- a/bookworm/document/formats/html.py
+++ b/bookworm/document/formats/html.py
@@ -6,6 +6,8 @@ from concurrent.futures import ProcessPoolExecutor
 from contextlib import contextmanager
 from functools import cached_property
 from pathlib import Path
+from urllib import parse as urllib_parse
+from urllib.request import url2pathname
 
 import requests
 from lxml import etree
@@ -15,6 +17,7 @@ from more_itertools import zip_offset
 from yarl import URL
 
 from bookworm.http_tools import HttpResource
+from bookworm.image_io import ImageIO
 from bookworm.logger import logger
 from bookworm.structured_text import (
     HEADING_LEVELS,
@@ -255,6 +258,74 @@ class BaseHtmlDocument(SinglePageDocument):
 
     def get_document_table_markup(self, table_index):
         return self.structure.get_table_markup(table_index)
+
+    def get_document_embedded_image_info(self, image_index):
+        return self.structure.get_image_info(image_index)
+
+    def get_document_embedded_image(self, image_index) -> ImageIO:
+        image_info = self.get_document_embedded_image_info(image_index)
+        if image_info.src.lower().startswith("data:image/"):
+            try:
+                return ImageIO.from_data_uri(image_info.src)
+            except Exception as e:
+                raise DocumentIOError("Failed to decode embedded image") from e
+        if not self._is_local_image_source(image_info.src):
+            raise DocumentIOError("Remote images are not supported")
+        image_path = self._resolve_image_path(image_info.src)
+        if image := ImageIO.from_filename(image_path, preserve_mode=True):
+            return image
+        raise DocumentIOError(f"Failed to load embedded image: {image_path}")
+
+    @staticmethod
+    def _is_local_image_source(src: str) -> bool:
+        parsed = urllib_parse.urlparse(src)
+        scheme = parsed.scheme.lower()
+        if scheme == "":
+            return not parsed.netloc
+        return scheme == "file" or (len(scheme) == 1 and scheme.isalpha())
+
+    def _resolve_image_path(self, src: str) -> Path:
+        if src.lower().startswith("file:"):
+            return self._file_uri_to_path(src)
+        clean_src = src.split("#", 1)[0].split("?", 1)[0]
+        image_path = Path(urllib_parse.unquote(clean_src))
+        if image_path.is_absolute():
+            return image_path
+        if self._image_base_url:
+            resolved_src = urllib_parse.urljoin(self._image_base_url, src)
+            if not self._is_local_image_source(resolved_src):
+                raise DocumentIOError("Remote images are not supported")
+            return self._local_image_source_to_path(resolved_src)
+        base_path = getattr(self, "filename", None) or self.get_file_system_path()
+        return Path(base_path).parent / image_path
+
+    @staticmethod
+    def _file_uri_to_path(src: str) -> Path:
+        parsed = urllib_parse.urlparse(src)
+        path = f"//{parsed.netloc}{parsed.path}" if parsed.netloc else parsed.path
+        return Path(url2pathname(path))
+
+    @classmethod
+    def _local_image_source_to_path(cls, src: str) -> Path:
+        if src.lower().startswith("file:"):
+            return cls._file_uri_to_path(src)
+        clean_src = src.split("#", 1)[0].split("?", 1)[0]
+        return Path(urllib_parse.unquote(clean_src))
+
+    @cached_property
+    def _image_base_url(self) -> str:
+        try:
+            html = lxml_html.fromstring(self.html_string)
+        except Exception:
+            return ""
+        base_href = get_first_element(html.xpath("//base[@href]/@href"), "").strip()
+        if not base_href:
+            return ""
+        base_path = getattr(self, "filename", None) or self.get_file_system_path()
+        document_base_url = Path(base_path).parent.resolve().as_uri()
+        if not document_base_url.endswith("/"):
+            document_base_url += "/"
+        return urllib_parse.urljoin(document_base_url, base_href)
 
 
 class FileSystemHtmlDocument(BaseHtmlDocument):

--- a/bookworm/document/formats/html.py
+++ b/bookworm/document/formats/html.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 
 from __future__ import annotations
 
@@ -9,7 +8,6 @@ from pathlib import Path
 from urllib import parse as urllib_parse
 from urllib.request import url2pathname
 
-import requests
 from lxml import etree
 from lxml import html as lxml_html
 from more_itertools import first as get_first_element
@@ -21,23 +19,18 @@ from bookworm.image_io import ImageIO
 from bookworm.logger import logger
 from bookworm.structured_text import (
     HEADING_LEVELS,
-    SemanticElementType,
-    Style,
     TextRange,
 )
 from bookworm.structured_text.structured_html_parser import StructuredHtmlParser
 from bookworm.utils import (
-    NEWLINE,
     TextContentDecoder,
     escape_html,
     is_external_url,
-    remove_excess_blank_lines,
 )
 
-from .. import SINGLE_PAGE_DOCUMENT_PAGER, BookMetadata, ChangeDocument
-from .. import DocumentCapability as DC
 from .. import (
-    DocumentError,
+    SINGLE_PAGE_DOCUMENT_PAGER,
+    BookMetadata,
     DocumentIOError,
     LinkTarget,
     ReadingMode,
@@ -45,6 +38,7 @@ from .. import (
     SinglePageDocument,
     TreeStackBuilder,
 )
+from .. import DocumentCapability as DC
 
 log = logger.getChild(__name__)
 # Default cache timeout
@@ -58,7 +52,6 @@ def get_clean_html(html_string: str) -> (str, BookMetadata):
     # Therefore, we run it in a separate process
 
     import trafilatura
-    from trafilatura.external import JT_STOPLIST, custom_justext
 
     html_string = StructuredHtmlParser.normalize_html(html_string)
 
@@ -82,9 +75,7 @@ def get_clean_html(html_string: str) -> (str, BookMetadata):
     )
 
     # Extract the body
-    extracted = trafilatura.extract(
-        html_string, output_format="xml", include_links=True
-    )
+    extracted = trafilatura.extract(html_string, output_format="xml", include_links=True)
     xml_content = etree.fromstring(extracted)
     main_content = xml_content.xpath("main")[0]
     for node in main_content.cssselect("head"):
@@ -92,9 +83,7 @@ def get_clean_html(html_string: str) -> (str, BookMetadata):
     output_template = [
         "<html><body>",
         "<h1>%s</h1>" % (escape_html(doc_metadata.title),),
-        lxml_html.tostring(
-            main_content, pretty_print=False, method="html", encoding="unicode"
-        ),
+        lxml_html.tostring(main_content, pretty_print=False, method="html", encoding="unicode"),
         "</body></html>",
     ]
     return ("".join(output_template), doc_metadata)
@@ -121,10 +110,12 @@ class BaseHtmlDocument(SinglePageDocument):
     def read(self):
         super().read()
         self._text = None
+        self._storage_text = None
         self._outline = None
         self._metainfo = None
         self._semantic_structure = {}
         self._style_info = {}
+        self._text_position_map = None
         try:
             self.html_string = self.get_html()
         except Exception as e:
@@ -143,6 +134,35 @@ class BaseHtmlDocument(SinglePageDocument):
 
     def get_content(self):
         return self._text
+
+    def get_storage_content(self):
+        return self._storage_text if self._storage_text is not None else self._text
+
+    def get_legacy_content(self):
+        if hasattr(self, "_legacy_content"):
+            return self._legacy_content
+        html = getattr(self, "_parsed_html_content", self.html_string)
+        parser_kwargs = {"include_images": False}
+        if type(html) in (str, bytes):
+            legacy_parser = StructuredHtmlParser.from_string(html, **parser_kwargs)
+        else:
+            legacy_parser = StructuredHtmlParser(html, **parser_kwargs)
+        self._legacy_content = legacy_parser.get_text()
+        return self._legacy_content
+
+    def get_text_position_map(self):
+        return self._text_position_map or super().get_text_position_map()
+
+    def iter_content_hash_images(self):
+        if not getattr(self, "structure", None):
+            return ()
+        return tuple(
+            (
+                storage_range,
+                self._get_embedded_image_content_hash_identity(image_info),
+            )
+            for image_info, storage_range in self.structure.iter_image_storage_ranges()
+        )
 
     def get_document_semantic_structure(self):
         return self._semantic_structure
@@ -171,10 +191,9 @@ class BaseHtmlDocument(SinglePageDocument):
         href = self.link_targets[link_range]
         if is_external_url(href):
             return LinkTarget(url=href, is_external=True)
-        else:
-            _filename, anchor = href.split("#") if "#" in href else (href, None)
-            if anchor := self.anchors.get(anchor, None):
-                return LinkTarget(url=href, is_external=False, position=anchor)
+        _filename, anchor = href.split("#") if "#" in href else (href, None)
+        if anchor := self.anchors.get(anchor, None):
+            return LinkTarget(url=href, is_external=False, position=anchor)
 
     def parse_to_clean_text(self):
         with ProcessPoolExecutor(max_workers=1) as executor:
@@ -182,9 +201,7 @@ class BaseHtmlDocument(SinglePageDocument):
             try:
                 result = task.result()
             except Exception as e:
-                log.exception(
-                    "Failed to parse html string for clean view", exc_info=True
-                )
+                log.exception("Failed to parse html string for clean view", exc_info=True)
                 raise DocumentIOError from e
             html_content, metadata = result
             self._metainfo = metadata
@@ -201,6 +218,7 @@ class BaseHtmlDocument(SinglePageDocument):
         return self.parse_text_and_structure(self.html_string)
 
     def parse_text_and_structure(self, html):
+        self._parsed_html_content = html
         if type(html) in (str, bytes):
             extracted_text_and_info = StructuredHtmlParser.from_string(html)
         else:
@@ -211,6 +229,8 @@ class BaseHtmlDocument(SinglePageDocument):
         self.link_targets = extracted_text_and_info.link_targets
         self.anchors = extracted_text_and_info.anchors
         self._text = text = extracted_text_and_info.get_text()
+        self._storage_text = extracted_text_and_info.get_storage_text()
+        self._text_position_map = extracted_text_and_info.text_position_map
         heading_poses = sorted(
             (
                 (rng, h)
@@ -232,9 +252,7 @@ class BaseHtmlDocument(SinglePageDocument):
                 )
                 stack.push(section)
             all_sections = tuple(root.iter_children())
-            for this_sect, next_sect in zip_offset(
-                all_sections, all_sections, offsets=(0, 1)
-            ):
+            for this_sect, next_sect in zip_offset(all_sections, all_sections, offsets=(0, 1)):
                 this_sect.text_range.stop = next_sect.text_range.start - 1
             last_pos = len(text)
             if all_sections:
@@ -275,6 +293,28 @@ class BaseHtmlDocument(SinglePageDocument):
         if image := ImageIO.from_filename(image_path, preserve_mode=True):
             return image
         raise DocumentIOError(f"Failed to load embedded image: {image_path}")
+
+    def _get_embedded_image_content_hash_identity(self, image_info):
+        src = image_info.src
+        if src.lower().startswith("data:image/"):
+            try:
+                return ("bytes", ImageIO.data_uri_to_bytes(src))
+            except Exception:
+                log.warning("Failed to hash embedded data URI image.", exc_info=True)
+                return None
+        parsed_src = urllib_parse.urlparse(src)
+        if not parsed_src.scheme and not parsed_src.netloc and self._image_base_url:
+            src = urllib_parse.urljoin(self._image_base_url, src)
+        if not self._is_local_image_source(src):
+            return ("src", src.strip().encode())
+        try:
+            image_path = self._resolve_image_path(src)
+            return ("bytes", image_path.read_bytes())
+        except Exception:
+            log.warning(
+                f"Failed to hash embedded image from path '{src}'.", exc_info=True
+            )
+            return None
 
     @staticmethod
     def _is_local_image_source(src: str) -> bool:
@@ -372,9 +412,7 @@ class WebHtmlDocument(BaseHtmlDocument):
         )
         current_url_path = URL(url).path
         # Now strip the base_url from internal anchors
-        for maybe_internal_anchor in html_tree.xpath(
-            f"//a[starts-with(@href, '{url}')]"
-        ):
+        for maybe_internal_anchor in html_tree.xpath(f"//a[starts-with(@href, '{url}')]"):
             href = maybe_internal_anchor.get("href")
             if (URL(href).path) != current_url_path:
                 continue

--- a/bookworm/document/formats/html.py
+++ b/bookworm/document/formats/html.py
@@ -105,7 +105,7 @@ class BaseHtmlDocument(SinglePageDocument):
 
     def __getstate__(self) -> dict:
         """Support for pickling."""
-        return super().__getstate__() | dict(html_string=self.html_string)
+        return super().__getstate__() | {"html_string": self.html_string}
 
     def read(self):
         super().read()

--- a/bookworm/document/formats/odf.py
+++ b/bookworm/document/formats/odf.py
@@ -1,9 +1,11 @@
-# coding: utf-8
 
 from __future__ import annotations
 
 import sys
 from functools import lru_cache
+from pathlib import PurePosixPath
+from urllib import parse as urllib_parse
+from zipfile import BadZipFile, ZipFile
 
 from odf import opendocument
 
@@ -13,7 +15,6 @@ sys.modules["opendocument"] = opendocument
 
 from dataclasses import dataclass
 from functools import cached_property
-from pathlib import Path
 
 from bs4 import BeautifulSoup
 from lxml.html import fromstring as ParseHtml
@@ -21,16 +22,25 @@ from lxml.html import tostring as SerializeHtml
 from odf.odf2xhtml import ODF2XHTML
 
 from bookworm import typehints as t
-from bookworm.concurrency import process_worker
+from bookworm.image_io import ImageIO
 from bookworm.document.uri import DocumentUri
 from bookworm.logger import logger
 from bookworm.paths import home_data_path
 from bookworm.structured_text.structured_html_parser import StructuredHtmlParser
 from bookworm.utils import NEWLINE, escape_html, generate_file_md5
 
-from .. import BaseDocument, BasePage, BookMetadata, ChangeDocument
+from .. import (
+    BaseDocument,
+    BasePage,
+    BookMetadata,
+    ChangeDocument,
+    DocumentIOError,
+    DummyDocument,
+    Pager,
+    Section,
+    TreeStackBuilder,
+)
 from .. import DocumentCapability as DC
-from .. import DocumentError, DummyDocument, Pager, Section, TreeStackBuilder
 
 log = logger.getChild(__name__)
 
@@ -99,24 +109,88 @@ class OdpSlide(BasePage):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         html_string = self.section.data["html_content"]
+        self.html_string = html_string
         (
+            self.structure,
             self.text,
+            self.storage_text,
             self.semantic_elements,
             self.style_info,
+            self.text_position_map,
         ) = self.extract_info_and_structure(html_string)
 
     def extract_info_and_structure(self, html_string):
         parsed = StructuredHtmlParser.from_string(html_string)
-        return parsed.get_text(), parsed.semantic_elements, parsed.styled_elements
+        return (
+            parsed,
+            parsed.get_text(),
+            parsed.get_storage_text(),
+            parsed.semantic_elements,
+            parsed.styled_elements,
+            parsed.text_position_map,
+        )
 
     def get_text(self):
         return self.text
+
+    def get_storage_text(self):
+        return self.storage_text
+
+    def get_legacy_text(self):
+        if hasattr(self, "_legacy_text"):
+            return self._legacy_text
+        self._legacy_text = StructuredHtmlParser.from_string(
+            self.html_string,
+            include_images=False,
+        ).get_text()
+        return self._legacy_text
+
+    def get_text_position_map(self):
+        return self.text_position_map
+
+    def iter_content_hash_images(self):
+        return tuple(
+            (
+                storage_range,
+                self._get_embedded_image_content_hash_identity(image_info),
+            )
+            for image_info, storage_range in self.structure.iter_image_storage_ranges()
+        )
+
+    def _get_embedded_image_content_hash_identity(self, image_info):
+        src = image_info.src
+        if src.lower().startswith("data:image/"):
+            try:
+                return ("bytes", ImageIO.data_uri_to_bytes(src))
+            except Exception:
+                log.warning("Failed to hash embedded data URI image.", exc_info=True)
+                return None
+        parsed_src = urllib_parse.urlsplit(src)
+        if parsed_src.scheme or parsed_src.netloc:
+            return ("src", src.strip().encode())
+        return self.document.get_package_image_content_hash_identity(src)
 
     def get_style_info(self) -> dict:
         return self.style_info
 
     def get_semantic_structure(self) -> dict:
         return self.semantic_elements
+
+    def get_embedded_image_info(self, image_index: int):
+        return self.structure.get_image_info(image_index)
+
+    def get_embedded_image(self, image_index: int) -> ImageIO:
+        image_info = self.get_embedded_image_info(image_index)
+        if image_info.src.lower().startswith("data:image/"):
+            try:
+                return ImageIO.from_data_uri(image_info.src)
+            except Exception as e:
+                raise DocumentIOError("Failed to decode embedded image") from e
+        image_bytes = self.document.get_package_image_bytes(image_info.src)
+        try:
+            return ImageIO.from_bytes(image_bytes)
+        except Exception as e:
+            raise DocumentIOError("Failed to decode embedded image") from e
 
 
 class OdfPresentation(BaseDocument):
@@ -180,6 +254,26 @@ class OdfPresentation(BaseDocument):
             author="",
         )
 
+    def get_package_image_bytes(self, src: str) -> bytes:
+        parsed_src = urllib_parse.urlsplit(src)
+        if parsed_src.scheme or parsed_src.netloc:
+            raise DocumentIOError("Remote images are not supported")
+        image_path = PurePosixPath(urllib_parse.unquote(parsed_src.path))
+        if image_path.is_absolute() or ".." in image_path.parts or not image_path.parts:
+            raise DocumentIOError("Invalid ODF package image path")
+        try:
+            with ZipFile(self.get_file_system_path()) as package:
+                return package.read(image_path.as_posix())
+        except (BadZipFile, KeyError, OSError) as e:
+            raise DocumentIOError(f"Could not resolve embedded image: {src}") from e
+
+    def get_package_image_content_hash_identity(self, src: str):
+        try:
+            return ("bytes", self.get_package_image_bytes(src))
+        except DocumentIOError:
+            log.warning(f"Failed to hash ODF package image '{src}'.", exc_info=True)
+            return None
+
     def _generate_slides_from_html(self, html_string):
         retval = {}
         html_body = ParseHtml(html_string).body
@@ -190,7 +284,5 @@ class OdfPresentation(BaseDocument):
                 if slide_title.startswith("page"):
                     slide_title = _("Slide {number}").format(number=idx + 1)
                     legend.text = slide_title
-            retval[slide_title] = BeautifulSoup(
-                SerializeHtml(fieldset), "lxml"
-            ).decode_contents()
+            retval[slide_title] = BeautifulSoup(SerializeHtml(fieldset), "lxml").decode_contents()
         return retval

--- a/bookworm/document/hash_utils.py
+++ b/bookworm/document/hash_utils.py
@@ -1,0 +1,11 @@
+from bookworm.structured_text import CURRENT_CONTENT_HASH_VERSION
+
+
+def get_persistent_content_hash(current_hash: str | None, legacy_hash: str | None):
+    """Return the hash/version pair that should be persisted for future matches."""
+    if current_hash is not None:
+        return current_hash, CURRENT_CONTENT_HASH_VERSION
+    if legacy_hash is not None:
+        # Keep legacy hashes marked as legacy so path changes can still match them.
+        return legacy_hash, None
+    return None, CURRENT_CONTENT_HASH_VERSION

--- a/bookworm/gui/book_viewer/__init__.py
+++ b/bookworm/gui/book_viewer/__init__.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 
 import math
 import time
@@ -9,7 +8,6 @@ from pathlib import Path
 
 import wx
 
-from bookworm.text_to_speech import TextToSpeechService
 from bookworm import app, config, speech
 from bookworm import typehints as t
 from bookworm.concurrency import CancellationToken, threaded_worker
@@ -45,6 +43,7 @@ from bookworm.structured_text import (
     Style,
     TextRange,
 )
+from bookworm.text_to_speech import TextToSpeechService
 from bookworm.utils import gui_thread_safe
 
 from . import recents_manager
@@ -79,8 +78,7 @@ TEXT_CTRL_OFFSET = 1
 
 def _get_structural_navigation_speech(text, element_label, element_type):
     is_generic_image = (
-        element_type is SemanticElementType.FIGURE
-        and text.strip() == f"[{element_label}]"
+        element_type is SemanticElementType.FIGURE and text.strip() == f"[{element_label}]"
     )
     if is_generic_image:
         return element_label, ""
@@ -102,13 +100,11 @@ class ResourceLoader:
     def init_resolver(self, uri):
         try:
             resolver = UriResolver(uri)
-        except ReaderError as e:
+        except ReaderError:
             log.exception(f"Failed to resolve document uri: {uri}", exc_info=True)
             self.view.notify_user(
                 _("Failed to open document"),
-                _(
-                    "The document you are trying to open could not be opened in Bookworm."
-                ),
+                _("The document you are trying to open could not be opened in Bookworm."),
                 icon=wx.ICON_ERROR,
             )
             return
@@ -118,8 +114,7 @@ class ResourceLoader:
             AsyncSnakDialog(
                 task=partial(resolver.read_document),
                 done_callback=lambda fut: self.resolve_document(fut.result, uri),
-                dismiss_callback=lambda: self._cancellation_token.request_cancellation()
-                or True,
+                dismiss_callback=lambda: self._cancellation_token.request_cancellation() or True,
                 message=_("Opening document, please wait..."),
                 parent=self.view,
             )
@@ -154,9 +149,7 @@ class ResourceLoader:
                 # Translators: the title of an error message
                 _("Document Restricted"),
                 # Translators: the content of an error message
-                _(
-                    "Could not open Document.\nThe document is restricted by the publisher."
-                ),
+                _("Could not open Document.\nThe document is restricted by the publisher."),
                 icon=wx.ICON_ERROR,
             )
         except UnsupportedDocumentError as e:
@@ -180,9 +173,7 @@ class ResourceLoader:
                 # Translators: the title of an error message
                 _("Archive contains no documents"),
                 # Translators: the content of an error message
-                _(
-                    "Bookworm cannot open this archive file.\nThe archive contains no documents."
-                ),
+                _("Bookworm cannot open this archive file.\nThe archive contains no documents."),
                 icon=wx.ICON_ERROR,
             )
         except ArchiveContainsMultipleDocuments as e:
@@ -221,10 +212,7 @@ class ResourceLoader:
                 # Translators: the title of an error message
                 _("Error Openning Document"),
                 # Translators: the content of an error message
-                _(
-                    "Could not open document.\n"
-                    "An unknown error occurred while loading the file."
-                ),
+                _("Could not open document.\nAn unknown error occurred while loading the file."),
                 icon=wx.ICON_ERROR,
             )
         finally:
@@ -273,9 +261,7 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
         self.createControls()
 
         self.toolbar = self.CreateToolBar()
-        self.toolbar.SetWindowStyle(
-            wx.TB_FLAT | wx.TB_HORIZONTAL | wx.NO_BORDER | wx.TB_TEXT
-        )
+        self.toolbar.SetWindowStyle(wx.TB_FLAT | wx.TB_HORIZONTAL | wx.NO_BORDER | wx.TB_TEXT)
         self.statusBar = self.CreateStatusBar()
         self._nav_provider = NavigationProvider(
             ctrl=self.contentTextCtrl,
@@ -290,12 +276,8 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
         # Bind Events
         self.tocTreeCtrl.Bind(wx.EVT_SET_FOCUS, self.onTocTreeFocus, self.tocTreeCtrl)
         self.Bind(wx.EVT_TREE_ITEM_ACTIVATED, self.onTOCItemClick, self.tocTreeCtrl)
-        self.Bind(
-            wx.EVT_TOOL, lambda e: self.onTextCtrlZoom(-1), id=wx.ID_PREVIEW_ZOOM_OUT
-        )
-        self.Bind(
-            wx.EVT_TOOL, lambda e: self.onTextCtrlZoom(1), id=wx.ID_PREVIEW_ZOOM_IN
-        )
+        self.Bind(wx.EVT_TOOL, lambda e: self.onTextCtrlZoom(-1), id=wx.ID_PREVIEW_ZOOM_OUT)
+        self.Bind(wx.EVT_TOOL, lambda e: self.onTextCtrlZoom(1), id=wx.ID_PREVIEW_ZOOM_IN)
         self.Bind(
             self.contentTextCtrl.EVT_CARET,
             self.onCaretMoved,
@@ -327,9 +309,7 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
         # If global mode is on, only the pynput listener should handle media keys.
         if config.conf["reading"]["enable_global_media_keys"]:
             if key_name:
-                log.debug(
-                    f"Local media key '{key_name}' ignored; global mode is active."
-                )
+                log.debug(f"Local media key '{key_name}' ignored; global mode is active.")
             event.Skip()  # Pass all other keys (like Tab) through.
             return
         # --- Local Mode Handling ---
@@ -377,11 +357,11 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
         )
         self.set_text_view_margins()
         # Translators: label for the reading progress slider
-        readingProgressLabel = wx.StaticText(
-            panel, -1, _("Reading progress percentage")
-        )
+        readingProgressLabel = wx.StaticText(panel, -1, _("Reading progress percentage"))
         self.readingProgressSlider = wx.Slider(
-            panel, -1, style=wx.SL_HORIZONTAL  # | wx.SL_LABELS
+            panel,
+            -1,
+            style=wx.SL_HORIZONTAL,  # | wx.SL_LABELS
         )
         self.readingProgressSlider.SetTick(5)
 
@@ -412,9 +392,7 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
         self.CenterOnScreen(wx.BOTH)
 
     def finalize_gui_creation(self):
-        opendyslexic_font_filename = fonts_path(
-            "opendyslexic", "OpenDyslexic-Regular.ttf"
-        )
+        opendyslexic_font_filename = fonts_path("opendyslexic", "OpenDyslexic-Regular.ttf")
         wx.Font.AddPrivateFont(str(opendyslexic_font_filename))
         self.set_content_view_font()
         self.add_tools()
@@ -447,9 +425,7 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
         finfo = wx.FontInfo().FaceName(config.conf["appearance"]["font_facename"])
         configured_font = wx.Font(finfo)
         font_point_size = (
-            font_size
-            if font_size is not None
-            else config.conf["appearance"]["font_point_size"]
+            font_size if font_size is not None else config.conf["appearance"]["font_point_size"]
         )
         configured_font.SetPointSize(font_point_size)
         if config.conf["appearance"]["use_bold_font"]:
@@ -498,9 +474,7 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
             self.tocTreeCtrl.SetFocus()
 
     def load_document(self, document, original_uri=None) -> bool:
-        with reader_book_loaded.connected_to(
-            self.book_loaded_handler, sender=self.reader
-        ):
+        with reader_book_loaded.connected_to(self.book_loaded_handler, sender=self.reader):
             self.reader.set_document(document, original_uri=original_uri)
 
     @gui_thread_safe
@@ -509,9 +483,7 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
 
     def open_uri(self, uri, callback=None):
         self.unloadCurrentEbook()
-        ResourceLoader(
-            self, uri, callback=callback or self.default_book_loaded_callback
-        )
+        ResourceLoader(self, uri, callback=callback or self.default_book_loaded_callback)
 
     def decrypt_document(self, uri):
         if uri.view_args.get("n_attempts"):
@@ -529,12 +501,9 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
             )
         retval = self.get_password_from_user()
         if retval is None:
-            return
-        else:
-            new_uri = uri.create_copy(
-                view_args={"decryption_key": retval, "n_attempts": "1"}
-            )
-            return self.open_uri(new_uri)
+            return None
+        new_uri = uri.create_copy(view_args={"decryption_key": retval, "n_attempts": "1"})
+        return self.open_uri(new_uri)
 
     def open_document(self, document):
         self.unloadCurrentEbook()
@@ -567,8 +536,7 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
 
     def unloadCurrentEbook(self):
         true_unload_opt = (
-            not isinstance(self.reader.document, DummyDocument)
-            and self.reader.document is not None
+            not isinstance(self.reader.document, DummyDocument) and self.reader.document is not None
         )
         self.readingProgressSlider.SetValue(0)
         self.reader.unload()
@@ -615,9 +583,7 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
             current_ratio = (self.reader.current_page + 1) / len(self.reader.document)
         percentage_ratio = math.ceil(current_ratio * 100)
         wx.CallAfter(self.readingProgressSlider.SetValue, percentage_ratio)
-        percentage_display = app.current_language.format_percentage(
-            percentage_ratio / 100
-        )
+        percentage_display = app.current_language.format_percentage(percentage_ratio / 100)
         # Translators: text of reading progress shown in the status bar
         status_text = _("{percentage} completed").format(percentage=percentage_display)
         if existing_status := self.get_statusbar_text():
@@ -683,7 +649,7 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
     def navigate_to_structural_element(self, element_type, forward):
         if not self.reader.ready:
             wx.Bell()
-            return
+            return None
         current_insertion_point = self.get_insertion_point()
         pos = self.reader.get_semantic_element(
             element_type,
@@ -703,9 +669,7 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
                 move_to_start_of_line,
             ) = SEMANTIC_ELEMENT_OUTPUT_OPTIONS[actual_element_type]
             text_start, text_stop = (
-                self.get_containing_line(start + 1)
-                if should_speak_whole_text
-                else (start, stop)
+                self.get_containing_line(start + 1) if should_speak_whole_text else (start, stop)
             )
             text = self.get_text_by_range(text_start, text_stop)
             element_label = _(element_label)
@@ -715,9 +679,7 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
                 actual_element_type,
             )
             target_position = (
-                start
-                if not move_to_start_of_line
-                else self.get_containing_line(stop - 1)[0]
+                start if not move_to_start_of_line else self.get_containing_line(stop - 1)[0]
             )
             self.set_insertion_point(target_position)
             speech.announce(msg, True)
@@ -767,12 +729,8 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
     def onSliderValueChanged(self, event):
         target_nav_percentage = event.GetSelection()
         if self.reader.document.is_single_page_document():
-            pos_percentage = math.floor(
-                self.get_last_position() * (target_nav_percentage / 100)
-            )
-            target_position = self.get_start_of_line(
-                self.get_line_number(pos_percentage)
-            )
+            pos_percentage = math.floor(self.get_last_position() * (target_nav_percentage / 100))
+            target_position = self.get_start_of_line(self.get_line_number(pos_percentage))
             self.set_insertion_point(target_position, set_focus_to_text_ctrl=False)
         else:
             page_count = len(self.reader.document)
@@ -781,9 +739,7 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
             )
             self.reader.go_to_page(target_page, set_focus_to_text_ctrl=False)
             target_position = 0
-        percentage_display = app.current_language.format_percentage(
-            target_nav_percentage / 100
-        )
+        percentage_display = app.current_language.format_percentage(target_nav_percentage / 100)
         reading_position_change.send(
             self,
             position=target_position,
@@ -799,9 +755,7 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
             self.SetIcon(wx.Icon(str(icon_file)))
 
     def set_text_view_margins(self):
-        config_margin = round(
-            1000 * (config.conf["appearance"]["text_view_margins"] / 100)
-        )
+        config_margin = round(1000 * (config.conf["appearance"]["text_view_margins"] / 100))
         margins = wx.Point(config_margin, config_margin)
         self.contentTextCtrl.SetMargins(margins)
 
@@ -820,16 +774,12 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
         )
         return password if password else None
 
-    def highlight_range(
-        self, start, end, foreground=wx.NullColour, background=wx.NullColour
-    ):
+    def highlight_range(self, start, end, foreground=wx.NullColour, background=wx.NullColour):
         line_start = self.get_containing_line(start)[0]
         attr = wx.TextAttr()
         self.contentTextCtrl.GetStyle(line_start + TEXT_CTRL_OFFSET, attr)
         attr.SetBackgroundColour(wx.YELLOW)
-        self.contentTextCtrl.SetStyle(
-            start + TEXT_CTRL_OFFSET, end + TEXT_CTRL_OFFSET, attr
-        )
+        self.contentTextCtrl.SetStyle(start + TEXT_CTRL_OFFSET, end + TEXT_CTRL_OFFSET, attr)
 
     def clear_highlight(self, start=0, end=-1):
         textCtrl = self.contentTextCtrl
@@ -847,24 +797,23 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
         page = self.reader.get_current_page_object()
         if self.reader.document.is_single_page_document():
             return self.reader.current_book.title
+        page_number = page.number
+        if self.reader.document.uses_chapter_by_chapter_navigation_model():
+            # Translators: the label of the page content text area
+            label_msg = "{chapter}"
         else:
-            page_number = page.number
-            if self.reader.document.uses_chapter_by_chapter_navigation_model():
-                # Translators: the label of the page content text area
-                label_msg = "{chapter}"
-            else:
-                # Translators: the label of the page content text area
-                label_msg = _("Page {page} of {total}")
-                label_msg = f"{label_msg} " + chr(0x00B7) + " {chapter}"
-                if config.conf["general"]["include_page_label"] and (
-                    page_label := page.get_label()
-                ):
-                    page_number = f"{page_number} ({page_label})"
-            return label_msg.format(
-                page=page_number,
-                total=len(self.reader.document),
-                chapter=page.section.title,
-            )
+            # Translators: the label of the page content text area
+            label_msg = _("Page {page} of {total}")
+            label_msg = f"{label_msg} " + chr(0x00B7) + " {chapter}"
+            if config.conf["general"]["include_page_label"] and (
+                page_label := page.get_label()
+            ):
+                page_number = f"{page_number} ({page_label})"
+        return label_msg.format(
+            page=page_number,
+            total=len(self.reader.document),
+            chapter=page.section.title,
+        )
 
     def unselect_text(self):
         self.contentTextCtrl.SelectNone()
@@ -927,9 +876,7 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
 
     def select_text(self, fpos, tpos):
         self.contentTextCtrl.SetFocusFromKbd()
-        self.contentTextCtrl.SetSelection(
-            fpos + TEXT_CTRL_OFFSET, tpos + TEXT_CTRL_OFFSET
-        )
+        self.contentTextCtrl.SetSelection(fpos + TEXT_CTRL_OFFSET, tpos + TEXT_CTRL_OFFSET)
 
     def set_insertion_point(self, to, set_focus_to_text_ctrl=True):
         actual_position = to + TEXT_CTRL_OFFSET
@@ -955,6 +902,14 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
     def get_insertion_point(self):
         return self.contentTextCtrl.GetInsertionPoint() - TEXT_CTRL_OFFSET
 
+    @staticmethod
+    def control_to_view_position(pos):
+        return pos - TEXT_CTRL_OFFSET
+
+    @staticmethod
+    def view_to_control_position(pos):
+        return pos + TEXT_CTRL_OFFSET
+
     def get_last_position(self):
         # WHY: The structure is `\n[content]\n`. The real length is `len(content) + 2`.
         # The clean length is `len(content)`. So we must subtract 2.
@@ -970,9 +925,7 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
             actual_end = self.contentTextCtrl.GetLastPosition() - TEXT_CTRL_OFFSET
         return self.contentTextCtrl.GetRange(actual_start, actual_end)
 
-    def get_text_from_user(
-        self, title, label, style=wx.OK | wx.CANCEL | wx.CENTER, value=""
-    ):
+    def get_text_from_user(self, title, label, style=wx.OK | wx.CANCEL | wx.CENTER, value=""):
         dlg = wx.TextEntryDialog(self, label, title, style=style, value=value)
         if dlg.ShowModal() == wx.ID_OK:
             return dlg.GetValue().strip()

--- a/bookworm/gui/book_viewer/__init__.py
+++ b/bookworm/gui/book_viewer/__init__.py
@@ -2,14 +2,11 @@
 import math
 import time
 import webbrowser
-from contextlib import contextmanager
 from functools import partial
-from pathlib import Path
 
 import wx
 
 from bookworm import app, config, speech
-from bookworm import typehints as t
 from bookworm.concurrency import CancellationToken, threaded_worker
 from bookworm.document import (
     ArchiveContainsMultipleDocuments,
@@ -43,7 +40,6 @@ from bookworm.structured_text import (
     Style,
     TextRange,
 )
-from bookworm.text_to_speech import TextToSpeechService
 from bookworm.utils import gui_thread_safe
 
 from . import recents_manager

--- a/bookworm/gui/book_viewer/__init__.py
+++ b/bookworm/gui/book_viewer/__init__.py
@@ -39,12 +39,18 @@ from bookworm.signals import (
     reader_book_unloaded,
     reading_position_change,
 )
-from bookworm.structured_text import SEMANTIC_ELEMENT_OUTPUT_OPTIONS, Style, TextRange
+from bookworm.structured_text import (
+    SEMANTIC_ELEMENT_OUTPUT_OPTIONS,
+    SemanticElementType,
+    Style,
+    TextRange,
+)
 from bookworm.utils import gui_thread_safe
 
 from . import recents_manager
 from .menubar import BookRelatedMenuIds, MenubarProvider
 from .navigation import NavigationProvider
+from .render_view import EmbeddedImageDialog
 from .state import StateProvider
 
 log = logger.getChild(__name__)
@@ -69,6 +75,19 @@ STYLE_TO_WX_TEXT_ATTR_STYLES = {
 }
 
 TEXT_CTRL_OFFSET = 1
+
+
+def _get_structural_navigation_speech(text, element_label, element_type):
+    is_generic_image = (
+        element_type is SemanticElementType.FIGURE
+        and text.strip() == f"[{element_label}]"
+    )
+    if is_generic_image:
+        return element_label, ""
+    return _("{text}: {item_type}").format(
+        text=text,
+        item_type=element_label,
+    ), element_label
 
 
 class ResourceLoader:
@@ -689,7 +708,12 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
                 else (start, stop)
             )
             text = self.get_text_by_range(text_start, text_stop)
-            msg = _("{text}: {item_type}").format(text=text, item_type=_(element_label))
+            element_label = _(element_label)
+            msg, tts_speech_prefix = _get_structural_navigation_speech(
+                text,
+                element_label,
+                actual_element_type,
+            )
             target_position = (
                 start
                 if not move_to_start_of_line
@@ -701,7 +725,7 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
             reading_position_change.send(
                 self,
                 position=start,
-                tts_speech_prefix=_(element_label),
+                tts_speech_prefix=tts_speech_prefix,
             )
         else:
             element_label = SEMANTIC_ELEMENT_OUTPUT_OPTIONS[element_type][0]
@@ -879,6 +903,15 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
 
     def show_html_dialog(self, markup, title):
         browseable_message(markup, title=title, is_html=True)
+
+    def show_image_dialog(self, image, title, suggested_filename=None):
+        with EmbeddedImageDialog(
+            self,
+            title=title,
+            image_io=image,
+            suggested_filename=suggested_filename,
+        ) as dlg:
+            dlg.ShowModal()
 
     def get_line_number(self, pos=None):
         # WHY: Use our own gatekeeper if pos is not provided.

--- a/bookworm/gui/book_viewer/core_dialogs.py
+++ b/bookworm/gui/book_viewer/core_dialogs.py
@@ -234,6 +234,7 @@ class ElementKind(enum.IntEnum):
     LIST = SemanticElementType.LIST
     TABLE = SemanticElementType.TABLE
     QUOTE = SemanticElementType.QUOTE
+    FIGURE = SemanticElementType.FIGURE
 
     @property
     def display(self):

--- a/bookworm/gui/book_viewer/core_dialogs.py
+++ b/bookworm/gui/book_viewer/core_dialogs.py
@@ -6,7 +6,6 @@ import threading
 from collections import namedtuple
 from itertools import chain
 
-import more_itertools
 import wx
 import wx.lib.sized_controls as sc
 
@@ -22,7 +21,6 @@ from bookworm.gui.components import (
     ImmutableObjectListView,
     PageRangeControl,
     SimpleDialog,
-    make_sized_static_box,
 )
 from bookworm.image_io import ImageIO
 from bookworm.logger import logger
@@ -33,10 +31,6 @@ from bookworm.structured_text import (
     SEMANTIC_ELEMENT_OUTPUT_OPTIONS,
     SemanticElementType,
 )
-from bookworm.utils import gui_thread_safe
-
-from .navigation import NavigationProvider
-
 log = logger.getChild(__name__)
 
 
@@ -150,7 +144,6 @@ class SearchBookDialog(SimpleDialog):
     def addControls(self, parent):
         self.reader = self.parent.reader
         self.is_single_page_document = self.reader.document.is_single_page_document()
-        num_pages = len(self.parent.reader.document)
         recent_terms = config.conf["history"]["recent_terms"]
 
         # Translators: the label of an edit field in the search dialog
@@ -212,9 +205,7 @@ class GoToPageDialog(SimpleDialog):
     def addControls(self, parent):
         page_count = len(self.parent.reader.document)
         # Translators: the label of an edit field in the go to page dialog
-        label = wx.StaticText(
-            parent, -1, _("Page number, of {total}:").format(total=page_count)
-        )
+        wx.StaticText(parent, -1, _("Page number, of {total}:").format(total=page_count))
         self.pageNumberCtrl = EnhancedSpinCtrl(
             parent,
             -1,

--- a/bookworm/gui/book_viewer/core_dialogs.py
+++ b/bookworm/gui/book_viewer/core_dialogs.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 import enum
 import operator
 import threading

--- a/bookworm/gui/book_viewer/recents_manager.py
+++ b/bookworm/gui/book_viewer/recents_manager.py
@@ -1,7 +1,8 @@
-# coding: utf-8
 
 from bookworm.database import PinnedDocument, RecentDocument
+from bookworm.document.hash_utils import get_persistent_content_hash
 from bookworm.logger import logger
+from bookworm.structured_text import CURRENT_CONTENT_HASH_VERSION
 
 log = logger.getChild(__name__)
 _CONTENT_HASH_UNSET = object()
@@ -18,7 +19,25 @@ def _get_documents_by_content_hash(model, content_hash, uri):
         return []
     matching_documents = []
     for doc in model.query:
-        if doc.content_hash == content_hash and doc.uri.format == uri.format:
+        if (
+            doc.content_hash == content_hash
+            and doc.content_hash_version == CURRENT_CONTENT_HASH_VERSION
+            and doc.uri.format == uri.format
+        ):
+            matching_documents.append(doc)
+    return matching_documents
+
+
+def _get_legacy_documents_by_content_hash(model, content_hash, uri):
+    if content_hash is None:
+        return []
+    matching_documents = []
+    for doc in model.query:
+        if (
+            doc.content_hash == content_hash
+            and doc.content_hash_version != CURRENT_CONTENT_HASH_VERSION
+            and doc.uri.format == uri.format
+        ):
             matching_documents.append(doc)
     return matching_documents
 
@@ -64,15 +83,27 @@ def get_document_unique(model, document):
     doc = _get_document_by_uri(model, uri)
     content_hash = (
         doc.content_hash
-        if doc is not None and doc.content_hash is not None
+        if doc is not None
+        and doc.content_hash_version == CURRENT_CONTENT_HASH_VERSION
+        and doc.content_hash is not None
         else _CONTENT_HASH_UNSET
     )
     if content_hash is _CONTENT_HASH_UNSET:
         content_hash = document.get_content_hash()
-    matching_documents = _merge_matching_documents(
-        doc,
-        _get_documents_by_content_hash(model, content_hash, uri),
+    legacy_content_hash = document.get_legacy_content_hash()
+    stored_content_hash, stored_content_hash_version = get_persistent_content_hash(
+        content_hash,
+        legacy_content_hash,
     )
+    hash_matching_documents = _get_documents_by_content_hash(model, content_hash, uri)
+    hash_matching_documents.extend(
+        _get_legacy_documents_by_content_hash(
+            model,
+            legacy_content_hash,
+            uri,
+        )
+    )
+    matching_documents = _merge_matching_documents(doc, hash_matching_documents)
     doc = doc or (matching_documents[0] if matching_documents else None)
     if doc is not None:
         duplicates = [candidate for candidate in matching_documents if candidate.id != doc.id]
@@ -80,14 +111,19 @@ def get_document_unique(model, document):
         _delete_duplicate_documents(model, duplicates)
         doc.title = document.metadata.title
         doc.uri = uri
-        if doc.content_hash is None:
-            doc.content_hash = content_hash
+        if (
+            doc.content_hash != stored_content_hash
+            or doc.content_hash_version != stored_content_hash_version
+        ):
+            doc.content_hash = stored_content_hash
+            doc.content_hash_version = stored_content_hash_version
         model.session.commit()
         return doc
     return model.get_or_create(
         title=document.metadata.title,
         uri=uri,
-        content_hash=content_hash,
+        content_hash=stored_content_hash,
+        content_hash_version=stored_content_hash_version,
     )
 
 

--- a/bookworm/gui/book_viewer/render_view.py
+++ b/bookworm/gui/book_viewer/render_view.py
@@ -1,10 +1,12 @@
 # coding: utf-8
 
+from pathlib import Path
+
 import wx
 import wx.lib.scrolledpanel as scrolled
 
 from bookworm import speech
-from bookworm.gui.components import Dialog, ImageViewControl
+from bookworm.gui.components import ImageViewControl
 from bookworm.image_io import ImageIO
 from bookworm.logger import logger
 from bookworm.runtime import IS_HIGH_CONTRAST_ACTIVE
@@ -122,3 +124,267 @@ class ViewPageAsImageDialog(wx.Dialog):
     def Close(self, *args, **kwargs):
         super().Close(*args, **kwargs)
         reader_page_changed.disconnect(self.onPageChange, sender=self.reader)
+
+
+class EmbeddedImageDialog(wx.Dialog):
+    """Show an image embedded in a book."""
+
+    ID_RESET_ZOOM = wx.NewIdRef()
+    MIN_ZOOM = 0.1
+    MAX_ZOOM = 10.0
+    SAVE_FORMAT_CHOICES = (("PNG", ".png"), ("JPEG", ".jpg"))
+
+    def __init__(
+        self,
+        parent,
+        title,
+        image_io: ImageIO,
+        suggested_filename="image.png",
+        size=(700, 600),
+        style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER | wx.MAXIMIZE_BOX,
+    ):
+        super().__init__(parent, title=title, size=size, style=style)
+        bg_color = (215, 215, 215) if not IS_HIGH_CONTRAST_ACTIVE else (30, 30, 30)
+        self.SetBackgroundColour(wx.Colour(bg_color))
+        self.parent = parent
+        self.image_io = image_io
+        self.suggested_filename = self._normalize_suggested_filename(
+            suggested_filename
+        )
+        self.scaling_factor = 0.2
+        self._zoom_factor = 1.0
+        self._build_controls()
+        self.setDialogImage()
+        self.Bind(wx.EVT_CHAR_HOOK, self.onCharHook)
+        self.CenterOnParent()
+
+    def _build_controls(self):
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        toolbar = wx.ToolBar(self, -1, style=wx.TB_FLAT | wx.TB_HORIZONTAL)
+        self._add_tool(toolbar, wx.ID_ZOOM_IN, _("Zoom In"), wx.ART_PLUS)
+        self._add_tool(toolbar, wx.ID_ZOOM_OUT, _("Zoom Out"), wx.ART_MINUS)
+        self._add_tool(toolbar, self.ID_RESET_ZOOM, _("Actual Size"), wx.ART_GO_HOME)
+        toolbar.AddSeparator()
+        self._add_tool(toolbar, wx.ID_SAVE, _("Save As"), wx.ART_FILE_SAVE)
+        self._add_tool(toolbar, wx.ID_COPY, _("Copy"), wx.ART_COPY)
+        toolbar.AddSeparator()
+        self._add_tool(toolbar, wx.ID_CLOSE, _("Close"), wx.ART_CLOSE)
+        toolbar.Realize()
+        sizer.Add(toolbar, 0, wx.EXPAND)
+
+        self.scroll = scrolled.ScrolledPanel(self, -1, name=_("Image"), style=0)
+        self.scroll.SetTransparent(0)
+        panel_sizer = wx.BoxSizer(wx.VERTICAL)
+        self.imageCtrl = ImageViewControl(self.scroll, -1)
+        panel_sizer.Add(self.imageCtrl, 1, wx.CENTER | wx.BOTH)
+        self.scroll.SetSizer(panel_sizer)
+        sizer.Add(self.scroll, 1, wx.EXPAND)
+        self.SetSizer(sizer)
+
+        self.Bind(wx.EVT_TOOL, lambda event: self.set_zoom(1), id=wx.ID_ZOOM_IN)
+        self.Bind(wx.EVT_TOOL, lambda event: self.set_zoom(-1), id=wx.ID_ZOOM_OUT)
+        self.Bind(wx.EVT_TOOL, lambda event: self.set_zoom(0), id=self.ID_RESET_ZOOM)
+        self.Bind(wx.EVT_TOOL, self.onSaveImage, id=wx.ID_SAVE)
+        self.Bind(wx.EVT_TOOL, self.onCopyImage, id=wx.ID_COPY)
+        self.Bind(wx.EVT_TOOL, lambda event: self.Close(), id=wx.ID_CLOSE)
+
+    def _add_tool(self, toolbar, tool_id, label, art_id):
+        bitmap = wx.ArtProvider.GetBitmap(art_id, wx.ART_TOOLBAR, (16, 16))
+        toolbar.AddTool(tool_id, label, bitmap)
+        toolbar.SetToolShortHelp(tool_id, label)
+
+    def _normalize_suggested_filename(self, suggested_filename):
+        filename = Path(suggested_filename or "image.png").name or "image.png"
+        if not Path(filename).suffix:
+            filename = f"{filename}.png"
+        return filename
+
+    @property
+    def scroll_rate_x(self):
+        return max(1, round(self.imageCtrl.Size[0] * 0.05))
+
+    @property
+    def scroll_rate_y(self):
+        return max(1, round(self.imageCtrl.Size[1] * 0.025))
+
+    def set_zoom(self, val):
+        if val == 0:
+            self.zoom_factor = 1.0
+        else:
+            self.zoom_factor += val * self.scaling_factor
+
+    @property
+    def zoom_factor(self):
+        return self._zoom_factor
+
+    @zoom_factor.setter
+    def zoom_factor(self, value):
+        if (value < self.MIN_ZOOM) or (value > self.MAX_ZOOM):
+            return
+        self._zoom_factor = value
+        self.setDialogImage(reset_scroll_pos=False)
+        self.scroll.SetupScrolling(
+            rate_x=self.scroll_rate_x, rate_y=self.scroll_rate_y, scrollToTop=False
+        )
+        # Translators: a message announced to the user when the zoom factor changes
+        speech.announce(
+            _("Zoom is at {factor} percent").format(factor=int(value * 100))
+        )
+
+    def setDialogImage(self, reset_scroll_pos=True):
+        image = self.getRenderedImage()
+        self.imageCtrl.RenderImageIO(image)
+        self.scroll.SetupScrolling(
+            rate_x=self.scroll_rate_x, rate_y=self.scroll_rate_y, scrollToTop=False
+        )
+        if reset_scroll_pos:
+            wx.CallLater(50, self.scroll.Scroll, 0, 0)
+        self.scroll.SetFocus()
+
+    def getRenderedImage(self):
+        if self.zoom_factor == 1.0:
+            return self.image_io
+        width = max(1, round(self.image_io.width * self.zoom_factor))
+        height = max(1, round(self.image_io.height * self.zoom_factor))
+        return ImageIO.from_pil(self.image_io.to_pil().resize((width, height)))
+
+    def onCharHook(self, event):
+        keycode = event.GetKeyCode()
+        modifiers = event.GetModifiers()
+        if keycode == wx.WXK_ESCAPE:
+            self.Close()
+            return
+        if modifiers != wx.MOD_CONTROL:
+            event.Skip()
+            return
+        if keycode == ord("="):
+            self.set_zoom(1)
+        elif keycode == ord("-"):
+            self.set_zoom(-1)
+        elif keycode == ord("0"):
+            self.set_zoom(0)
+        elif keycode == ord("S"):
+            self.onSaveImage(event)
+        elif keycode == ord("C"):
+            self.onCopyImage(event)
+        else:
+            event.Skip()
+
+    def onSaveImage(self, event):
+        with wx.FileDialog(
+            self,
+            # Translators: title of a save file dialog for an embedded book image
+            _("Save Image"),
+            defaultDir=wx.GetUserHome(),
+            defaultFile=self.suggested_filename,
+            wildcard=_("PNG Image") + " (*.png)|*.png|"
+            + _("JPEG Image")
+            + " (*.jpg)|*.jpg",
+            style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
+        ) as save_dialog:
+            if save_dialog.ShowModal() != wx.ID_OK:
+                return
+            selected_path = save_dialog.GetPath()
+            output_path, image_format = self.get_save_target(
+                selected_path, save_dialog.GetFilterIndex()
+            )
+        if not self.confirm_overwrite_after_suffix_normalization(
+            selected_path,
+            output_path,
+        ):
+            return
+        try:
+            pil_image = self.prepare_image_for_save(
+                self.image_io.to_pil(),
+                image_format,
+            )
+            pil_image.save(output_path, format=image_format)
+        except Exception:
+            log.exception("Failed to save embedded image.", exc_info=True)
+            wx.MessageBox(
+                _("Could not save this image."),
+                _("Save Image"),
+                style=wx.ICON_ERROR,
+                parent=self,
+            )
+        else:
+            speech.announce(_("Image saved"), True)
+
+    @staticmethod
+    def prepare_image_for_save(pil_image, image_format):
+        if image_format == "JPEG":
+            return pil_image.convert("RGB")
+        if image_format == "PNG" and pil_image.mode not in {
+            "1",
+            "L",
+            "LA",
+            "P",
+            "RGB",
+            "RGBA",
+            "I",
+            "I;16",
+        }:
+            output_mode = "RGBA" if "A" in pil_image.getbands() else "RGB"
+            return pil_image.convert(output_mode)
+        return pil_image
+
+    @classmethod
+    def get_save_target(cls, path, filter_index):
+        index = (
+            filter_index if 0 <= filter_index < len(cls.SAVE_FORMAT_CHOICES) else 0
+        )
+        image_format, suffix = cls.SAVE_FORMAT_CHOICES[index]
+        output_path = Path(path)
+        if output_path.suffix.lower() != suffix:
+            output_path = output_path.with_suffix(suffix)
+        return output_path, image_format
+
+    def confirm_overwrite_after_suffix_normalization(self, selected_path, output_path):
+        if not self.should_confirm_overwrite_after_suffix_normalization(
+            selected_path,
+            output_path,
+        ):
+            return True
+        retval = wx.MessageBox(
+            # Translators: content of a message confirming overwrite of an image file
+            _(
+                'A file named "{filename}" already exists. Do you want to replace it?'
+            ).format(
+                filename=Path(output_path).name,
+            ),
+            # Translators: title of a message confirming overwrite of an image file
+            _("Confirm Save As"),
+            style=wx.YES_NO | wx.NO_DEFAULT | wx.ICON_WARNING,
+            parent=self,
+        )
+        return retval == wx.YES
+
+    @staticmethod
+    def should_confirm_overwrite_after_suffix_normalization(
+        selected_path,
+        output_path,
+    ):
+        selected_path = Path(selected_path)
+        output_path = Path(output_path)
+        return output_path != selected_path and output_path.exists()
+
+    def onCopyImage(self, event):
+        try:
+            if not wx.TheClipboard.Open():
+                raise RuntimeError("Could not open the clipboard")
+            try:
+                data = wx.BitmapDataObject()
+                data.SetBitmap(self.image_io.to_wx_bitmap())
+                wx.TheClipboard.SetData(data)
+            finally:
+                wx.TheClipboard.Close()
+        except Exception:
+            log.exception("Failed to copy embedded image.", exc_info=True)
+            wx.MessageBox(
+                _("Could not copy this image."),
+                _("Copy Image"),
+                style=wx.ICON_ERROR,
+                parent=self,
+            )
+        else:
+            speech.announce(_("Image copied to clipboard"), True)

--- a/bookworm/gui/book_viewer/render_view.py
+++ b/bookworm/gui/book_viewer/render_view.py
@@ -292,10 +292,7 @@ class EmbeddedImageDialog(wx.Dialog):
         ):
             return
         try:
-            pil_image = self.prepare_image_for_save(
-                self.image_io.to_pil(),
-                image_format,
-            )
+            pil_image = ImageIO.prepare_pil_for_save(self.image_io.to_pil(), image_format)
             pil_image.save(output_path, format=image_format)
         except Exception:
             log.exception("Failed to save embedded image.", exc_info=True)
@@ -307,24 +304,6 @@ class EmbeddedImageDialog(wx.Dialog):
             )
         else:
             speech.announce(_("Image saved"), True)
-
-    @staticmethod
-    def prepare_image_for_save(pil_image, image_format):
-        if image_format == "JPEG":
-            return pil_image.convert("RGB")
-        if image_format == "PNG" and pil_image.mode not in {
-            "1",
-            "L",
-            "LA",
-            "P",
-            "RGB",
-            "RGBA",
-            "I",
-            "I;16",
-        }:
-            output_mode = "RGBA" if "A" in pil_image.getbands() else "RGB"
-            return pil_image.convert(output_mode)
-        return pil_image
 
     @classmethod
     def get_save_target(cls, path, filter_index):

--- a/bookworm/gui/book_viewer/render_view.py
+++ b/bookworm/gui/book_viewer/render_view.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 from pathlib import Path
 
 import wx

--- a/bookworm/gui/text_ctrl_mixin.py
+++ b/bookworm/gui/text_ctrl_mixin.py
@@ -3,7 +3,6 @@
 import wx
 import wx.lib.newevent
 
-import bookworm.typehints as t
 from bookworm.logger import logger
 from bookworm.structured_text import SemanticElementType
 from bookworm import config

--- a/bookworm/gui/text_ctrl_mixin.py
+++ b/bookworm/gui/text_ctrl_mixin.py
@@ -34,7 +34,7 @@ SEMANTIC_MAP = {
     "L": SemanticElementType.LIST,
     "T": SemanticElementType.TABLE,
     "Q": SemanticElementType.QUOTE,
-    # "G": SemanticElementType.FIGURE,
+    "I": SemanticElementType.FIGURE,
 }
 SEMANTIC_MAP |= HEADING_LEVEL_KEY_MAP
 SEMANTIC_KEY_MAP = {ord(k): v for k, v in SEMANTIC_MAP.items()}

--- a/bookworm/gui/text_ctrl_mixin.py
+++ b/bookworm/gui/text_ctrl_mixin.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 import wx
 import wx.lib.newevent
 

--- a/bookworm/image_io.py
+++ b/bookworm/image_io.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import base64
 import io
 import importlib
 import tempfile
 from dataclasses import dataclass
+from urllib.parse import unquote_to_bytes
 
 import fitz
 import wx
@@ -57,9 +59,11 @@ class ImageIO:
         return self.from_cv2(cv2.bitwise_not(self.to_cv2()))
 
     @classmethod
-    def from_filename(cls, image_path: t.PathLike) -> "ImageBlueprint":
+    def from_filename(cls, image_path: t.PathLike, *, preserve_mode=False) -> "ImageIO":
         try:
-            pil_image = Image.open(image_path).convert("RGB")
+            pil_image = Image.open(image_path)
+            if not preserve_mode:
+                pil_image = pil_image.convert("RGB")
             return cls.from_pil(pil_image)
         except Exception:
             log.exception(
@@ -67,7 +71,9 @@ class ImageIO:
             )
 
     @classmethod
-    def from_pil(cls, image: Image.Image) -> "ImageBlueprint":
+    def from_pil(cls, image: Image.Image) -> "ImageIO":
+        if image.mode == "P":
+            image = image.convert("RGBA" if "transparency" in image.info else "RGB")
         return cls(
             data=image.tobytes(),
             width=image.width,
@@ -134,13 +140,24 @@ class ImageIO:
         )
 
     def to_pil(self) -> Image.Image:
-        return Image.frombytes("RGB", self.size, self.data)
+        return Image.frombytes(self.mode, self.size, self.data)
 
     def to_cv2(self):
         pil_image = self.to_pil().convert("RGB")
         return cv2.cvtColor(np.array(pil_image, dtype=np.uint8), cv2.COLOR_RGB2GRAY)
 
     def to_wx_bitmap(self):
+        pil_image = self.to_pil()
+        if any(band.upper() == "A" for band in pil_image.getbands()):
+            rgba_image = pil_image.convert("RGBA")
+            red, green, blue, alpha = rgba_image.split()
+            rgb_image = Image.merge("RGB", (red, green, blue))
+            return wx.ImageFromBuffer(
+                self.width,
+                self.height,
+                bytearray(rgb_image.tobytes()),
+                bytearray(alpha.tobytes()),
+            ).ConvertToBitmap()
         img = self.as_rgb()
         return wx.ImageFromBuffer(
             img.width, img.height, bytearray(img.data)
@@ -153,13 +170,26 @@ class ImageIO:
 
     def as_bytes(self, *, format="JPEG"):
         buf = io.BytesIO()
-        self.to_pil().save(buf, format=format)
+        image_format = "JPEG" if format.upper() == "JPG" else format.upper()
+        image = self.to_pil()
+        if image_format == "JPEG" and image.mode != "RGB":
+            image = image.convert("RGB")
+        image.save(buf, format=image_format)
         return buf.getvalue()
 
     @classmethod
     def from_bytes(cls, value):
         img = Image.open(io.BytesIO(value))
         return cls.from_pil(img)
+
+    @classmethod
+    def from_data_uri(cls, value: str):
+        header, encoded = value.split(",", 1)
+        if ";base64" in header.lower():
+            data = base64.b64decode(encoded)
+        else:
+            data = unquote_to_bytes(encoded)
+        return cls.from_bytes(data)
 
     def make_thumbnail(self, width, height, *, exact_fit=False, fil_color="#fff"):
         pil_image = self.to_pil()

--- a/bookworm/image_io.py
+++ b/bookworm/image_io.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import base64
 import io
-import importlib
-import tempfile
 from dataclasses import dataclass
 from urllib.parse import unquote_to_bytes
 

--- a/bookworm/image_io.py
+++ b/bookworm/image_io.py
@@ -184,12 +184,14 @@ class ImageIO:
 
     @classmethod
     def from_data_uri(cls, value: str):
+        return cls.from_bytes(cls.data_uri_to_bytes(value))
+
+    @staticmethod
+    def data_uri_to_bytes(value: str) -> bytes:
         header, encoded = value.split(",", 1)
         if ";base64" in header.lower():
-            data = base64.b64decode(encoded)
-        else:
-            data = unquote_to_bytes(encoded)
-        return cls.from_bytes(data)
+            return base64.b64decode(encoded)
+        return unquote_to_bytes(encoded)
 
     def make_thumbnail(self, width, height, *, exact_fit=False, fil_color="#fff"):
         pil_image = self.to_pil()

--- a/bookworm/image_io.py
+++ b/bookworm/image_io.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 from __future__ import annotations
 
 import base64

--- a/bookworm/image_io.py
+++ b/bookworm/image_io.py
@@ -17,6 +17,7 @@ np = lazy_module("numpy")
 cv2 = lazy_module("cv2")
 
 log = logger.getChild(__name__)
+PNG_SAVE_MODES = {"1", "L", "LA", "P", "RGB", "RGBA", "I", "I;16"}
 
 
 @dataclass
@@ -170,6 +171,8 @@ class ImageIO:
         image = self.to_pil()
         if image_format == "JPEG" and image.mode != "RGB":
             image = image.convert("RGB")
+        elif image_format == "PNG" and image.mode not in PNG_SAVE_MODES:
+            image = image.convert("RGBA" if "A" in image.getbands() else "RGB")
         image.save(buf, format=image_format)
         return buf.getvalue()
 

--- a/bookworm/image_io.py
+++ b/bookworm/image_io.py
@@ -143,6 +143,16 @@ class ImageIO:
         pil_image = self.to_pil().convert("RGB")
         return cv2.cvtColor(np.array(pil_image, dtype=np.uint8), cv2.COLOR_RGB2GRAY)
 
+    @staticmethod
+    def prepare_pil_for_save(pil_image: Image.Image, image_format: str) -> Image.Image:
+        image_format = "JPEG" if image_format.upper() == "JPG" else image_format.upper()
+        if image_format == "JPEG" and pil_image.mode != "RGB":
+            return pil_image.convert("RGB")
+        if image_format == "PNG" and pil_image.mode not in PNG_SAVE_MODES:
+            output_mode = "RGBA" if "A" in pil_image.getbands() else "RGB"
+            return pil_image.convert(output_mode)
+        return pil_image
+
     def to_wx_bitmap(self):
         pil_image = self.to_pil()
         if any(band.upper() == "A" for band in pil_image.getbands()):
@@ -168,11 +178,7 @@ class ImageIO:
     def as_bytes(self, *, format="JPEG"):
         buf = io.BytesIO()
         image_format = "JPEG" if format.upper() == "JPG" else format.upper()
-        image = self.to_pil()
-        if image_format == "JPEG" and image.mode != "RGB":
-            image = image.convert("RGB")
-        elif image_format == "PNG" and image.mode not in PNG_SAVE_MODES:
-            image = image.convert("RGBA" if "A" in image.getbands() else "RGB")
+        image = self.prepare_pil_for_save(self.to_pil(), image_format)
         image.save(buf, format=image_format)
         return buf.getvalue()
 

--- a/bookworm/reader.py
+++ b/bookworm/reader.py
@@ -557,11 +557,37 @@ class EBookReader:
             )
 
     def handle_special_action_for_position(self, position: int) -> bool:
+        page = self.get_current_page_object()
+        image_open_failed = False
+        for idx, image_range in enumerate(
+            self.iter_semantic_ranges_for_elements_of_type(SemanticElementType.FIGURE)
+        ):
+            if position in range(*image_range):
+                try:
+                    image_info = page.get_embedded_image_info(idx)
+                    image = page.get_embedded_image(idx)
+                except (DocumentIOError, IndexError, NotImplementedError):
+                    log.exception("Failed to open embedded image.", exc_info=True)
+                    image_open_failed = True
+                    break
+                else:
+                    self._show_image(image, image_info)
+                    return True
         for link_range in self.iter_semantic_ranges_for_elements_of_type(
             SemanticElementType.LINK
         ):
             if position in range(*link_range):
                 self.navigate_to_link_by_range(link_range)
+                return True
+        if image_open_failed:
+            if notify_user := getattr(self.view, "notify_user", None):
+                notify_user(
+                    _("Image unavailable"),
+                    _("Could not open this image."),
+                )
+            else:
+                self.view.notify_invalid_action()
+            return True
         try:
             for idx, tbl_range in enumerate(
                 self.iter_semantic_ranges_for_elements_of_type(
@@ -569,10 +595,12 @@ class EBookReader:
                 )
             ):
                 if position in range(*tbl_range):
-                    table_markup = self.get_current_page_object().get_table_markup(idx)
+                    table_markup = page.get_table_markup(idx)
                     self._show_table(table_markup)
+                    return True
         except NotImplementedError:
             pass
+        return False
 
     @staticmethod
     def _get_semantic_element_from_page(page, element_type, forward, anchor):
@@ -732,3 +760,14 @@ class EBookReader:
             )
             title = f"{caption_text} · {title}"
         self.view.show_html_dialog(table_markup, title=title)
+
+    def _show_image(self, image, image_info):
+        # Translators: title of a dialog that shows an embedded book image
+        title = _("Image View")
+        if image_info.label:
+            title = f"{image_info.label} - {title}"
+        self.view.show_image_dialog(
+            image,
+            title=title,
+            suggested_filename=image_info.suggested_filename,
+        )

--- a/bookworm/reader.py
+++ b/bookworm/reader.py
@@ -1,11 +1,10 @@
-# coding: utf-8
 
 import os
 import re
 import string
 from contextlib import suppress
-from pathlib import Path
 
+import sqlalchemy as sa
 from selectolax.parser import HTMLParser
 
 from bookworm import app, config
@@ -18,18 +17,14 @@ from bookworm.document import (
     BaseDocument,
     BasePage,
     ChangeDocument,
-)
-from bookworm.document import DocumentCapability as DC
-from bookworm.document import (
     DocumentEncryptedError,
-    DocumentError,
     DocumentIOError,
     PaginationError,
     Section,
 )
 from bookworm.document.formats import *
+from bookworm.document.hash_utils import get_persistent_content_hash
 from bookworm.document.uri import DocumentUri
-from bookworm.i18n import is_rtl
 from bookworm.logger import logger
 from bookworm.signals import (
     reader_book_loaded,
@@ -38,7 +33,13 @@ from bookworm.signals import (
     reader_section_changed,
     reading_position_change,
 )
-from bookworm.structured_text import SemanticElementType, TextStructureMetadata
+from bookworm.structured_text import (
+    CURRENT_CONTENT_HASH_VERSION,
+    CURRENT_POSITION_MODEL_VERSION,
+    SemanticElementType,
+    TextRange,
+    TextStructureMetadata,
+)
 
 log = logger.getChild(__name__)
 
@@ -101,9 +102,7 @@ class UriResolver:
             return doc, self.original_uri
         except ChangeDocument as e:
             # Propagate the original URI through the conversion chain.
-            return UriResolver(
-                uri=e.new_uri, original_uri=self.original_uri
-            ).read_document()
+            return UriResolver(uri=e.new_uri, original_uri=self.original_uri).read_document()
         except:
             if (fallback_uri := self.uri.fallback_uri) is not None:
                 if self.num_fallbacks < 4:
@@ -123,9 +122,7 @@ class UriResolver:
         except DocumentIOError as e:
             raise ResourceDoesNotExist("Failed to load document") from e
         except Exception as e:
-            if type(e) in PASS_THROUGH__DOCUMENT_EXCEPTIONS or isinstance(
-                e, ChangeDocument
-            ):
+            if type(e) in PASS_THROUGH__DOCUMENT_EXCEPTIONS or isinstance(e, ChangeDocument):
                 raise e
             raise ReaderError("Failed to open document") from e
         return document
@@ -137,12 +134,12 @@ class EBookReader:
     """
 
     __slots__ = [
-        "document",
-        "stored_document_info",
-        "view",
         "__state",
         "current_book",
         "current_book_record",
+        "document",
+        "stored_document_info",
+        "view",
     ]
 
     def _record_matches_document(self, record, uri_for_storage, content_hash):
@@ -151,6 +148,7 @@ class EBookReader:
         return (
             content_hash is not None
             and record.content_hash == content_hash
+            and record.content_hash_version == CURRENT_CONTENT_HASH_VERSION
             and record.uri.format == uri_for_storage.format
         )
 
@@ -159,6 +157,7 @@ class EBookReader:
             return []
         records = (
             model.query.filter(model.content_hash == content_hash)
+            .filter(model.content_hash_version == CURRENT_CONTENT_HASH_VERSION)
             .order_by(model.id.asc())
             .all()
         )
@@ -167,6 +166,22 @@ class EBookReader:
             for record in records
             if self._record_matches_document(record, uri_for_storage, content_hash)
         ]
+
+    def _get_legacy_matching_document_records(self, model, *, uri_for_storage, legacy_content_hash):
+        if legacy_content_hash is None:
+            return []
+        records = (
+            model.query.filter(model.content_hash == legacy_content_hash)
+            .filter(
+                sa.or_(
+                    model.content_hash_version.is_(None),
+                    model.content_hash_version != CURRENT_CONTENT_HASH_VERSION,
+                )
+            )
+            .order_by(model.id.asc())
+            .all()
+        )
+        return [record for record in records if record.uri.format == uri_for_storage.format]
 
     def _select_document_record(self, records, uri_for_storage):
         for record in records:
@@ -183,9 +198,7 @@ class EBookReader:
         if uri_record is not None:
             matching_records.append(uri_record)
         matching_ids = {
-            record.id
-            for record in matching_records
-            if getattr(record, "id", None) is not None
+            record.id for record in matching_records if getattr(record, "id", None) is not None
         }
         for record in hash_matching_records:
             if record.id in matching_ids:
@@ -209,6 +222,7 @@ class EBookReader:
         for duplicate in duplicates:
             if duplicate.get_last_position() != (0, 0):
                 record.last_page, record.last_position = duplicate.get_last_position()
+                record.position_version = duplicate.position_version
                 return
 
     def _merge_document_records(self, model, session, record, duplicates):
@@ -226,30 +240,48 @@ class EBookReader:
         title: str,
         uri_for_storage: DocumentUri,
         content_hash_provider: t.Callable[[], str | None],
+        legacy_content_hash_provider: t.Callable[[], str | None] | None = None,
     ):
         session = model.session()
         uri_record = self._get_document_record_by_uri(model, uri_for_storage)
-        content_hash = (
-            uri_record.content_hash
-            if uri_record is not None and uri_record.content_hash is not None
-            else content_hash_provider()
+        if (
+            uri_record is not None
+            and uri_record.content_hash_version == CURRENT_CONTENT_HASH_VERSION
+            and uri_record.content_hash is not None
+        ):
+            content_hash = uri_record.content_hash
+        else:
+            content_hash = content_hash_provider()
+        legacy_content_hash = (
+            legacy_content_hash_provider()
+            if legacy_content_hash_provider is not None
+            else None
+        )
+        stored_content_hash, stored_content_hash_version = get_persistent_content_hash(
+            content_hash,
+            legacy_content_hash,
         )
         matching_records = self._get_matching_document_records(
             model,
             uri_for_storage=uri_for_storage,
             content_hash=content_hash,
         )
-        matching_records = self._merge_matching_document_records(
-            uri_record, matching_records
-        )
-        record = uri_record or self._select_document_record(
-            matching_records, uri_for_storage
-        )
+        if legacy_content_hash_provider is not None:
+            matching_records.extend(
+                self._get_legacy_matching_document_records(
+                    model,
+                    uri_for_storage=uri_for_storage,
+                    legacy_content_hash=legacy_content_hash,
+                )
+            )
+        matching_records = self._merge_matching_document_records(uri_record, matching_records)
+        record = uri_record or self._select_document_record(matching_records, uri_for_storage)
         if record is None:
             record = model(
                 title=title,
                 uri=uri_for_storage,
-                content_hash=content_hash,
+                content_hash=stored_content_hash,
+                content_hash_version=stored_content_hash_version,
             )
         else:
             duplicate_records = [
@@ -258,8 +290,12 @@ class EBookReader:
             self._merge_document_records(model, session, record, duplicate_records)
             if record.title != title:
                 record.title = title
-            if record.content_hash is None:
-                record.content_hash = content_hash
+            if (
+                record.content_hash != stored_content_hash
+                or record.content_hash_version != stored_content_hash_version
+            ):
+                record.content_hash = stored_content_hash
+                record.content_hash_version = stored_content_hash_version
             if record.uri != uri_for_storage:
                 record.uri = uri_for_storage
         session.add(record)
@@ -278,32 +314,149 @@ class EBookReader:
                 content_hash = doc.get_content_hash()
             return content_hash
 
+        def get_legacy_content_hash():
+            return doc.get_legacy_content_hash()
+
         self.current_book_record = self._get_or_create_document_record(
             Book,
             title=current_book.title,
             uri_for_storage=uri_for_storage,
             content_hash_provider=get_content_hash,
+            legacy_content_hash_provider=get_legacy_content_hash,
         )
         return self._get_or_create_document_record(
             DocumentPositionInfo,
             title=current_book.title,
             uri_for_storage=uri_for_storage,
             content_hash_provider=get_content_hash,
+            legacy_content_hash_provider=get_legacy_content_hash,
         )
 
     def get_or_create_current_book_record(self):
         if self.current_book_record is not None:
             return self.current_book_record
         if self.document is None:
-            return
+            return None
         current_book = self.document.metadata
         self.current_book_record = self._get_or_create_document_record(
             Book,
             title=current_book.title,
             uri_for_storage=self.document.uri,
             content_hash_provider=self.document.get_content_hash,
+            legacy_content_hash_provider=self.document.get_legacy_content_hash,
         )
         return self.current_book_record
+
+    def _get_page_for_position_mapping(self, page_number=None):
+        page_number = self.current_page if page_number is None else page_number
+        if self.document is None or page_number not in self.document:
+            return None
+        return self.document[page_number]
+
+    def view_to_storage_position(self, pos, page_number=None, affinity="before"):
+        page = self._get_page_for_position_mapping(page_number)
+        if page is None:
+            return max(0, pos)
+        return page.display_to_storage_position(pos, affinity=affinity)
+
+    def storage_to_view_position(self, pos, page_number=None, affinity="before"):
+        page = self._get_page_for_position_mapping(page_number)
+        if page is None:
+            return max(0, pos)
+        return page.storage_to_display_position(pos, affinity=affinity)
+
+    def view_to_storage_range(self, start, stop, page_number=None):
+        page = self._get_page_for_position_mapping(page_number)
+        if page is None:
+            return TextRange(start, stop)
+        return page.display_to_storage_range(start, stop)
+
+    def storage_to_view_range(self, start, stop, page_number=None):
+        page = self._get_page_for_position_mapping(page_number)
+        if page is None:
+            return TextRange(start, stop)
+        return page.storage_to_display_range(start, stop)
+
+    def legacy_view_to_storage_position(self, pos, page_number=None, affinity="before"):
+        page = self._get_page_for_position_mapping(page_number)
+        if page is None:
+            return max(0, pos)
+        return page.legacy_to_storage_position(pos, affinity=affinity)
+
+    def legacy_view_to_storage_range(self, start, stop, page_number=None):
+        page = self._get_page_for_position_mapping(page_number)
+        if page is None:
+            return TextRange(start, stop)
+        return page.legacy_to_storage_range(start, stop)
+
+    def _migrate_current_document_positions(self):
+        if self.document is None or self.current_book_record is None:
+            return
+        session = self.current_book_record.session()
+        has_updates = False
+        if (
+            self.stored_document_info is not None
+            and self.stored_document_info.position_version != CURRENT_POSITION_MODEL_VERSION
+        ):
+            self.stored_document_info.last_position = self.legacy_view_to_storage_position(
+                self.stored_document_info.last_position,
+                self.stored_document_info.last_page,
+                affinity="after",
+            )
+            self.stored_document_info.position_version = CURRENT_POSITION_MODEL_VERSION
+            session.add(self.stored_document_info)
+            has_updates = True
+        for model in (Bookmark, Note, Quote):
+            stale_records = (
+                model.query.filter_by(book_id=self.current_book_record.id)
+                .filter(
+                    sa.or_(
+                        model.position_version.is_(None),
+                        model.position_version != CURRENT_POSITION_MODEL_VERSION,
+                    )
+                )
+                .all()
+            )
+            for record in stale_records:
+                page_number = record.page_number
+                if hasattr(record, "start_pos") and hasattr(record, "end_pos"):
+                    if record.start_pos is not None and record.end_pos is not None:
+                        storage_range = self.legacy_view_to_storage_range(
+                            record.start_pos,
+                            record.end_pos,
+                            page_number,
+                        )
+                        record.start_pos, record.end_pos = storage_range.astuple()
+                        record.position = record.start_pos
+                    elif record.start_pos is not None:
+                        record.start_pos = self.legacy_view_to_storage_position(
+                            record.start_pos,
+                            page_number,
+                            affinity="after",
+                        )
+                        record.position = record.start_pos
+                    elif record.end_pos is not None:
+                        record.end_pos = self.legacy_view_to_storage_range(
+                            0,
+                            record.end_pos,
+                            page_number,
+                        ).stop
+                        record.position = self.legacy_view_to_storage_position(
+                            record.position, page_number, affinity="after"
+                        )
+                    else:
+                        record.position = self.legacy_view_to_storage_position(
+                            record.position, page_number, affinity="after"
+                        )
+                else:
+                    record.position = self.legacy_view_to_storage_position(
+                        record.position, page_number, affinity="after"
+                    )
+                record.position_version = CURRENT_POSITION_MODEL_VERSION
+                session.add(record)
+                has_updates = True
+        if has_updates:
+            session.commit()
 
     # Convenience method: make this available for importers as a staticmethod
     get_document_format_info = staticmethod(get_document_format_info)
@@ -318,9 +471,7 @@ class EBookReader:
         self.current_book_record = None
         self.__state = {}
 
-    def set_document(
-        self, document: BaseDocument, original_uri: str | None = None
-    ) -> None:
+    def set_document(self, document: BaseDocument, original_uri: str | None = None) -> None:
         self.stored_document_info = None
         self.current_book_record = None
         self.__state["ready"] = False
@@ -341,6 +492,7 @@ class EBookReader:
             self.stored_document_info = self._get_or_create_document_position_info(
                 document, uri_for_storage
             )
+        self._migrate_current_document_positions()
         # the current_page is set after the document position info and related models are created in order to allow dependent services to access the current_book
         self.current_page = 0
         if open_args := self.document.uri.openner_args:
@@ -348,18 +500,16 @@ class EBookReader:
             pos = int(open_args.get("position", 0))
             self.go_to_page(page, pos)
             self.view.contentTextCtrl.SetFocus()
-        elif (
-            self.stored_document_info
-            and config.conf["general"]["open_with_last_position"]
-        ):
+        elif self.stored_document_info and config.conf["general"]["open_with_last_position"]:
             try:
                 log.debug("Navigating to the last saved position.")
                 page_number, pos = self.stored_document_info.get_last_position()
-                self.go_to_page(page_number, pos)
-            except:
-                log.exception(
-                    "Failed to restore last saved reading position", exc_info=True
+                self.go_to_page(
+                    page_number,
+                    self.storage_to_view_position(pos, page_number),
                 )
+            except:
+                log.exception("Failed to restore last saved reading position", exc_info=True)
         if self.active_section is None:
             self.__state["active_section"] = self.document.get_section_at_position(
                 self.view.get_insertion_point()
@@ -386,9 +536,7 @@ class EBookReader:
             log.debug("Closing current document.")
             self.document.close()
         except:
-            log.exception(
-                "An exception was raised while closing the eBook", exc_info=True
-            )
+            log.exception("An exception was raised while closing the eBook", exc_info=True)
             if app.debug:
                 raise
         finally:
@@ -400,7 +548,7 @@ class EBookReader:
             return
         self.stored_document_info.save_position(
             self.current_page,
-            self.view.get_insertion_point(),
+            self.view_to_storage_position(self.view.get_insertion_point()),
         )
 
     @property
@@ -481,8 +629,7 @@ class EBookReader:
                 ):
                     self.current_page = next_move
                     return True
-                else:
-                    return False
+                return False
         elif unit == "section":
             this_section = self.active_section
             target = "simple_next" if to == "next" else "simple_prev"
@@ -552,9 +699,7 @@ class EBookReader:
                 self.go_to_page(page_num)
             start, end = nav_stack_top["source_range"]
             self.view.go_to_position(start, end)
-            reading_position_change.send(
-                self.view, position=start, tts_speech_prefix=""
-            )
+            reading_position_change.send(self.view, position=start, tts_speech_prefix="")
 
     def handle_special_action_for_position(self, position: int) -> bool:
         page = self.get_current_page_object()
@@ -573,9 +718,7 @@ class EBookReader:
                 else:
                     self._show_image(image, image_info)
                     return True
-        for link_range in self.iter_semantic_ranges_for_elements_of_type(
-            SemanticElementType.LINK
-        ):
+        for link_range in self.iter_semantic_ranges_for_elements_of_type(SemanticElementType.LINK):
             if position in range(*link_range):
                 self.navigate_to_link_by_range(link_range)
                 return True
@@ -590,9 +733,7 @@ class EBookReader:
             return True
         try:
             for idx, tbl_range in enumerate(
-                self.iter_semantic_ranges_for_elements_of_type(
-                    SemanticElementType.TABLE
-                )
+                self.iter_semantic_ranges_for_elements_of_type(SemanticElementType.TABLE)
             ):
                 if position in range(*tbl_range):
                     table_markup = page.get_table_markup(idx)
@@ -605,11 +746,7 @@ class EBookReader:
     @staticmethod
     def _get_semantic_element_from_page(page, element_type, forward, anchor):
         semantics = TextStructureMetadata(page.semantic_structure)
-        pos_getter = (
-            semantics.get_next_element_pos
-            if forward
-            else semantics.get_prev_element_pos
-        )
+        pos_getter = semantics.get_next_element_pos if forward else semantics.get_prev_element_pos
         return pos_getter(element_type, anchor=anchor)
 
     def get_semantic_element(self, element_type, forward, anchor):
@@ -618,9 +755,7 @@ class EBookReader:
         )
 
     def iter_semantic_ranges_for_elements_of_type(self, element_type):
-        semantics = TextStructureMetadata(
-            self.get_current_page_object().semantic_structure
-        )
+        semantics = TextStructureMetadata(self.get_current_page_object().semantic_structure)
         yield from semantics.iter_ranges(element_type)
 
     def navigate_to_link_by_range(self, link_range):
@@ -628,7 +763,7 @@ class EBookReader:
         if target_info is None:
             log.warning(f"Could not resolve link target: {link_range=}")
             return
-        elif target_info.is_external:
+        if target_info.is_external:
             self.view.go_to_webpage(target_info.url)
         else:
             start, end = target_info.position
@@ -650,9 +785,7 @@ class EBookReader:
         if include_author and self.current_book.author:
             author = self.current_book.author
             # Translators: the title of the window when an e-book is open
-            view_title = _("{title} — by {author}").format(
-                title=view_title, author=author
-            )
+            view_title = _("{title} — by {author}").format(title=view_title, author=author)
         return view_title + f" - {app.display_name}"
 
     @staticmethod
@@ -677,7 +810,13 @@ class EBookReader:
         # Check for existing thead
         if table.css_first("thead"):
             if not has_caption:
-                return re.sub(r"(<table[^>]*>)", r"\1" + sr_caption, table_markup, count=1, flags=re.IGNORECASE)
+                return re.sub(
+                    r"(<table[^>]*>)",
+                    r"\1" + sr_caption,
+                    table_markup,
+                    count=1,
+                    flags=re.IGNORECASE,
+                )
             return table_markup
 
         # Detection Logic
@@ -702,7 +841,13 @@ class EBookReader:
 
         if not promote_header:
             if not has_caption:
-                return re.sub(r"(<table[^>]*>)", r"\1" + sr_caption, table_markup, count=1, flags=re.IGNORECASE)
+                return re.sub(
+                    r"(<table[^>]*>)",
+                    r"\1" + sr_caption,
+                    table_markup,
+                    count=1,
+                    flags=re.IGNORECASE,
+                )
             return table_markup
 
         # Reconstruction Logic
@@ -755,9 +900,7 @@ class EBookReader:
         # Translators: title of a message dialog that shows a table as html document
         title = _("Table View")
         if (table_caption := HTMLParser(table_markup).css_first("caption")) is not None:
-            caption_text = (
-                table_caption.text().strip(string.whitespace).replace("\n", " ")
-            )
+            caption_text = table_caption.text().strip(string.whitespace).replace("\n", " ")
             title = f"{caption_text} · {title}"
         self.view.show_html_dialog(table_markup, title=title)
 

--- a/bookworm/reader.py
+++ b/bookworm/reader.py
@@ -722,15 +722,6 @@ class EBookReader:
             if position in range(*link_range):
                 self.navigate_to_link_by_range(link_range)
                 return True
-        if image_open_failed:
-            if notify_user := getattr(self.view, "notify_user", None):
-                notify_user(
-                    _("Image unavailable"),
-                    _("Could not open this image."),
-                )
-            else:
-                self.view.notify_invalid_action()
-            return True
         try:
             for idx, tbl_range in enumerate(
                 self.iter_semantic_ranges_for_elements_of_type(SemanticElementType.TABLE)
@@ -741,6 +732,15 @@ class EBookReader:
                     return True
         except NotImplementedError:
             pass
+        if image_open_failed:
+            if notify_user := getattr(self.view, "notify_user", None):
+                notify_user(
+                    _("Image unavailable"),
+                    _("Could not open this image."),
+                )
+            else:
+                self.view.notify_invalid_action()
+            return True
         return False
 
     @staticmethod

--- a/bookworm/structured_text/__init__.py
+++ b/bookworm/structured_text/__init__.py
@@ -1,11 +1,18 @@
-# coding: utf-8
 
-from .primitives import TextInfo, TextRange
+from .primitives import (
+    CURRENT_CONTENT_HASH_VERSION,
+    CURRENT_POSITION_MODEL_VERSION,
+    TEXT_OBJECT_REPLACEMENT_CHAR,
+    TextInfo,
+    TextPositionMap,
+    TextPositionReplacement,
+    TextRange,
+)
 from .string_builder import StringBuilder
 from .structural_elements import (
     HEADING_LEVELS,
-    ImageElementInfo,
     SEMANTIC_ELEMENT_OUTPUT_OPTIONS,
+    ImageElementInfo,
     SemanticElementType,
     Style,
     TextStructureMetadata,

--- a/bookworm/structured_text/__init__.py
+++ b/bookworm/structured_text/__init__.py
@@ -17,3 +17,20 @@ from .structural_elements import (
     Style,
     TextStructureMetadata,
 )
+
+__all__ = [
+    "CURRENT_CONTENT_HASH_VERSION",
+    "CURRENT_POSITION_MODEL_VERSION",
+    "HEADING_LEVELS",
+    "ImageElementInfo",
+    "SEMANTIC_ELEMENT_OUTPUT_OPTIONS",
+    "SemanticElementType",
+    "StringBuilder",
+    "Style",
+    "TEXT_OBJECT_REPLACEMENT_CHAR",
+    "TextInfo",
+    "TextPositionMap",
+    "TextPositionReplacement",
+    "TextRange",
+    "TextStructureMetadata",
+]

--- a/bookworm/structured_text/__init__.py
+++ b/bookworm/structured_text/__init__.py
@@ -4,6 +4,7 @@ from .primitives import TextInfo, TextRange
 from .string_builder import StringBuilder
 from .structural_elements import (
     HEADING_LEVELS,
+    ImageElementInfo,
     SEMANTIC_ELEMENT_OUTPUT_OPTIONS,
     SemanticElementType,
     Style,

--- a/bookworm/structured_text/primitives.py
+++ b/bookworm/structured_text/primitives.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 
 """Provides primitives for structuring a blob of text."""
 
@@ -15,6 +14,10 @@ from more_itertools import locate
 from pytqsm import segment as segment_sentences
 
 from bookworm import typehints as t
+
+TEXT_OBJECT_REPLACEMENT_CHAR = "\ufffc"
+CURRENT_POSITION_MODEL_VERSION = 2
+CURRENT_CONTENT_HASH_VERSION = 2
 
 
 @attr.s(auto_attribs=True, slots=True, hash=False)
@@ -34,10 +37,9 @@ class TextRange(Container):
     def operator_imp(self, other, operator_func):
         if isinstance(other, self.__class__):
             return operator_func(self.start, other.start)
-        elif type(other) is int:
+        if type(other) is int:
             return operator_func(self.start, other)
-        else:
-            return NotImplemented
+        return NotImplemented
 
     def __gt__(self, other):
         return self.operator_imp(other, operator.gt)
@@ -65,6 +67,271 @@ class TextRange(Container):
 
     def as_slice(self):
         return slice(self.start, self.stop)
+
+
+@attr.s(auto_attribs=True, slots=True, frozen=True)
+class TextPositionReplacement:
+    display_start: int
+    display_stop: int
+    storage_start: int
+    storage_stop: int
+
+    @property
+    def display_length(self):
+        return self.display_stop - self.display_start
+
+    @property
+    def storage_length(self):
+        return self.storage_stop - self.storage_start
+
+
+@attr.s(auto_attribs=True, slots=True, frozen=True)
+class TextPositionMap:
+    """Maps user-visible text offsets to stable storage offsets."""
+
+    display_length: int
+    storage_length: int
+    replacements: tuple[TextPositionReplacement, ...] = ()
+
+    @classmethod
+    def identity(cls, text_length=0):
+        return cls(
+            display_length=max(text_length, 0),
+            storage_length=max(text_length, 0),
+        )
+
+    @classmethod
+    def from_collapsed_ranges(cls, display_text, ranges, replacement_text=None):
+        replacement_text = replacement_text or TEXT_OBJECT_REPLACEMENT_CHAR
+        normalized_ranges = []
+        previous_stop = 0
+        for text_range in sorted(ranges, key=lambda rng: (rng.start, rng.stop)):
+            start = max(0, text_range.start)
+            stop = min(len(display_text), text_range.stop)
+            if stop <= start or start < previous_stop:
+                continue
+            normalized_ranges.append(TextRange(start, stop))
+            previous_stop = stop
+        if not normalized_ranges:
+            return display_text, cls.identity(len(display_text))
+
+        storage_chunks = []
+        replacements = []
+        display_cursor = 0
+        storage_cursor = 0
+        for display_range in normalized_ranges:
+            prefix = display_text[display_cursor : display_range.start]
+            storage_chunks.append(prefix)
+            storage_cursor += len(prefix)
+            storage_start = storage_cursor
+            storage_chunks.append(replacement_text)
+            storage_cursor += len(replacement_text)
+            replacements.append(
+                TextPositionReplacement(
+                    display_start=display_range.start,
+                    display_stop=display_range.stop,
+                    storage_start=storage_start,
+                    storage_stop=storage_cursor,
+                )
+            )
+            display_cursor = display_range.stop
+        suffix = display_text[display_cursor:]
+        storage_chunks.append(suffix)
+        storage_cursor += len(suffix)
+        return "".join(storage_chunks), cls(
+            display_length=len(display_text),
+            storage_length=storage_cursor,
+            replacements=tuple(replacements),
+        )
+
+    @classmethod
+    def from_texts(cls, display_text, storage_text):
+        """Build a position map between two mostly-identical text models."""
+        if display_text == storage_text:
+            return cls.identity(len(display_text))
+        display_length = len(display_text)
+        storage_length = len(storage_text)
+        replacements = []
+        display_cursor = 0
+        storage_cursor = 0
+        while display_cursor < display_length and storage_cursor < storage_length:
+            if display_text[display_cursor] == storage_text[storage_cursor]:
+                display_cursor += 1
+                storage_cursor += 1
+                continue
+            display_anchor, storage_anchor = cls._find_alignment_anchor(
+                display_text,
+                storage_text,
+                display_cursor,
+                storage_cursor,
+            )
+            replacements.append(
+                TextPositionReplacement(
+                    display_start=display_cursor,
+                    display_stop=display_anchor,
+                    storage_start=storage_cursor,
+                    storage_stop=storage_anchor,
+                )
+            )
+            display_cursor = display_anchor
+            storage_cursor = storage_anchor
+        if display_cursor < display_length or storage_cursor < storage_length:
+            replacements.append(
+                TextPositionReplacement(
+                    display_start=display_cursor,
+                    display_stop=display_length,
+                    storage_start=storage_cursor,
+                    storage_stop=storage_length,
+                )
+            )
+        return cls(
+            display_length=display_length,
+            storage_length=storage_length,
+            replacements=tuple(replacements),
+        )
+
+    @staticmethod
+    def _find_alignment_anchor(display_text, storage_text, display_start, storage_start):
+        anchor_lengths = (48, 32, 24, 16, 12, 8, 6, 4, 3, 2, 1)
+        search_window = 4096
+        display_length = len(display_text)
+        storage_length = len(storage_text)
+        best = None
+        for anchor_length in anchor_lengths:
+            if display_start + anchor_length <= display_length:
+                display_offset_limit = min(
+                    search_window,
+                    display_length - display_start - anchor_length,
+                )
+                storage_limit = min(
+                    storage_length,
+                    storage_start + search_window + anchor_length,
+                )
+                for display_offset in range(display_offset_limit + 1):
+                    if best is not None and display_offset > best[0]:
+                        break
+                    anchor_start = display_start + display_offset
+                    anchor = display_text[anchor_start : anchor_start + anchor_length]
+                    storage_anchor = storage_text.find(anchor, storage_start, storage_limit)
+                    if storage_anchor != -1:
+                        score = display_offset + (storage_anchor - storage_start)
+                        candidate = (score, -anchor_length, anchor_start, storage_anchor)
+                        if best is None or candidate < best:
+                            best = candidate
+            if storage_start + anchor_length <= storage_length:
+                storage_offset_limit = min(
+                    search_window,
+                    storage_length - storage_start - anchor_length,
+                )
+                display_limit = min(
+                    display_length,
+                    display_start + search_window + anchor_length,
+                )
+                for storage_offset in range(storage_offset_limit + 1):
+                    if best is not None and storage_offset > best[0]:
+                        break
+                    anchor_start = storage_start + storage_offset
+                    anchor = storage_text[anchor_start : anchor_start + anchor_length]
+                    display_anchor = display_text.find(anchor, display_start, display_limit)
+                    if display_anchor != -1:
+                        score = storage_offset + (display_anchor - display_start)
+                        candidate = (score, -anchor_length, display_anchor, anchor_start)
+                        if best is None or candidate < best:
+                            best = candidate
+        if best is not None:
+            return best[2], best[3]
+        return display_length, storage_length
+
+    @staticmethod
+    def _clamp(pos):
+        return max(pos, 0)
+
+    def display_to_storage_position(self, pos, affinity="before"):
+        pos = self._clamp(pos)
+        delta = 0
+        for replacement in self.replacements:
+            if pos < replacement.display_start:
+                break
+            if (
+                replacement.display_length == 0
+                and pos == replacement.display_start
+            ):
+                return (
+                    replacement.storage_stop if affinity == "after" else replacement.storage_start
+                )
+            if replacement.display_start <= pos < replacement.display_stop:
+                return (
+                    replacement.storage_stop if affinity == "after" else replacement.storage_start
+                )
+            delta += replacement.display_length - replacement.storage_length
+        return self._clamp(pos - delta)
+
+    def storage_to_display_position(self, pos, affinity="before"):
+        pos = self._clamp(pos)
+        delta = 0
+        for replacement in self.replacements:
+            if pos < replacement.storage_start:
+                break
+            if (
+                replacement.storage_length == 0
+                and pos == replacement.storage_start
+            ):
+                return (
+                    replacement.display_stop if affinity == "after" else replacement.display_start
+                )
+            if replacement.storage_start <= pos < replacement.storage_stop:
+                return (
+                    replacement.display_stop if affinity == "after" else replacement.display_start
+                )
+            delta += replacement.display_length - replacement.storage_length
+        return self._clamp(pos + delta)
+
+    def _display_to_storage_range_stop(self, pos):
+        pos = self._clamp(pos)
+        delta = 0
+        for replacement in self.replacements:
+            if pos < replacement.display_start:
+                break
+            if pos == replacement.display_start:
+                return self._clamp(pos - delta)
+            if replacement.display_start < pos < replacement.display_stop:
+                return replacement.storage_stop
+            delta += replacement.display_length - replacement.storage_length
+        return self._clamp(pos - delta)
+
+    def _storage_to_display_range_stop(self, pos):
+        pos = self._clamp(pos)
+        delta = 0
+        for replacement in self.replacements:
+            if pos < replacement.storage_start:
+                break
+            if pos == replacement.storage_start:
+                return self._clamp(pos + delta)
+            if replacement.storage_start < pos < replacement.storage_stop:
+                return replacement.display_stop
+            delta += replacement.display_length - replacement.storage_length
+        return self._clamp(pos + delta)
+
+    def display_to_storage_range(self, start, stop):
+        start_affinity = "before"
+        if start < stop:
+            for replacement in self.replacements:
+                if start < replacement.display_start:
+                    break
+                if (
+                    replacement.display_length == 0
+                    and start == replacement.display_start
+                ):
+                    start_affinity = "after"
+                    break
+        storage_start = self.display_to_storage_position(start, affinity=start_affinity)
+        storage_stop = self._display_to_storage_range_stop(stop)
+        return TextRange(storage_start, max(storage_start, storage_stop))
+
+    def storage_to_display_range(self, start, stop):
+        display_start = self.storage_to_display_position(start, affinity="before")
+        display_stop = self._storage_to_display_range_stop(stop)
+        return TextRange(display_start, max(display_start, display_stop))
 
 
 @attr.s(auto_attribs=True)
@@ -122,9 +389,7 @@ class TextInfo:
         newline = "\n"
         p_locations = list(locate(self.text, lambda c: c == newline))
         start_locations = [0] + [l + 1 for l in p_locations[:-1]]
-        for (start_pos, stop_pos), parag in zip(
-            zip(start_locations, p_locations), paragraphs
-        ):
+        for (start_pos, stop_pos), parag in zip(zip(start_locations, p_locations), paragraphs):
             if not parag.strip():
                 continue
             p_start_pos = self.start_pos + start_pos
@@ -150,27 +415,19 @@ class TextInfo:
         index = bisect.bisect_right(markers, pos)
         if index < len(markers):
             return marker_map[markers[index]]
-        elif index >= len(markers) and markers:
+        if index >= len(markers) and markers:
             return marker_map[markers[-1]]
-        else:
-            raise LookupError(
-                f"Could not find a paragraph located at the right of position {pos}"
-            )
+        raise LookupError(f"Could not find a paragraph located at the right of position {pos}")
 
     def get_paragraph_to_the_left_of(self, pos):
         marker_map = {item.start: item for item in self.configured_markers}
         markers = list(marker_map)
         markers.sort()
         if not markers:
-            raise LookupError(
-                f"Could not find a paragraph located at the left of position {pos}"
-            )
+            raise LookupError(f"Could not find a paragraph located at the left of position {pos}")
         index = bisect.bisect_left(markers, pos)
         if index == 0:
             return marker_map[markers[0]]
-        elif index > 0:
+        if index > 0:
             return marker_map[markers[index - 1]]
-        else:
-            raise LookupError(
-                f"Could not find a paragraph located at the left of position {pos}"
-            )
+        raise LookupError(f"Could not find a paragraph located at the left of position {pos}")

--- a/bookworm/structured_text/primitives.py
+++ b/bookworm/structured_text/primitives.py
@@ -59,9 +59,6 @@ class TextRange(Container):
     def __iter__(self):
         return iter((self.start, self.stop))
 
-    def __hash__(self):
-        return hash((self.start, self.stop))
-
     def astuple(self):
         return (self.start, self.stop)
 

--- a/bookworm/structured_text/structural_elements.py
+++ b/bookworm/structured_text/structural_elements.py
@@ -1,17 +1,10 @@
-# coding: utf-8
-
 """Provides elements that help to define the structure for a blob of text."""
 
 from __future__ import annotations
 
-import re
 from enum import IntEnum, auto
-from itertools import chain
 
 import attr
-
-from bookworm import typehints as t
-from bookworm.utils import normalize_line_breaks
 
 from .primitives import TextRange
 

--- a/bookworm/structured_text/structural_elements.py
+++ b/bookworm/structured_text/structural_elements.py
@@ -47,6 +47,14 @@ class SemanticElementType(IntEnum):
     FIGURE = auto()
 
 
+@attr.s(auto_attribs=True, slots=True, frozen=True)
+class ImageElementInfo:
+    text_range: TextRange
+    src: str
+    label: str
+    suggested_filename: str = ""
+
+
 HEADING_LEVELS = {
     SemanticElementType.HEADING_1,
     SemanticElementType.HEADING_2,
@@ -68,7 +76,7 @@ SEMANTIC_ELEMENT_OUTPUT_OPTIONS = {
     SemanticElementType.LIST: (_("List"), False, True),
     SemanticElementType.QUOTE: (_("Quote"), True, True),
     SemanticElementType.TABLE: (_("Table"), False, True),
-    SemanticElementType.FIGURE: (_("Image"), False, True),
+    SemanticElementType.FIGURE: (_("Image"), False, False),
 }
 
 
@@ -83,9 +91,7 @@ class TextStructureMetadata:
             yield rngs
 
     def get_range(self, element_ranges, forward, anchor):
-        element_ranges.sort()
-        if not forward:
-            element_ranges.reverse()
+        element_ranges = sorted(element_ranges, reverse=not forward)
         for start, stop in element_ranges:
             condition = (
                 start > anchor

--- a/bookworm/structured_text/structured_html_parser.py
+++ b/bookworm/structured_text/structured_html_parser.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from functools import cached_property
 from itertools import chain
+from pathlib import PurePosixPath
+from urllib import parse as urllib_parse
 
 import ftfy
 from inscriptis import Inscriptis
@@ -15,10 +17,16 @@ from selectolax.parser import HTMLParser
 
 from bookworm import typehints as t
 from bookworm.logger import logger
-from bookworm.structured_text import SemanticElementType, Style
+from bookworm.structured_text import (
+    ImageElementInfo,
+    SemanticElementType,
+    Style,
+    TextRange,
+)
 from bookworm.utils import remove_excess_blank_lines
 
 log = logger.getChild(__name__)
+IMAGE_ANNOTATION = "__bookworm_image__"
 INSCRIPTIS_PARSE_HTML_TREE = Inscriptis._parse_html_tree
 INSCRIPTIS_GET_TEXT = Inscriptis.get_text
 MAX_DECODE_LENGTH = int(5e6)
@@ -86,6 +94,7 @@ STYLE_HTML_ELEMENTS = {}
 INSCRIPTIS_ANNOTATION_RULES = {
     t: (k,) for (k, v) in SEMANTIC_HTML_ELEMENTS.items() for t in v
 }
+INSCRIPTIS_ANNOTATION_RULES["img#src"] = (IMAGE_ANNOTATION,)
 INSCRIPTIS_CONFIG = ParserConfig(
     css=STRICT_CSS_PROFILE,
     display_images=False,
@@ -103,6 +112,7 @@ class StructuredHtmlParser(Inscriptis):
         "anchors",
         "styled_elements",
         "_table_elements",
+        "_image_elements",
     ]
 
     @staticmethod
@@ -125,17 +135,17 @@ class StructuredHtmlParser(Inscriptis):
         self.html_id_ranges = {}
         self.styled_elements = {}
         self._table_elements = []
+        self._image_elements = []
         kwargs.setdefault("config", INSCRIPTIS_CONFIG)
+        if args:
+            self._prepare_image_elements(args[0])
         super().__init__(*args, **kwargs)
 
     def _parse_html_tree(self, state, tree):
         canvas = state.canvas
-        try:
-            start_index = canvas.current_block.idx
-        except TypeError:
-            start_index = 0
+        start_index = self._get_canvas_index(canvas)
         super()._parse_html_tree(state, tree)
-        end_index = canvas.current_block.idx
+        end_index = self._get_canvas_index(canvas)
         try:
             anot = canvas.annotations[-1]
         except IndexError:
@@ -149,8 +159,221 @@ class StructuredHtmlParser(Inscriptis):
             self.html_id_ranges[anch] = element_range
         if tree.tag == "table":
             self._table_elements.append(tree)
+            self._resolve_table_image_ranges(
+                tree,
+                canvas.get_text(),
+                canvas.annotations,
+                start_index,
+                end_index,
+            )
+        if (
+            tree.tag == "img"
+            and (src := tree.attrib.get("src", ""))
+            and self._is_navigable_image(tree)
+        ):
+            label = self._get_image_label(tree)
+            placeholder = self._get_image_placeholder(label)
+            text_range = self._find_placeholder_range(
+                canvas.get_text(),
+                placeholder,
+                start_index,
+                end_index,
+            )
+            self._image_elements.append(
+                ImageElementInfo(
+                    text_range=text_range or TextRange(-1, -1),
+                    src=src,
+                    label=label,
+                    suggested_filename=self._get_suggested_filename(src),
+                )
+            )
 
         return state.canvas
+
+    @staticmethod
+    def _get_canvas_index(canvas):
+        try:
+            return canvas.current_block.idx
+        except TypeError:
+            return 0
+
+    @classmethod
+    def _prepare_image_elements(cls, tree):
+        for image in tree.iter("img"):
+            if not cls._is_navigable_image(image):
+                continue
+            label = cls._get_image_label(image)
+            placeholder = cls._get_image_placeholder(label)
+            image.text = (
+                placeholder if image.text is None else f"{placeholder} {image.text}"
+            )
+
+    @classmethod
+    def _is_navigable_image(cls, image):
+        return (
+            bool(image.attrib.get("src", ""))
+            and not cls._is_hidden_image(image)
+            and not cls._is_decorative_image(image)
+        )
+
+    @classmethod
+    def _is_decorative_image(cls, image):
+        return cls._has_empty_alt(image) and not cls._get_non_alt_image_label(image)
+
+    @staticmethod
+    def _has_empty_alt(image):
+        return "alt" in image.attrib and not image.attrib.get("alt", "").strip()
+
+    @classmethod
+    def _get_non_alt_image_label(cls, image):
+        for label in (
+            image.attrib.get("title", ""),
+            cls._get_figure_caption(image),
+        ):
+            label = cls._normalize_image_label(label)
+            if label:
+                return label
+        return ""
+
+    @staticmethod
+    def _is_hidden_image(image):
+        return any(
+            StructuredHtmlParser._is_hidden_element(element)
+            for element in chain((image,), image.iterancestors())
+        )
+
+    @staticmethod
+    def _is_hidden_element(element):
+        return "hidden" in element.attrib or StructuredHtmlParser._has_display_none(
+            element
+        )
+
+    @staticmethod
+    def _has_display_none(element):
+        for directive in element.attrib.get("style", "").lower().split(";"):
+            if ":" not in directive:
+                continue
+            key, value = (part.strip() for part in directive.split(":", 1))
+            value = value.split("!", 1)[0].strip()
+            if key == "display" and value == "none":
+                return True
+        return False
+
+    @staticmethod
+    def _get_image_placeholder(label):
+        return f"[{label}]"
+
+    @classmethod
+    def _find_placeholder_range(cls, text, placeholder, start=0, stop=None):
+        if stop is None or stop < start:
+            stop = len(text)
+        start = max(start, 0)
+        index = text.find(placeholder, start, stop)
+        if index == -1:
+            return
+        return TextRange(index, index + len(placeholder))
+
+    def _resolve_table_image_ranges(
+        self,
+        table,
+        text,
+        annotations,
+        start_index,
+        end_index,
+    ):
+        table_image_infos = self._get_table_image_infos(table)
+        if not table_image_infos:
+            return
+        image_annotations = self._get_image_annotations(
+            annotations,
+            start_index,
+            end_index,
+        )
+        for image_info, annotation in zip(table_image_infos, image_annotations):
+            text_range = self._get_placeholder_range_from_annotation(
+                text,
+                annotation,
+                image_info.label,
+            )
+            if not text_range:
+                continue
+            image_info.text_range.start = text_range.start
+            image_info.text_range.stop = text_range.stop
+
+    def _get_table_image_infos(self, table):
+        table_image_count = sum(
+            1
+            for image in table.iter("img")
+            if self._is_navigable_image(image)
+        )
+        if not table_image_count:
+            return ()
+        return self._image_elements[-table_image_count:]
+
+    @staticmethod
+    def _get_image_annotations(annotations, start_index, end_index):
+        return tuple(
+            annotation
+            for annotation in annotations
+            if annotation.metadata == IMAGE_ANNOTATION
+            and start_index <= annotation.start
+            and annotation.end <= end_index
+        )
+
+    def _get_placeholder_range_from_annotation(self, text, annotation, label):
+        placeholder = self._get_image_placeholder(label)
+        return self._find_placeholder_range(
+            text,
+            placeholder,
+            annotation.start,
+            annotation.end,
+        ) or TextRange(annotation.start, annotation.end)
+
+    def _get_visible_image_elements(self):
+        return tuple(
+            image_info
+            for image_info in self._image_elements
+            if image_info.text_range.start >= 0
+        )
+
+    @staticmethod
+    def _get_image_label(image):
+        for label in (
+            image.attrib.get("alt", ""),
+            image.attrib.get("title", ""),
+            StructuredHtmlParser._get_figure_caption(image),
+        ):
+            label = StructuredHtmlParser._normalize_image_label(label)
+            if label:
+                return label
+        return _("Image")
+
+    @staticmethod
+    def _get_figure_caption(image):
+        for figure in image.iterancestors("figure"):
+            caption = " ".join(figure.xpath(".//figcaption//text()")).strip()
+            if caption:
+                return caption
+        return ""
+
+    @staticmethod
+    def _normalize_image_label(label):
+        label = " ".join(label.split())
+        if not label or not any(char.isalnum() for char in label):
+            return ""
+        return label
+
+    @staticmethod
+    def _get_suggested_filename(src):
+        if src.lower().startswith("data:image/"):
+            media_type = src.split(",", 1)[0].split(";", 1)[0]
+            image_type = media_type.split("/", 1)[-1].split("+", 1)[0]
+            if image_type == "jpeg":
+                image_type = "jpg"
+            return f"image.{image_type or 'png'}"
+        path = urllib_parse.urlparse(src).path
+        filename = PurePosixPath(urllib_parse.unquote(path)).name
+        return filename or _("Image")
 
     @classmethod
     def preprocess_html_string(cls, html_string):
@@ -179,7 +402,15 @@ class StructuredHtmlParser(Inscriptis):
     def semantic_elements(self):
         annotations = {}
         for anot in self.get_annotations():
+            if anot.metadata == IMAGE_ANNOTATION:
+                continue
             annotations.setdefault(anot.metadata, []).append((anot.start, anot.end))
+        if self._image_elements:
+            image_ranges = annotations.setdefault(SemanticElementType.FIGURE, [])
+            image_ranges.extend(
+                image.text_range.astuple()
+                for image in self._get_visible_image_elements()
+            )
         return annotations
 
     @cached_property
@@ -196,3 +427,6 @@ class StructuredHtmlParser(Inscriptis):
             ]
         )
         return parsed.html
+
+    def get_image_info(self, image_index):
+        return self._get_visible_image_elements()[image_index]

--- a/bookworm/structured_text/structured_html_parser.py
+++ b/bookworm/structured_text/structured_html_parser.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 
 from __future__ import annotations
 
@@ -10,17 +9,16 @@ from urllib import parse as urllib_parse
 
 import ftfy
 from inscriptis import Inscriptis
-from inscriptis.css_profiles import RELAXED_CSS_PROFILE, STRICT_CSS_PROFILE
+from inscriptis.css_profiles import STRICT_CSS_PROFILE
 from inscriptis.model.config import ParserConfig
 from lxml import html as html_parser
 from selectolax.parser import HTMLParser
 
-from bookworm import typehints as t
 from bookworm.logger import logger
 from bookworm.structured_text import (
     ImageElementInfo,
     SemanticElementType,
-    Style,
+    TextPositionMap,
     TextRange,
 )
 from bookworm.utils import remove_excess_blank_lines
@@ -91,9 +89,7 @@ SEMANTIC_HTML_ELEMENTS = {
     # }
 }
 STYLE_HTML_ELEMENTS = {}
-INSCRIPTIS_ANNOTATION_RULES = {
-    t: (k,) for (k, v) in SEMANTIC_HTML_ELEMENTS.items() for t in v
-}
+INSCRIPTIS_ANNOTATION_RULES = {t: (k,) for (k, v) in SEMANTIC_HTML_ELEMENTS.items() for t in v}
 INSCRIPTIS_ANNOTATION_RULES["img#src"] = (IMAGE_ANNOTATION,)
 INSCRIPTIS_CONFIG = ParserConfig(
     css=STRICT_CSS_PROFILE,
@@ -108,11 +104,14 @@ class StructuredHtmlParser(Inscriptis):
     """Subclass of ```inscriptis.Inscriptis``` to provide the position of structural elements."""
 
     __slots__ = [
-        "link_range_to_target",
-        "anchors",
-        "styled_elements",
-        "_table_elements",
+        "_display_text",
         "_image_elements",
+        "_storage_text",
+        "_table_elements",
+        "_text_position_map",
+        "anchors",
+        "link_range_to_target",
+        "styled_elements",
     ]
 
     @staticmethod
@@ -129,17 +128,25 @@ class StructuredHtmlParser(Inscriptis):
         html_string = ftfy.fix_text(html_string, config)
         return remove_excess_blank_lines(html_string)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, include_images=True, **kwargs):
         self.link_range_to_target = {}
         self.anchors = {}
         self.html_id_ranges = {}
         self.styled_elements = {}
         self._table_elements = []
         self._image_elements = []
+        self._display_text = ""
+        self._storage_text = ""
+        self._text_position_map = TextPositionMap.identity(0)
         kwargs.setdefault("config", INSCRIPTIS_CONFIG)
-        if args:
+        if include_images and args:
             self._prepare_image_elements(args[0])
         super().__init__(*args, **kwargs)
+        self._display_text = remove_excess_blank_lines(INSCRIPTIS_GET_TEXT(self))
+        self._storage_text, self._text_position_map = TextPositionMap.from_collapsed_ranges(
+            self._display_text,
+            (image.text_range for image in self._get_visible_image_elements()),
+        )
 
     def _parse_html_tree(self, state, tree):
         canvas = state.canvas
@@ -204,9 +211,7 @@ class StructuredHtmlParser(Inscriptis):
                 continue
             label = cls._get_image_label(image)
             placeholder = cls._get_image_placeholder(label)
-            image.text = (
-                placeholder if image.text is None else f"{placeholder} {image.text}"
-            )
+            image.text = placeholder if image.text is None else f"{placeholder} {image.text}"
 
     @classmethod
     def _is_navigable_image(cls, image):
@@ -244,9 +249,7 @@ class StructuredHtmlParser(Inscriptis):
 
     @staticmethod
     def _is_hidden_element(element):
-        return "hidden" in element.attrib or StructuredHtmlParser._has_display_none(
-            element
-        )
+        return "hidden" in element.attrib or StructuredHtmlParser._has_display_none(element)
 
     @staticmethod
     def _has_display_none(element):
@@ -270,7 +273,7 @@ class StructuredHtmlParser(Inscriptis):
         start = max(start, 0)
         index = text.find(placeholder, start, stop)
         if index == -1:
-            return
+            return None
         return TextRange(index, index + len(placeholder))
 
     def _resolve_table_image_ranges(
@@ -301,11 +304,7 @@ class StructuredHtmlParser(Inscriptis):
             image_info.text_range.stop = text_range.stop
 
     def _get_table_image_infos(self, table):
-        table_image_count = sum(
-            1
-            for image in table.iter("img")
-            if self._is_navigable_image(image)
-        )
+        table_image_count = sum(1 for image in table.iter("img") if self._is_navigable_image(image))
         if not table_image_count:
             return ()
         return self._image_elements[-table_image_count:]
@@ -331,10 +330,15 @@ class StructuredHtmlParser(Inscriptis):
 
     def _get_visible_image_elements(self):
         return tuple(
-            image_info
-            for image_info in self._image_elements
-            if image_info.text_range.start >= 0
+            image_info for image_info in self._image_elements if image_info.text_range.start >= 0
         )
+
+    def iter_image_storage_ranges(self):
+        for image_info in self._get_visible_image_elements():
+            yield image_info, self.display_to_storage_range(
+                image_info.text_range.start,
+                image_info.text_range.stop,
+            )
 
     @staticmethod
     def _get_image_label(image):
@@ -387,16 +391,38 @@ class StructuredHtmlParser(Inscriptis):
         return html_content
 
     @classmethod
-    def from_string(cls, html_string):
+    def from_string(cls, html_string, *, include_images=True):
         html_content = cls.preprocess_html_string(html_string)
-        return cls(html_parser.fromstring(html_content))
+        return cls(
+            html_parser.fromstring(html_content),
+            include_images=include_images,
+        )
 
     @classmethod
-    def from_lxml_html_tree(cls, lxml_html_tree):
-        return cls(lxml_html_tree)
+    def from_lxml_html_tree(cls, lxml_html_tree, *, include_images=True):
+        return cls(lxml_html_tree, include_images=include_images)
 
     def get_text(self):
-        return remove_excess_blank_lines(INSCRIPTIS_GET_TEXT(self))
+        return self._display_text
+
+    def get_storage_text(self):
+        return self._storage_text
+
+    @property
+    def text_position_map(self):
+        return self._text_position_map
+
+    def display_to_storage_position(self, pos, affinity="before"):
+        return self._text_position_map.display_to_storage_position(pos, affinity=affinity)
+
+    def storage_to_display_position(self, pos, affinity="before"):
+        return self._text_position_map.storage_to_display_position(pos, affinity=affinity)
+
+    def display_to_storage_range(self, start, stop):
+        return self._text_position_map.display_to_storage_range(start, stop)
+
+    def storage_to_display_range(self, start, stop):
+        return self._text_position_map.storage_to_display_range(start, stop)
 
     @cached_property
     def semantic_elements(self):
@@ -408,8 +434,7 @@ class StructuredHtmlParser(Inscriptis):
         if self._image_elements:
             image_ranges = annotations.setdefault(SemanticElementType.FIGURE, [])
             image_ranges.extend(
-                image.text_range.astuple()
-                for image in self._get_visible_image_elements()
+                image.text_range.astuple() for image in self._get_visible_image_elements()
             )
         return annotations
 

--- a/bookworm/structured_text/structured_html_parser.py
+++ b/bookworm/structured_text/structured_html_parser.py
@@ -82,11 +82,6 @@ SEMANTIC_HTML_ELEMENTS = {
     SemanticElementType.TABLE: {
         "table",
     },
-    # SemanticElementType.FIGURE: {
-    # "img",
-    # "figure",
-    # "picture",
-    # }
 }
 STYLE_HTML_ELEMENTS = {}
 INSCRIPTIS_ANNOTATION_RULES = {t: (k,) for (k, v) in SEMANTIC_HTML_ELEMENTS.items() for t in v}
@@ -231,11 +226,11 @@ class StructuredHtmlParser(Inscriptis):
 
     @classmethod
     def _get_non_alt_image_label(cls, image):
-        for label in (
+        for raw_label in (
             image.attrib.get("title", ""),
             cls._get_figure_caption(image),
         ):
-            label = cls._normalize_image_label(label)
+            label = cls._normalize_image_label(raw_label)
             if label:
                 return label
         return ""
@@ -342,12 +337,12 @@ class StructuredHtmlParser(Inscriptis):
 
     @staticmethod
     def _get_image_label(image):
-        for label in (
+        for raw_label in (
             image.attrib.get("alt", ""),
             image.attrib.get("title", ""),
             StructuredHtmlParser._get_figure_caption(image),
         ):
-            label = StructuredHtmlParser._normalize_image_label(label)
+            label = StructuredHtmlParser._normalize_image_label(raw_label)
             if label:
                 return label
         return _("Image")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ class DummyView:
         self.toc_tree = None
         self.input_result = ""
         self.insertion_point = 0
+        self.image_dialog_args = None
         self.state_on_section_change: Section = None
         self.contentTextCtrl = DummyTextCtrl()
         self.reader = None
@@ -67,6 +68,12 @@ class DummyView:
         pass
 
     def show_html_dialog(self, markup: str, title: str) -> None:
+        pass
+
+    def show_image_dialog(self, image, title: str, suggested_filename=None) -> None:
+        self.image_dialog_args = (image, title, suggested_filename)
+
+    def notify_invalid_action(self) -> None:
         pass
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,4 @@
-import os
 from pathlib import Path
-import tempfile
-import time
 
 import pytest
 from sqlalchemy.orm import close_all_sessions
@@ -9,10 +6,8 @@ from sqlalchemy.pool import NullPool
 
 from bookworm.config import setup_config
 from bookworm.database import init_database
-from bookworm.database.models import Base
 from bookworm.document.elements import Section
 from bookworm.reader import EBookReader
-from bookworm.service.handler import ServiceHandler
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/test_annotator.py
+++ b/tests/test_annotator.py
@@ -2,8 +2,6 @@ from pathlib import Path
 import shutil
 from types import SimpleNamespace
 
-import pytest
-
 from bookworm import config
 from bookworm.annotation import AnnotationService, NoteTaker
 from bookworm.annotation import annotation_gui
@@ -11,10 +9,7 @@ from bookworm.annotation.annotation_gui import AnnotationMenu
 from bookworm.annotation.annotator import AnnotationSortCriteria, Quoter
 from bookworm.database.models import *
 from bookworm.document.uri import DocumentUri
-from bookworm.signals import reader_book_loaded
 from bookworm.structured_text import SemanticElementType, TextRange
-
-from conftest import asset, reader
 
 
 def test_notes_can_not_overlap(asset, reader):
@@ -23,7 +18,7 @@ def test_notes_can_not_overlap(asset, reader):
     assert Book.query.count() == 1
     annot = NoteTaker(reader)
     # This should succeed
-    comment = annot.create(
+    annot.create(
         title="test", content="test", position=0, start_pos=0, end_pos=1
     )
     # check if it overlaps at start_pos 0, end_pos 1, page_number 0 and position 0

--- a/tests/test_annotator.py
+++ b/tests/test_annotator.py
@@ -1,15 +1,18 @@
-from datetime import datetime, timedelta
 from pathlib import Path
 import shutil
+from types import SimpleNamespace
 
 import pytest
 
 from bookworm import config
 from bookworm.annotation import AnnotationService, NoteTaker
-from bookworm.annotation.annotator import AnnotationSortCriteria
+from bookworm.annotation import annotation_gui
+from bookworm.annotation.annotation_gui import AnnotationMenu
+from bookworm.annotation.annotator import AnnotationSortCriteria, Quoter
 from bookworm.database.models import *
 from bookworm.document.uri import DocumentUri
 from bookworm.signals import reader_book_loaded
+from bookworm.structured_text import SemanticElementType, TextRange
 
 from conftest import asset, reader
 
@@ -128,4 +131,52 @@ def test_comments_are_styled_on_initial_landing_page(asset, reader, view, monkey
     reader.load(uri)
 
     assert styled_positions == [0]
+    reader.unload()
+
+
+def test_extending_highlight_to_before_image_preserves_range_stop(
+    reader, view, tmp_path, monkeypatch
+):
+    html_path = tmp_path / "image.html"
+    html_path.write_text(
+        """
+        <html>
+            <head><title>Book</title></head>
+            <body><p>before <img src="pic.png" alt="Chart"> after text</p></body>
+        </html>
+        """,
+        encoding="utf-8",
+    )
+    reader.load(DocumentUri.from_filename(html_path))
+    image_start, image_stop = reader.document.get_document_semantic_structure()[
+        SemanticElementType.FIGURE
+    ][0]
+    existing_range = reader.view_to_storage_range(0, 2)
+    expected_range = reader.view_to_storage_range(0, image_start)
+    range_with_image = reader.view_to_storage_range(0, image_stop)
+    quote = Quoter(reader).create(
+        title="",
+        content="be",
+        start_pos=existing_range.start,
+        end_pos=existing_range.stop,
+    )
+    view.get_selection_range = lambda: TextRange(1, image_start)
+    view.get_text_by_range = lambda start, stop: reader.get_current_page_object().get_text()[
+        start:stop
+    ]
+    service = SimpleNamespace(style_highlight=lambda *args, **kwargs: None)
+    menu = SimpleNamespace(reader=reader, view=view, service=service)
+    monkeypatch.setattr(annotation_gui.wx, "GetKeyState", lambda key: False)
+    monkeypatch.setattr(annotation_gui.speech, "announce", lambda *args, **kwargs: None)
+
+    AnnotationMenu.onQuoteSelection(menu, None)
+
+    quote = Quoter(reader).get(quote.id)
+    assert quote.end_pos == expected_range.stop
+    assert quote.end_pos != range_with_image.stop
+    assert reader.storage_to_view_range(
+        quote.start_pos,
+        quote.end_pos,
+        quote.page_number,
+    ).astuple() == (0, image_start)
     reader.unload()

--- a/tests/test_content_hash_backfill.py
+++ b/tests/test_content_hash_backfill.py
@@ -1,26 +1,34 @@
 import shutil
 from pathlib import Path
 
-from alembic import command
+import pytest
 from alembic.config import Config
 from pptx import Presentation
-import pytest
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import close_all_sessions
 from sqlalchemy.pool import NullPool
 
+from alembic import command
 from bookworm.annotation import NoteTaker
 from bookworm.database import init_database
 from bookworm.database.models import (
     Book,
+    Bookmark,
     DocumentPositionInfo,
     Note,
     PinnedDocument,
+    Quote,
     RecentDocument,
 )
 from bookworm.document import BaseDocument, BasePage, BookMetadata, Pager, Section, create_document
 from bookworm.document.uri import DocumentUri
 from bookworm.gui.book_viewer import recents_manager
+from bookworm.structured_text import (
+    CURRENT_CONTENT_HASH_VERSION,
+    CURRENT_POSITION_MODEL_VERSION,
+    SemanticElementType,
+    TEXT_OBJECT_REPLACEMENT_CHAR,
+)
 
 
 def _make_alembic_config(db_url):
@@ -130,6 +138,464 @@ def test_loading_existing_records_backfills_hashes_and_preserves_annotations(
     assert NoteTaker(reader).get_for_page(0).count() == 1
 
 
+def test_legacy_image_placeholder_positions_are_migrated_on_load(reader, tmp_path):
+    html_path = tmp_path / "image.html"
+    html_path.write_text(
+        """
+        <html>
+            <head><title>Book</title></head>
+            <body>
+                <p>before <img src="pic.png" alt="Chart"> middle
+                <img src="pic.png" alt="Chart 2"> omega text</p>
+            </body>
+        </html>
+        """,
+        encoding="utf-8",
+    )
+    (tmp_path / "pic.png").write_bytes(b"same-image-bytes")
+    uri = DocumentUri.from_filename(html_path)
+    document = create_document(uri)
+    try:
+        legacy_text = document.get_legacy_content()
+        storage_text = document.get_storage_content()
+        legacy_hash = document.get_legacy_content_hash()
+        legacy_target = legacy_text.index("omega")
+        storage_target = storage_text.index("omega")
+        storage_selection = slice(storage_target, storage_target + len("omega"))
+        section = document.get_page(0).section
+
+        session = Book.session()
+        book = Book(
+            title=document.metadata.title,
+            uri=uri,
+            content_hash=legacy_hash,
+            content_hash_version=None,
+        )
+        session.add(book)
+        session.flush()
+        session.add(
+            DocumentPositionInfo(
+                title=document.metadata.title,
+                uri=uri,
+                content_hash=legacy_hash,
+                content_hash_version=None,
+                last_page=0,
+                last_position=legacy_target,
+                position_version=None,
+            )
+        )
+        session.add(
+            Bookmark(
+                title="bookmark",
+                page_number=0,
+                position=legacy_target,
+                section_title=section.title,
+                section_identifier=section.unique_identifier,
+                book_id=book.id,
+                position_version=None,
+            )
+        )
+        session.add(
+            Note(
+                title="note",
+                content="note content",
+                page_number=0,
+                position=legacy_target,
+                start_pos=legacy_target,
+                end_pos=legacy_target + len("omega"),
+                section_title=section.title,
+                section_identifier=section.unique_identifier,
+                book_id=book.id,
+                position_version=None,
+            )
+        )
+        session.add(
+            Quote(
+                title="quote",
+                content="quote content",
+                page_number=0,
+                position=legacy_target,
+                start_pos=legacy_target,
+                end_pos=legacy_target + len("omega"),
+                section_title=section.title,
+                section_identifier=section.unique_identifier,
+                book_id=book.id,
+                position_version=None,
+            )
+        )
+        session.commit()
+        session.execute(text("UPDATE book SET content_hash_version = NULL"))
+        session.execute(
+            text(
+                "UPDATE document_position_info "
+                "SET content_hash_version = NULL, position_version = NULL"
+            )
+        )
+        for table_name in ("bookmark", "note", "quote"):
+            session.execute(text(f"UPDATE {table_name} SET position_version = NULL"))
+        session.commit()
+        session.expire_all()
+
+        reader.load(uri)
+
+        assert Book.query.one().content_hash_version == CURRENT_CONTENT_HASH_VERSION
+        assert DocumentPositionInfo.query.one().position_version == CURRENT_POSITION_MODEL_VERSION
+        assert Bookmark.query.one().position_version == CURRENT_POSITION_MODEL_VERSION
+        assert Note.query.one().position_version == CURRENT_POSITION_MODEL_VERSION
+        assert Quote.query.one().position_version == CURRENT_POSITION_MODEL_VERSION
+        assert DocumentPositionInfo.query.one().last_position == storage_target
+        assert Bookmark.query.one().position == storage_target
+        assert Note.query.one().position == storage_target
+        assert Quote.query.one().position == storage_target
+        assert Note.query.one().start_pos == storage_target
+        assert Quote.query.one().start_pos == storage_target
+        assert Note.query.one().end_pos == storage_selection.stop
+        assert Quote.query.one().end_pos == storage_selection.stop
+
+        reader.view.set_insertion_point(document.get_content().index("omega") + 1)
+        reader.save_current_position()
+        assert (
+            DocumentPositionInfo.query.one().last_position
+            == document.display_to_storage_position(document.get_content().index("omega") + 1)
+        )
+    finally:
+        document.close()
+        reader.unload()
+
+
+def test_current_records_merge_legacy_duplicates_on_load(reader, tmp_path):
+    original_path = tmp_path / "original.html"
+    moved_path = tmp_path / "moved.html"
+    html_content = """
+    <html>
+        <head><title>Book</title></head>
+        <body>
+            <p>before <img src="pic.png" alt="Chart"> middle
+            <img src="pic.png" alt="Chart 2"> after text</p>
+        </body>
+    </html>
+    """
+    (tmp_path / "pic.png").write_bytes(b"same-image-bytes")
+    original_path.write_text(html_content, encoding="utf-8")
+    shutil.copy(original_path, moved_path)
+
+    original_uri = DocumentUri.from_filename(original_path)
+    moved_uri = DocumentUri.from_filename(moved_path)
+    document = create_document(moved_uri)
+    try:
+        current_hash = document.get_content_hash()
+        legacy_hash = document.get_legacy_content_hash()
+        legacy_position = document.get_legacy_content().index("after text")
+        storage_position = document.get_storage_content().index("after text")
+        section = document.get_page(0).section
+
+        session = Book.session()
+        current_book = Book(
+            title=document.metadata.title,
+            uri=moved_uri,
+            content_hash=current_hash,
+            content_hash_version=CURRENT_CONTENT_HASH_VERSION,
+        )
+        legacy_book = Book(
+            title=document.metadata.title,
+            uri=original_uri,
+            content_hash=legacy_hash,
+            content_hash_version=None,
+        )
+        session.add_all((current_book, legacy_book))
+        session.flush()
+        current_position_info = DocumentPositionInfo(
+            title=document.metadata.title,
+            uri=moved_uri,
+            content_hash=current_hash,
+            content_hash_version=CURRENT_CONTENT_HASH_VERSION,
+            last_page=0,
+            last_position=0,
+            position_version=CURRENT_POSITION_MODEL_VERSION,
+        )
+        legacy_position_info = DocumentPositionInfo(
+            title=document.metadata.title,
+            uri=original_uri,
+            content_hash=legacy_hash,
+            content_hash_version=None,
+            last_page=0,
+            last_position=legacy_position,
+            position_version=None,
+        )
+        legacy_note = Note(
+            title="note",
+            content="note content",
+            page_number=0,
+            position=legacy_position,
+            start_pos=None,
+            end_pos=None,
+            section_title=section.title,
+            section_identifier=section.unique_identifier,
+            book_id=legacy_book.id,
+            position_version=None,
+        )
+        session.add_all((current_position_info, legacy_position_info, legacy_note))
+        session.flush()
+        session.execute(
+            text("UPDATE book SET content_hash_version = NULL WHERE id = :id"),
+            {"id": legacy_book.id},
+        )
+        session.execute(
+            text(
+                "UPDATE document_position_info "
+                "SET content_hash_version = NULL, position_version = NULL "
+                "WHERE id = :id"
+            ),
+            {"id": legacy_position_info.id},
+        )
+        session.execute(
+            text("UPDATE note SET position_version = NULL WHERE id = :id"),
+            {"id": legacy_note.id},
+        )
+        session.commit()
+        session.expire_all()
+
+        reader.load(moved_uri)
+
+        assert Book.query.count() == 1
+        assert DocumentPositionInfo.query.count() == 1
+        assert Book.query.one().id == current_book.id
+        assert DocumentPositionInfo.query.one().id == current_position_info.id
+        assert DocumentPositionInfo.query.one().last_position == storage_position
+        assert DocumentPositionInfo.query.one().position_version == CURRENT_POSITION_MODEL_VERSION
+        assert Note.query.one().book_id == current_book.id
+        assert Note.query.one().position == storage_position
+        assert Note.query.one().position_version == CURRENT_POSITION_MODEL_VERSION
+    finally:
+        document.close()
+        reader.unload()
+
+
+def test_reader_merges_legacy_records_when_current_hash_is_unavailable(
+    reader,
+    tmp_path,
+):
+    original_path = tmp_path / "original.html"
+    moved_path = tmp_path / "moved.html"
+    html_content = """
+    <html>
+        <head><title>Book</title></head>
+        <body><p>before <img src="missing.png" alt="Chart"> after text</p></body>
+    </html>
+    """
+    original_path.write_text(html_content, encoding="utf-8")
+    moved_path.write_text(html_content, encoding="utf-8")
+
+    original_uri = DocumentUri.from_filename(original_path)
+    moved_uri = DocumentUri.from_filename(moved_path)
+    document = create_document(moved_uri)
+    try:
+        assert document.get_content_hash() is None
+        legacy_hash = document.get_legacy_content_hash()
+        legacy_position = document.get_legacy_content().index("after text")
+        storage_position = document.get_storage_content().index("after text")
+        section = document.get_page(0).section
+
+        session = Book.session()
+        legacy_book = Book(
+            title=document.metadata.title,
+            uri=original_uri,
+            content_hash=legacy_hash,
+            content_hash_version=None,
+        )
+        session.add(legacy_book)
+        session.flush()
+        session.add_all(
+            (
+                DocumentPositionInfo(
+                    title=document.metadata.title,
+                    uri=original_uri,
+                    content_hash=legacy_hash,
+                    content_hash_version=None,
+                    last_page=0,
+                    last_position=legacy_position,
+                    position_version=None,
+                ),
+                Note(
+                    title="note",
+                    content="note content",
+                    page_number=0,
+                    position=legacy_position,
+                    start_pos=None,
+                    end_pos=None,
+                    section_title=section.title,
+                    section_identifier=section.unique_identifier,
+                    book_id=legacy_book.id,
+                    position_version=None,
+                ),
+            )
+        )
+        session.commit()
+        session.execute(text("UPDATE book SET content_hash_version = NULL"))
+        session.execute(
+            text(
+                "UPDATE document_position_info "
+                "SET content_hash_version = NULL, position_version = NULL"
+            )
+        )
+        session.execute(text("UPDATE note SET position_version = NULL"))
+        session.commit()
+        session.expire_all()
+
+        reader.load(moved_uri)
+
+        assert Book.query.count() == 1
+        assert DocumentPositionInfo.query.count() == 1
+        assert Book.query.one().uri == moved_uri
+        assert DocumentPositionInfo.query.one().uri == moved_uri
+        assert Book.query.one().content_hash == legacy_hash
+        assert Book.query.one().content_hash_version is None
+        assert DocumentPositionInfo.query.one().content_hash == legacy_hash
+        assert DocumentPositionInfo.query.one().content_hash_version is None
+        assert DocumentPositionInfo.query.one().last_position == storage_position
+        assert DocumentPositionInfo.query.one().position_version == CURRENT_POSITION_MODEL_VERSION
+        assert Note.query.one().book_id == Book.query.one().id
+        assert Note.query.one().position == storage_position
+        assert Note.query.one().position_version == CURRENT_POSITION_MODEL_VERSION
+
+        next_path = tmp_path / "next.html"
+        next_path.write_text(html_content, encoding="utf-8")
+        next_uri = DocumentUri.from_filename(next_path)
+
+        reader.unload()
+        reader.load(next_uri)
+
+        assert Book.query.count() == 1
+        assert DocumentPositionInfo.query.count() == 1
+        assert Book.query.one().uri == next_uri
+        assert Book.query.one().content_hash == legacy_hash
+        assert Book.query.one().content_hash_version is None
+        assert DocumentPositionInfo.query.one().uri == next_uri
+        assert DocumentPositionInfo.query.one().content_hash == legacy_hash
+        assert DocumentPositionInfo.query.one().content_hash_version is None
+        assert DocumentPositionInfo.query.one().last_position == storage_position
+        assert DocumentPositionInfo.query.one().position_version == CURRENT_POSITION_MODEL_VERSION
+    finally:
+        document.close()
+        reader.unload()
+
+
+def test_legacy_ranges_ending_before_images_migrate_without_including_images(
+    reader, tmp_path
+):
+    html_path = tmp_path / "image.html"
+    html_path.write_text(
+        """
+        <html>
+            <head><title>Book</title></head>
+            <body>
+                <p>before <img src="pic.png" alt="Chart"> middle
+                <img src="pic.png" alt="Chart 2"> after text</p>
+            </body>
+        </html>
+        """,
+        encoding="utf-8",
+    )
+    (tmp_path / "pic.png").write_bytes(b"same-image-bytes")
+    uri = DocumentUri.from_filename(html_path)
+    document = create_document(uri)
+    try:
+        legacy_text = document.get_legacy_content()
+        storage_text = document.get_storage_content()
+        legacy_hash = document.get_legacy_content_hash()
+        legacy_before_second_image = legacy_text.index("after text")
+        first_image = storage_text.index(TEXT_OBJECT_REPLACEMENT_CHAR)
+        storage_before_second_image = storage_text.index(
+            TEXT_OBJECT_REPLACEMENT_CHAR,
+            first_image + 1,
+        )
+        second_image_start, _second_image_stop = document.get_document_semantic_structure()[
+            SemanticElementType.FIGURE
+        ][1]
+        section = document.get_page(0).section
+
+        session = Book.session()
+        book = Book(
+            title=document.metadata.title,
+            uri=uri,
+            content_hash=legacy_hash,
+            content_hash_version=None,
+        )
+        session.add(book)
+        session.flush()
+        note = Note(
+            title="note",
+            content="note content",
+            page_number=0,
+            position=0,
+            start_pos=0,
+            end_pos=legacy_before_second_image,
+            section_title=section.title,
+            section_identifier=section.unique_identifier,
+            book_id=book.id,
+            position_version=None,
+        )
+        quote = Quote(
+            title="quote",
+            content="quote content",
+            page_number=0,
+            position=0,
+            start_pos=0,
+            end_pos=legacy_before_second_image,
+            section_title=section.title,
+            section_identifier=section.unique_identifier,
+            book_id=book.id,
+            position_version=None,
+        )
+        session.add_all(
+            (
+                DocumentPositionInfo(
+                    title=document.metadata.title,
+                    uri=uri,
+                    content_hash=legacy_hash,
+                    content_hash_version=None,
+                    last_page=0,
+                    last_position=0,
+                    position_version=None,
+                ),
+                note,
+                quote,
+            )
+        )
+        session.flush()
+        session.execute(text("UPDATE book SET content_hash_version = NULL"))
+        session.execute(
+            text(
+                "UPDATE document_position_info "
+                "SET content_hash_version = NULL, position_version = NULL"
+            )
+        )
+        for table_name in ("note", "quote"):
+            session.execute(text(f"UPDATE {table_name} SET position_version = NULL"))
+        session.commit()
+        session.expire_all()
+
+        reader.load(uri)
+
+        assert Note.query.one().end_pos == storage_before_second_image
+        assert Quote.query.one().end_pos == storage_before_second_image
+        assert storage_text[Note.query.one().end_pos] == TEXT_OBJECT_REPLACEMENT_CHAR
+        assert storage_text[Quote.query.one().end_pos] == TEXT_OBJECT_REPLACEMENT_CHAR
+        assert reader.storage_to_view_range(
+            Note.query.one().start_pos,
+            Note.query.one().end_pos,
+            Note.query.one().page_number,
+        ).astuple() == (0, second_image_start)
+        assert reader.storage_to_view_range(
+            Quote.query.one().start_pos,
+            Quote.query.one().end_pos,
+            Quote.query.one().page_number,
+        ).astuple() == (0, second_image_start)
+    finally:
+        document.close()
+        reader.unload()
+
+
 def test_content_hash_migration_only_adds_schema(asset, tmp_path):
     db_path = tmp_path / "migration.db"
     db_url = f"sqlite:///{db_path}"
@@ -167,17 +633,29 @@ def test_content_hash_migration_only_adds_schema(asset, tmp_path):
     try:
         with migrated_engine.connect() as conn:
             revision = conn.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
-            assert revision == "707543f03b6d"
+            assert revision == "b743b2dbd3a1"
             for table_name in (
                 "book",
                 "document_position_info",
                 "recent_document",
                 "pinned_document",
             ):
-                content_hashes = conn.execute(
-                    text(f"SELECT content_hash FROM {table_name}")
-                ).scalars().all()
+                content_hashes = (
+                    conn.execute(text(f"SELECT content_hash FROM {table_name}")).scalars().all()
+                )
                 assert content_hashes == [None]
+                hash_versions = (
+                    conn.execute(text(f"SELECT content_hash_version FROM {table_name}"))
+                    .scalars()
+                    .all()
+                )
+                assert hash_versions == [None]
+            position_versions = (
+                conn.execute(text("SELECT position_version FROM document_position_info"))
+                .scalars()
+                .all()
+            )
+            assert position_versions == [None]
     finally:
         close_all_sessions()
         migrated_engine.dispose()
@@ -323,9 +801,35 @@ def test_textless_documents_do_not_merge_by_content_hash(reader, tmp_path):
 
 
 @pytest.mark.usefixtures("engine")
-def test_recent_documents_follow_path_changes_after_lazy_hash_backfill(
-    asset, tmp_path
-):
+def test_image_only_html_documents_do_not_merge_by_content_hash(tmp_path):
+    first_path = tmp_path / "first.html"
+    second_path = tmp_path / "second.html"
+    first_path.write_text(
+        '<html><head><title>First</title></head><body><img src="one.png" alt="One"></body></html>',
+        encoding="utf-8",
+    )
+    second_path.write_text(
+        '<html><head><title>Second</title></head><body><img src="two.png" alt="Two"></body></html>',
+        encoding="utf-8",
+    )
+    first_document = create_document(DocumentUri.from_filename(first_path))
+    second_document = create_document(DocumentUri.from_filename(second_path))
+    try:
+        assert first_document.get_content_hash() is None
+        assert second_document.get_content_hash() is None
+        assert first_document.get_legacy_content_hash() is None
+        assert second_document.get_legacy_content_hash() is None
+        recents_manager.add_to_recents(first_document)
+        recents_manager.add_to_recents(second_document)
+    finally:
+        first_document.close()
+        second_document.close()
+
+    assert RecentDocument.query.count() == 2
+
+
+@pytest.mark.usefixtures("engine")
+def test_recent_documents_follow_path_changes_after_lazy_hash_backfill(asset, tmp_path):
     original_uri = DocumentUri.from_filename(asset("roman.epub"))
     original_doc = create_document(original_uri)
 
@@ -383,6 +887,81 @@ def test_recent_documents_merge_existing_uri_and_hash_duplicates(asset, tmp_path
 
 
 @pytest.mark.usefixtures("engine")
+def test_recent_and_pinned_documents_merge_legacy_when_current_hash_is_unavailable(
+    tmp_path,
+):
+    original_path = tmp_path / "original.html"
+    moved_path = tmp_path / "moved.html"
+    html_content = """
+    <html>
+        <head><title>Book</title></head>
+        <body><p>before <img src="missing.png" alt="Chart"> after text</p></body>
+    </html>
+    """
+    original_path.write_text(html_content, encoding="utf-8")
+    moved_path.write_text(html_content, encoding="utf-8")
+
+    original_uri = DocumentUri.from_filename(original_path)
+    moved_document = create_document(DocumentUri.from_filename(moved_path))
+    try:
+        assert moved_document.get_content_hash() is None
+        legacy_hash = moved_document.get_legacy_content_hash()
+        legacy_recent = RecentDocument(
+            title=moved_document.metadata.title,
+            uri=original_uri,
+            content_hash=legacy_hash,
+            content_hash_version=None,
+        )
+        legacy_pinned = PinnedDocument(
+            title=moved_document.metadata.title,
+            uri=original_uri,
+            content_hash=legacy_hash,
+            content_hash_version=None,
+            is_pinned=True,
+            pinning_order=7,
+        )
+        RecentDocument.session.add_all((legacy_recent, legacy_pinned))
+        RecentDocument.session.commit()
+        RecentDocument.session.execute(
+            text("UPDATE recent_document SET content_hash_version = NULL")
+        )
+        RecentDocument.session.execute(
+            text("UPDATE pinned_document SET content_hash_version = NULL")
+        )
+        RecentDocument.session.commit()
+        RecentDocument.session.expire_all()
+
+        recents_manager.add_to_recents(moved_document)
+        assert recents_manager.is_pinned(moved_document) is True
+
+        next_path = tmp_path / "next.html"
+        next_path.write_text(html_content, encoding="utf-8")
+        next_document = create_document(DocumentUri.from_filename(next_path))
+        try:
+            assert next_document.get_content_hash() is None
+            assert next_document.get_legacy_content_hash() == legacy_hash
+            recents_manager.add_to_recents(next_document)
+            assert recents_manager.is_pinned(next_document) is True
+        finally:
+            next_document.close()
+    finally:
+        moved_document.close()
+
+    assert RecentDocument.query.count() == 1
+    assert PinnedDocument.query.count() == 1
+    recent = RecentDocument.query.one()
+    pinned = PinnedDocument.query.one()
+    assert recent.uri == next_document.uri
+    assert pinned.uri == next_document.uri
+    assert recent.content_hash == legacy_hash
+    assert pinned.content_hash == legacy_hash
+    assert recent.content_hash_version is None
+    assert pinned.content_hash_version is None
+    assert pinned.is_pinned is True
+    assert pinned.pinning_order == 7
+
+
+@pytest.mark.usefixtures("engine")
 def test_textless_recent_documents_do_not_merge_by_content_hash(tmp_path):
     first_path = tmp_path / "first.pptx"
     second_path = tmp_path / "second.pptx"
@@ -401,9 +980,7 @@ def test_textless_recent_documents_do_not_merge_by_content_hash(tmp_path):
     assert RecentDocument.query.count() == 2
 
 
-def test_loading_existing_uri_uses_stored_hash_without_recomputing(
-    reader, asset, monkeypatch
-):
+def test_loading_existing_uri_uses_stored_hash_without_recomputing(reader, asset, monkeypatch):
     uri = DocumentUri.from_filename(asset("roman.epub"))
     document = create_document(uri)
     content_hash = document.get_content_hash()
@@ -412,17 +989,17 @@ def test_loading_existing_uri_uses_stored_hash_without_recomputing(
         title=document.metadata.title,
         uri=uri,
         content_hash=content_hash,
+        content_hash_version=CURRENT_CONTENT_HASH_VERSION,
     )
     DocumentPositionInfo.get_or_create(
         title=document.metadata.title,
         uri=uri,
         content_hash=content_hash,
+        content_hash_version=CURRENT_CONTENT_HASH_VERSION,
     )
 
     def fail_get_content_hash():
-        raise AssertionError(
-            "reader should reuse the stored content hash for URI matches"
-        )
+        raise AssertionError("reader should reuse the stored content hash for URI matches")
 
     monkeypatch.setattr(document, "get_content_hash", fail_get_content_hash)
 
@@ -434,9 +1011,7 @@ def test_loading_existing_uri_uses_stored_hash_without_recomputing(
 
 
 @pytest.mark.usefixtures("engine")
-def test_recent_documents_with_existing_uri_use_stored_hash_without_recomputing(
-    asset, monkeypatch
-):
+def test_recent_documents_with_existing_uri_use_stored_hash_without_recomputing(asset, monkeypatch):
     uri = DocumentUri.from_filename(asset("roman.epub"))
     document = create_document(uri)
     content_hash = document.get_content_hash()
@@ -445,12 +1020,11 @@ def test_recent_documents_with_existing_uri_use_stored_hash_without_recomputing(
         title=document.metadata.title,
         uri=uri,
         content_hash=content_hash,
+        content_hash_version=CURRENT_CONTENT_HASH_VERSION,
     )
 
     def fail_get_content_hash():
-        raise AssertionError(
-            "recents should reuse the stored content hash for URI matches"
-        )
+        raise AssertionError("recents should reuse the stored content hash for URI matches")
 
     monkeypatch.setattr(document, "get_content_hash", fail_get_content_hash)
 
@@ -508,9 +1082,7 @@ def test_pinned_documents_do_not_match_across_formats(tmp_path):
 
 
 @pytest.mark.usefixtures("engine")
-def test_pinned_documents_follow_path_changes_after_lazy_hash_backfill(
-    asset, tmp_path
-):
+def test_pinned_documents_follow_path_changes_after_lazy_hash_backfill(asset, tmp_path):
     original_uri = DocumentUri.from_filename(asset("roman.epub"))
     original_doc = create_document(original_uri)
 
@@ -569,5 +1141,65 @@ def test_pinned_documents_merge_existing_uri_and_hash_duplicates(asset, tmp_path
     assert merged_pinned.id == current_pinned.id
     assert merged_pinned.uri == DocumentUri.from_filename(moved_path)
     assert merged_pinned.content_hash == content_hash
+    assert merged_pinned.is_pinned is True
+    assert merged_pinned.pinning_order == 7
+
+
+@pytest.mark.usefixtures("engine")
+def test_pinned_documents_merge_legacy_duplicate_with_existing_uri(asset, tmp_path):
+    original_uri = DocumentUri.from_filename(asset("roman.epub"))
+    moved_path = shutil.copy(Path(original_uri.path), tmp_path / "roman.epub")
+    moved_document = create_document(DocumentUri.from_filename(moved_path))
+    try:
+        moved_uri = moved_document.uri
+        current_hash = moved_document.get_content_hash()
+        legacy_hash = moved_document.get_legacy_content_hash()
+        current_pinned = PinnedDocument.get_or_create(
+            title=moved_document.metadata.title,
+            uri=moved_uri,
+        )
+        current_pinned.content_hash = None
+        current_pinned.content_hash_version = None
+        current_pinned.is_pinned = False
+        current_pinned.pinning_order = 0
+        legacy_pinned = PinnedDocument(
+            title=moved_document.metadata.title,
+            uri=original_uri,
+            content_hash=legacy_hash,
+            content_hash_version=None,
+            is_pinned=True,
+            pinning_order=7,
+        )
+        PinnedDocument.session.add(legacy_pinned)
+        PinnedDocument.session.flush()
+        PinnedDocument.session.execute(
+            text(
+                "UPDATE pinned_document "
+                "SET content_hash = NULL, content_hash_version = NULL, is_pinned = 0, pinning_order = 0 "
+                "WHERE id = :id"
+            ),
+            {"id": current_pinned.id},
+        )
+        PinnedDocument.session.execute(
+            text(
+                "UPDATE pinned_document "
+                "SET content_hash_version = NULL, is_pinned = 1, pinning_order = 7 "
+                "WHERE id = :id"
+            ),
+            {"id": legacy_pinned.id},
+        )
+        PinnedDocument.session.commit()
+        PinnedDocument.session.expire_all()
+
+        assert recents_manager.is_pinned(moved_document) is True
+    finally:
+        moved_document.close()
+
+    assert PinnedDocument.query.count() == 1
+    merged_pinned = PinnedDocument.query.one()
+    assert merged_pinned.id == current_pinned.id
+    assert merged_pinned.uri == moved_uri
+    assert merged_pinned.content_hash == current_hash
+    assert merged_pinned.content_hash_version == CURRENT_CONTENT_HASH_VERSION
     assert merged_pinned.is_pinned is True
     assert merged_pinned.pinning_order == 7

--- a/tests/test_embedded_images.py
+++ b/tests/test_embedded_images.py
@@ -1,10 +1,13 @@
+import base64
 import os
+import zipfile
 from functools import cached_property
 from io import BytesIO
+from types import SimpleNamespace
 
+import pytest
 from ebooklib import epub
 from PIL import Image
-import pytest
 
 from bookworm.document import (
     SINGLE_PAGE_DOCUMENT_PAGER,
@@ -17,11 +20,18 @@ from bookworm.document import (
 )
 from bookworm.document.formats.epub import EpubDocument
 from bookworm.document.formats.html import FileSystemHtmlDocument
+from bookworm.document.formats.odf import OdfPresentation
 from bookworm.document.uri import DocumentUri
 from bookworm.gui.book_viewer import _get_structural_navigation_speech
 from bookworm.gui.book_viewer.render_view import EmbeddedImageDialog
 from bookworm.image_io import ImageIO
-from bookworm.structured_text import ImageElementInfo, SemanticElementType, TextRange
+from bookworm.structured_text import (
+    TEXT_OBJECT_REPLACEMENT_CHAR,
+    ImageElementInfo,
+    SemanticElementType,
+    TextPositionMap,
+    TextRange,
+)
 from bookworm.structured_text.structured_html_parser import StructuredHtmlParser
 
 
@@ -187,6 +197,113 @@ def test_structured_html_parser_collects_image_ranges_and_metadata():
     assert parser.get_image_info(0).suggested_filename == "alt.png"
 
 
+def test_structured_html_parser_uses_stable_storage_placeholders():
+    parser = StructuredHtmlParser.from_string(
+        """
+        <html><body>
+            before <img src="images/alt.png" alt="Alt text"> after
+            <img src="images/fallback.png">
+        </body></html>
+        """
+    )
+
+    display_text = parser.get_text()
+    storage_text = parser.get_storage_text()
+    ranges = parser.semantic_elements[SemanticElementType.FIGURE]
+
+    assert [display_text[start:stop] for start, stop in ranges] == [
+        "[Alt text]",
+        "[Image]",
+    ]
+    assert storage_text.count(TEXT_OBJECT_REPLACEMENT_CHAR) == 2
+    for start, stop in ranges:
+        storage_range = parser.display_to_storage_range(start, stop)
+        assert (
+            storage_text[storage_range.start : storage_range.stop] == TEXT_OBJECT_REPLACEMENT_CHAR
+        )
+        assert parser.storage_to_display_range(
+            storage_range.start, storage_range.stop
+        ).astuple() == (start, stop)
+
+
+def test_structured_html_parser_keeps_range_stops_before_following_images():
+    parser = StructuredHtmlParser.from_string(
+        """
+        <html><body>
+            before <img src="images/alt.png" alt="Alt text"> after
+        </body></html>
+        """
+    )
+
+    display_text = parser.get_text()
+    storage_text = parser.get_storage_text()
+    image_start, image_stop = parser.semantic_elements[SemanticElementType.FIGURE][0]
+
+    before_image = parser.display_to_storage_range(0, image_start)
+    assert storage_text[before_image.start : before_image.stop] == display_text[:image_start]
+    assert TEXT_OBJECT_REPLACEMENT_CHAR not in storage_text[before_image.start : before_image.stop]
+    assert parser.storage_to_display_range(before_image.start, before_image.stop).astuple() == (
+        0,
+        image_start,
+    )
+
+    image_and_text = parser.display_to_storage_range(0, image_stop)
+    assert storage_text[image_and_text.start : image_and_text.stop].endswith(
+        TEXT_OBJECT_REPLACEMENT_CHAR
+    )
+
+
+def test_text_position_map_from_texts_preserves_legacy_image_boundaries():
+    legacy_text = "before middle after text\n"
+    storage_text = f"before {TEXT_OBJECT_REPLACEMENT_CHAR} middle {TEXT_OBJECT_REPLACEMENT_CHAR} after text\n"
+    mapper = TextPositionMap.from_texts(legacy_text, storage_text)
+
+    after_text = legacy_text.index("after")
+    second_image = storage_text.index(
+        TEXT_OBJECT_REPLACEMENT_CHAR,
+        storage_text.index(TEXT_OBJECT_REPLACEMENT_CHAR) + 1,
+    )
+    after_text_storage = storage_text.index("after")
+
+    assert mapper.display_to_storage_position(after_text, affinity="before") == second_image
+    assert mapper.display_to_storage_position(after_text, affinity="after") == after_text_storage
+    assert mapper.display_to_storage_range(0, after_text).stop == second_image
+    assert mapper.display_to_storage_range(after_text, after_text + len("after")).start == (
+        after_text_storage
+    )
+
+
+def test_html_legacy_content_hash_uses_pre_image_navigation_text(tmp_path):
+    image_path = tmp_path / "pic.png"
+    image_path.write_bytes(make_png_bytes())
+    html_path = tmp_path / "book.html"
+    html_path.write_text(
+        """
+        <html>
+            <head><title>Book</title></head>
+            <body><p>alpha <img src="pic.png" alt="Picture"> omega</p></body>
+        </html>
+        """,
+        encoding="utf-8",
+    )
+    document = FileSystemHtmlDocument(DocumentUri.from_filename(html_path))
+    document.read()
+
+    try:
+        legacy_parser = StructuredHtmlParser.from_string(
+            html_path.read_text(encoding="utf-8"),
+            include_images=False,
+        )
+        legacy_text = legacy_parser.get_text()
+        assert TEXT_OBJECT_REPLACEMENT_CHAR not in legacy_text
+        assert document.get_legacy_content() == legacy_text
+        assert document.get_legacy_content_hash() == document._hash_document_text(
+            legacy_text
+        )
+    finally:
+        document.close()
+
+
 def test_structured_html_parser_ignores_symbol_only_image_alt_text():
     parser = StructuredHtmlParser.from_string(
         '<html><body><img src="images/pic.png" alt="{%}"></body></html>'
@@ -309,28 +426,14 @@ def test_structured_html_parser_matches_visible_table_image_when_text_repeats():
     assert parser.get_image_info(0).src == "images/shown.png"
 
 
-def test_structured_html_parser_filters_hidden_images_from_metadata():
+def test_structured_html_parser_honors_hidden_attribute_when_filtering_images():
     parser = StructuredHtmlParser.from_string(
         """
         <html><body>
-            <img src="images/hidden.png" alt="Image" style="display:none">
-            <img src="images/shown.png" alt="Image">
-        </body></html>
-        """
-    )
-
-    text = parser.get_text()
-    ranges = parser.semantic_elements[SemanticElementType.FIGURE]
-
-    assert [text[start:stop] for start, stop in ranges] == ["[Image]"]
-    assert parser.get_image_info(0).src == "images/shown.png"
-
-
-def test_structured_html_parser_honors_important_when_filtering_hidden_images():
-    parser = StructuredHtmlParser.from_string(
-        """
-        <html><body>
-            <img src="images/hidden.png" alt="Hidden" style="display: none !important">
+            <img src="images/hidden.png" alt="Hidden" hidden>
+            <div hidden>
+                <img src="images/ancestor-hidden.png" alt="Ancestor hidden">
+            </div>
             <img src="images/shown.png" alt="Shown">
         </body></html>
         """
@@ -343,14 +446,11 @@ def test_structured_html_parser_honors_important_when_filtering_hidden_images():
     assert parser.get_image_info(0).src == "images/shown.png"
 
 
-def test_structured_html_parser_honors_hidden_attribute_when_filtering_images():
+def test_structured_html_parser_honors_important_when_filtering_hidden_images():
     parser = StructuredHtmlParser.from_string(
         """
         <html><body>
-            <img src="images/hidden.png" alt="Hidden" hidden>
-            <div hidden>
-                <img src="images/ancestor-hidden.png" alt="Ancestor hidden">
-            </div>
+            <img src="images/hidden.png" alt="Hidden" style="display: none !important">
             <img src="images/shown.png" alt="Shown">
         </body></html>
         """
@@ -518,7 +618,7 @@ def test_epub_document_resolves_domain_like_package_relative_image(tmp_path):
     document = make_epub_document(
         tmp_path,
         '<html><body><h1>Intro</h1><p><img src="foo.com/pic.png" alt="Picture"></p></body></html>',
-        make_epub_image_item("pic", "foo.com/pic.png", size=(5, 6)),
+        make_epub_image_item("pic", "chapters/foo.com/pic.png", size=(5, 6)),
     )
 
     assert document.get_document_embedded_image(0).size == (5, 6)
@@ -551,8 +651,8 @@ def test_epub_document_does_not_match_embedded_image_by_partial_suffix(tmp_path)
     document = make_epub_document(
         tmp_path,
         '<html><body><h1>Intro</h1><p><img src="cover.png" alt="Cover"></p></body></html>',
-        make_epub_image_item("backcover", "images/backcover.png", size=(3, 4)),
-        make_epub_image_item("cover", "images/cover.png", size=(6, 7)),
+        make_epub_image_item("backcover", "chapters/backcover.png", size=(3, 4)),
+        make_epub_image_item("cover", "chapters/cover.png", size=(6, 7)),
     )
 
     assert document.get_document_embedded_image(0).size == (6, 7)
@@ -564,6 +664,17 @@ def test_epub_document_does_not_choose_ambiguous_basename_fallback(tmp_path):
         '<html><body><h1>Intro</h1><p><img src="pic.png" alt="Picture"></p></body></html>',
         make_epub_image_item("pic1", "images/pic.png", size=(3, 4)),
         make_epub_image_item("pic2", "figures/pic.png", size=(6, 7)),
+    )
+
+    with pytest.raises(DocumentIOError):
+        document.get_document_embedded_image(0)
+
+
+def test_epub_document_does_not_choose_unique_basename_fallback(tmp_path):
+    document = make_epub_document(
+        tmp_path,
+        '<html><body><h1>Intro</h1><p><img src="../missing/pic.png" alt="Picture"></p></body></html>',
+        make_epub_image_item("pic", "images/pic.png", size=(6, 7)),
     )
 
     with pytest.raises(DocumentIOError):
@@ -584,6 +695,143 @@ def test_epub_document_wraps_undecodable_embedded_image(tmp_path):
 
     with pytest.raises(DocumentIOError):
         document.get_document_embedded_image(0)
+
+
+def test_html_content_hash_uses_embedded_image_bytes(tmp_path):
+    def make_document(directory, image_src, image_bytes=None, filename=None):
+        directory.mkdir()
+        if image_bytes is not None:
+            (directory / (filename or image_src)).write_bytes(image_bytes)
+        html_path = directory / "book.html"
+        html_path.write_text(
+            f"""
+            <html>
+                <head><title>Book</title></head>
+                <body><p>alpha <img src="{image_src}" alt="Picture"> omega</p></body>
+            </html>
+            """,
+            encoding="utf-8",
+        )
+        document = FileSystemHtmlDocument(DocumentUri.from_filename(html_path))
+        document.read()
+        return document
+
+    red_image = make_png_bytes(color=(255, 0, 0))
+    blue_image = make_png_bytes(color=(0, 0, 255))
+    first = make_document(tmp_path / "first", "pic.png", red_image)
+    same_image_different_name = make_document(
+        tmp_path / "same", "renamed.png", red_image
+    )
+    different_image = make_document(tmp_path / "different", "pic.png", blue_image)
+    inline_image_src = "data:image/png;base64," + base64.b64encode(red_image).decode("ascii")
+    inline_image = make_document(
+        tmp_path / "inline",
+        inline_image_src,
+        None,
+        filename="inline.png",
+    )
+
+    try:
+        assert first.get_content_hash() == same_image_different_name.get_content_hash()
+        assert first.get_content_hash() == inline_image.get_content_hash()
+        assert first.get_content_hash() != different_image.get_content_hash()
+    finally:
+        first.close()
+        same_image_different_name.close()
+        different_image.close()
+        inline_image.close()
+
+
+def test_html_content_hash_resolves_remote_base_href_for_relative_images(tmp_path):
+    def make_document(directory, base_href):
+        directory.mkdir()
+        html_path = directory / "book.html"
+        html_path.write_text(
+            f"""
+            <html>
+                <head><title>Book</title><base href="{base_href}"></head>
+                <body><p>alpha <img src="pic.png" alt="Picture"> omega</p></body>
+            </html>
+            """,
+            encoding="utf-8",
+        )
+        document = FileSystemHtmlDocument(DocumentUri.from_filename(html_path))
+        document.read()
+        return document
+
+    first = make_document(tmp_path / "first", "https://cdn.example.com/one/")
+    second = make_document(tmp_path / "second", "https://cdn.example.com/two/")
+
+    try:
+        assert first.get_content_hash() is not None
+        assert second.get_content_hash() is not None
+        assert first.get_content_hash() != second.get_content_hash()
+    finally:
+        first.close()
+        second.close()
+
+
+def test_odp_content_hash_uses_package_image_bytes(tmp_path):
+    def make_document(filename, image_bytes):
+        odp_path = tmp_path / filename
+        with zipfile.ZipFile(odp_path, "w") as package:
+            package.writestr("Pictures/pic.png", image_bytes)
+        document = OdfPresentation(DocumentUri.from_filename(odp_path))
+        document.parser = SimpleNamespace(title="Deck")
+        document.slides = {
+            "Slide": '<p>alpha <img src="Pictures/pic.png" alt="Picture"> omega</p>'
+        }
+        document.num_slides = 1
+        document._is_read = True
+        return document
+
+    first = make_document("first.odp", make_png_bytes(color=(255, 0, 0)))
+    second = make_document("second.odp", make_png_bytes(color=(0, 0, 255)))
+
+    try:
+        assert first.get_content_hash() != second.get_content_hash()
+        image_info = first.get_page(0).get_embedded_image_info(0)
+        image = first.get_page(0).get_embedded_image(0)
+        assert image_info.src == "Pictures/pic.png"
+        assert image.size == (3, 2)
+    finally:
+        first.close()
+        second.close()
+
+
+def test_epub_content_hash_uses_embedded_image_bytes(tmp_path):
+    first_dir = tmp_path / "first"
+    second_dir = tmp_path / "second"
+    first_dir.mkdir()
+    second_dir.mkdir()
+    chapter_content = (
+        '<html><body><h1>Intro</h1><p>alpha '
+        '<img src="../images/pic.png" alt="Picture"> omega</p></body></html>'
+    )
+    first = make_epub_document(
+        first_dir,
+        chapter_content,
+        make_epub_image_item(
+            "pic",
+            "images/pic.png",
+            content=make_png_bytes(color=(255, 0, 0)),
+        ),
+    )
+    second = make_epub_document(
+        second_dir,
+        chapter_content,
+        make_epub_image_item(
+            "pic",
+            "images/pic.png",
+            content=make_png_bytes(color=(0, 0, 255)),
+        ),
+    )
+
+    try:
+        assert first.get_content_hash() != second.get_content_hash()
+    finally:
+        first.close()
+        second.close()
 
 
 def test_image_io_serializes_rgba_as_jpeg():
@@ -717,9 +965,7 @@ def test_reader_ctrl_enter_opens_embedded_image(reader, view):
     document = SyntheticImageDocument(
         "[Cover]",
         {SemanticElementType.FIGURE: [(0, 7)]},
-        image_infos=(
-            ImageElementInfo(TextRange(0, 7), "cover.png", "Cover", "cover.png"),
-        ),
+        image_infos=(ImageElementInfo(TextRange(0, 7), "cover.png", "Cover", "cover.png"),),
         images=(ImageIO.from_bytes(make_png_bytes(size=(8, 9))),),
     )
     document.read()
@@ -763,9 +1009,7 @@ def test_reader_ctrl_enter_activates_link_when_embedded_image_fails(reader, view
     assert view.image_dialog_args is None
 
 
-def test_reader_ctrl_enter_uses_document_order_after_backward_image_navigation(
-    reader, view
-):
+def test_reader_ctrl_enter_uses_document_order_after_backward_image_navigation(reader, view):
     document = SyntheticImageDocument(
         "[One]\n[Two]",
         {SemanticElementType.FIGURE: [(0, 5), (6, 11)]},

--- a/tests/test_embedded_images.py
+++ b/tests/test_embedded_images.py
@@ -1,0 +1,789 @@
+import os
+from functools import cached_property
+from io import BytesIO
+
+from ebooklib import epub
+from PIL import Image
+import pytest
+
+from bookworm.document import (
+    SINGLE_PAGE_DOCUMENT_PAGER,
+    BookMetadata,
+    DocumentCapability,
+    DocumentIOError,
+    LinkTarget,
+    Section,
+    SinglePageDocument,
+)
+from bookworm.document.formats.epub import EpubDocument
+from bookworm.document.formats.html import FileSystemHtmlDocument
+from bookworm.document.uri import DocumentUri
+from bookworm.gui.book_viewer import _get_structural_navigation_speech
+from bookworm.gui.book_viewer.render_view import EmbeddedImageDialog
+from bookworm.image_io import ImageIO
+from bookworm.structured_text import ImageElementInfo, SemanticElementType, TextRange
+from bookworm.structured_text.structured_html_parser import StructuredHtmlParser
+
+
+def make_png_bytes(size=(3, 2), color=(255, 0, 0)):
+    buf = BytesIO()
+    Image.new("RGB", size, color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def make_transparent_png_bytes():
+    buf = BytesIO()
+    image = Image.new("RGBA", (2, 1), (255, 0, 0, 255))
+    image.putpixel((1, 0), (0, 255, 0, 0))
+    image.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def make_palette_png_bytes():
+    image = Image.new("P", (2, 1))
+    image.putpalette([255, 0, 0, 0, 255, 0] + [0, 0, 0] * 254)
+    image.putdata([0, 1])
+    buf = BytesIO()
+    image.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def make_epub_image_item(
+    uid,
+    file_name,
+    *,
+    size=(6, 7),
+    media_type="image/png",
+    content=None,
+):
+    return epub.EpubItem(
+        uid=uid,
+        file_name=file_name,
+        media_type=media_type,
+        content=make_png_bytes(size=size) if content is None else content,
+    )
+
+
+def make_epub_document(tmp_path, chapter_content, *items):
+    book = epub.EpubBook()
+    book.set_title("Image book")
+    book.set_language("en")
+    chapter = epub.EpubHtml(title="Intro", file_name="chapters/ch1.xhtml", lang="en")
+    chapter.content = chapter_content
+    book.add_item(chapter)
+    for item in items:
+        book.add_item(item)
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.toc = (epub.Link("chapters/ch1.xhtml", "Intro", "intro"),)
+    book.spine = ["nav", chapter]
+    epub_path = tmp_path / "image_book.epub"
+    epub.write_epub(epub_path, book, {})
+    document = EpubDocument(DocumentUri.from_filename(epub_path))
+    document.read()
+    return document
+
+
+class SyntheticImageDocument(SinglePageDocument):
+    __internal__ = True
+    format = "synthetic_image_document"
+    extensions = ()
+    capabilities = (
+        DocumentCapability.SINGLE_PAGE
+        | DocumentCapability.STRUCTURED_NAVIGATION
+        | DocumentCapability.TOC_TREE
+        | DocumentCapability.LINKS
+    )
+
+    def __init__(
+        self,
+        text,
+        semantic_structure,
+        *,
+        image_infos=(),
+        images=(),
+        image_error=None,
+        link_target=None,
+    ):
+        super().__init__(DocumentUri(self.format, "", {}))
+        self.text = text
+        self.document_semantic_structure = semantic_structure
+        self.image_infos = image_infos
+        self.images = images
+        self.image_error = image_error
+        self.link_target = link_target
+
+    def read(self):
+        super().read()
+
+    def get_content(self):
+        return self.text
+
+    @cached_property
+    def toc_tree(self):
+        return Section(
+            title="Synthetic",
+            pager=SINGLE_PAGE_DOCUMENT_PAGER,
+            text_range=TextRange(0, len(self.text)),
+        )
+
+    @cached_property
+    def metadata(self):
+        return BookMetadata(title="Synthetic", author="")
+
+    def get_document_semantic_structure(self):
+        return self.document_semantic_structure
+
+    def get_document_style_info(self):
+        return {}
+
+    def get_document_table_markup(self, table_index):
+        raise NotImplementedError
+
+    def get_document_embedded_image_info(self, image_index):
+        return self.image_infos[image_index]
+
+    def get_document_embedded_image(self, image_index):
+        if self.image_error:
+            raise self.image_error
+        return self.images[image_index]
+
+    def resolve_link(self, text_range):
+        if self.link_target:
+            return self.link_target
+        raise NotImplementedError
+
+
+def test_structured_html_parser_collects_image_ranges_and_metadata():
+    parser = StructuredHtmlParser.from_string(
+        """
+        <html><body>
+            before <img src="images/alt.png" alt="Alt text"> after
+            <img src="images/title.png" title="Title text">
+            <figure>
+                <img src="images/caption.png">
+                <figcaption>Caption text</figcaption>
+            </figure>
+            <img src="images/fallback.png">
+        </body></html>
+        """
+    )
+
+    text = parser.get_text()
+    ranges = parser.semantic_elements[SemanticElementType.FIGURE]
+
+    assert [text[start:stop] for start, stop in ranges] == [
+        "[Alt text]",
+        "[Title text]",
+        "[Caption text]",
+        "[Image]",
+    ]
+    assert [parser.get_image_info(idx).label for idx in range(4)] == [
+        "Alt text",
+        "Title text",
+        "Caption text",
+        "Image",
+    ]
+    assert parser.get_image_info(0).suggested_filename == "alt.png"
+
+
+def test_structured_html_parser_ignores_symbol_only_image_alt_text():
+    parser = StructuredHtmlParser.from_string(
+        '<html><body><img src="images/pic.png" alt="{%}"></body></html>'
+    )
+
+    text = parser.get_text()
+    ranges = parser.semantic_elements[SemanticElementType.FIGURE]
+
+    assert [text[start:stop] for start, stop in ranges] == ["[Image]"]
+    assert parser.get_image_info(0).label == "Image"
+
+
+def test_structured_html_parser_uses_title_when_alt_is_not_meaningful():
+    parser = StructuredHtmlParser.from_string(
+        '<html><body><img src="images/pic.png" alt="{%}" title="Diagram"></body></html>'
+    )
+
+    text = parser.get_text()
+    ranges = parser.semantic_elements[SemanticElementType.FIGURE]
+
+    assert [text[start:stop] for start, stop in ranges] == ["[Diagram]"]
+    assert parser.get_image_info(0).label == "Diagram"
+
+
+def test_structured_html_parser_skips_images_with_empty_alt_text():
+    parser = StructuredHtmlParser.from_string(
+        """
+        <html><body>
+            <img src="images/decorative.png" alt="">
+            <img src="images/content.png" alt="Content">
+        </body></html>
+        """
+    )
+
+    text = parser.get_text()
+    ranges = parser.semantic_elements[SemanticElementType.FIGURE]
+
+    assert [text[start:stop] for start, stop in ranges] == ["[Content]"]
+    assert parser.get_image_info(0).src == "images/content.png"
+
+
+def test_structured_html_parser_keeps_empty_alt_images_with_title():
+    parser = StructuredHtmlParser.from_string(
+        '<html><body><img src="images/pic.png" alt="" title="Diagram"></body></html>'
+    )
+
+    text = parser.get_text()
+    ranges = parser.semantic_elements[SemanticElementType.FIGURE]
+
+    assert [text[start:stop] for start, stop in ranges] == ["[Diagram]"]
+    assert parser.get_image_info(0).label == "Diagram"
+
+
+def test_structured_html_parser_keeps_empty_alt_images_with_caption():
+    parser = StructuredHtmlParser.from_string(
+        """
+        <html><body>
+            <figure>
+                <img src="images/pic.png" alt="">
+                <figcaption>Diagram caption</figcaption>
+            </figure>
+        </body></html>
+        """
+    )
+
+    text = parser.get_text()
+    ranges = parser.semantic_elements[SemanticElementType.FIGURE]
+
+    assert [text[start:stop] for start, stop in ranges] == ["[Diagram caption]"]
+    assert parser.get_image_info(0).label == "Diagram caption"
+
+
+def test_structured_html_parser_places_image_ranges_after_rendered_prefixes():
+    parser = StructuredHtmlParser.from_string(
+        """
+        <html><body>
+            <ul>
+                <li><img src="images/list.png" alt="List image"> item</li>
+            </ul>
+            <table>
+                <tr>
+                    <td><img src="images/table.png" alt="Table image"></td>
+                    <td>cell</td>
+                </tr>
+            </table>
+        </body></html>
+        """
+    )
+
+    text = parser.get_text()
+    ranges = parser.semantic_elements[SemanticElementType.FIGURE]
+
+    assert [text[start:stop] for start, stop in ranges] == [
+        "[List image]",
+        "[Table image]",
+    ]
+
+
+def test_structured_html_parser_matches_visible_table_image_when_text_repeats():
+    parser = StructuredHtmlParser.from_string(
+        """
+        <html><body>
+            <table>
+                <tr>
+                    <td>[Diagram]</td>
+                    <td>
+                        <img src="images/hidden.png" alt="Diagram" style="display:none">
+                        <img src="images/shown.png" alt="Diagram">
+                    </td>
+                </tr>
+            </table>
+        </body></html>
+        """
+    )
+
+    text = parser.get_text()
+    ranges = parser.semantic_elements[SemanticElementType.FIGURE]
+
+    assert [text[start:stop] for start, stop in ranges] == ["[Diagram]"]
+    assert parser.get_image_info(0).src == "images/shown.png"
+
+
+def test_structured_html_parser_filters_hidden_images_from_metadata():
+    parser = StructuredHtmlParser.from_string(
+        """
+        <html><body>
+            <img src="images/hidden.png" alt="Image" style="display:none">
+            <img src="images/shown.png" alt="Image">
+        </body></html>
+        """
+    )
+
+    text = parser.get_text()
+    ranges = parser.semantic_elements[SemanticElementType.FIGURE]
+
+    assert [text[start:stop] for start, stop in ranges] == ["[Image]"]
+    assert parser.get_image_info(0).src == "images/shown.png"
+
+
+def test_structured_html_parser_honors_important_when_filtering_hidden_images():
+    parser = StructuredHtmlParser.from_string(
+        """
+        <html><body>
+            <img src="images/hidden.png" alt="Hidden" style="display: none !important">
+            <img src="images/shown.png" alt="Shown">
+        </body></html>
+        """
+    )
+
+    text = parser.get_text()
+    ranges = parser.semantic_elements[SemanticElementType.FIGURE]
+
+    assert [text[start:stop] for start, stop in ranges] == ["[Shown]"]
+    assert parser.get_image_info(0).src == "images/shown.png"
+
+
+def test_structured_html_parser_honors_hidden_attribute_when_filtering_images():
+    parser = StructuredHtmlParser.from_string(
+        """
+        <html><body>
+            <img src="images/hidden.png" alt="Hidden" hidden>
+            <div hidden>
+                <img src="images/ancestor-hidden.png" alt="Ancestor hidden">
+            </div>
+            <img src="images/shown.png" alt="Shown">
+        </body></html>
+        """
+    )
+
+    text = parser.get_text()
+    ranges = parser.semantic_elements[SemanticElementType.FIGURE]
+
+    assert [text[start:stop] for start, stop in ranges] == ["[Shown]"]
+    assert parser.get_image_info(0).src == "images/shown.png"
+
+
+def test_structured_html_parser_keeps_figure_ranges_and_image_info_in_lockstep():
+    parser = StructuredHtmlParser.from_string(
+        """
+        <html><body>
+            <p>[Chart]</p>
+            <img src="images/hidden.png" alt="Chart" style="display:none">
+            <img src="images/decorative.png" alt="">
+            <ul>
+                <li><img src="images/list.png" alt="Chart"> item</li>
+            </ul>
+            <table>
+                <tr>
+                    <td>[Chart]</td>
+                    <td><img src="images/table.png" alt="Chart"></td>
+                </tr>
+            </table>
+        </body></html>
+        """
+    )
+
+    text = parser.get_text()
+    ranges = parser.semantic_elements[SemanticElementType.FIGURE]
+    image_infos = [parser.get_image_info(idx) for idx in range(len(ranges))]
+
+    assert [text[start:stop] for start, stop in ranges] == ["[Chart]", "[Chart]"]
+    assert [(info.label, info.src) for info in image_infos] == [
+        ("Chart", "images/list.png"),
+        ("Chart", "images/table.png"),
+    ]
+    with pytest.raises(IndexError):
+        parser.get_image_info(len(ranges))
+
+
+def test_html_document_resolves_local_embedded_image(tmp_path):
+    image_path = tmp_path / "images" / "diagram.png"
+    image_path.parent.mkdir()
+    image_path.write_bytes(make_png_bytes(size=(4, 5)))
+    html_path = tmp_path / "book.html"
+    html_path.write_text(
+        '<html><head><title>Book</title></head><body><img src="images/diagram.png" alt="Diagram"></body></html>',
+        encoding="utf-8",
+    )
+    document = FileSystemHtmlDocument(DocumentUri.from_filename(html_path))
+    document.read()
+
+    image_info = document.get_document_embedded_image_info(0)
+    image = document.get_document_embedded_image(0)
+
+    assert image_info.label == "Diagram"
+    assert image_info.suggested_filename == "diagram.png"
+    assert image.size == (4, 5)
+
+
+def test_html_document_resolves_local_embedded_image_against_base_href(tmp_path):
+    image_path = tmp_path / "images" / "diagram.png"
+    image_path.parent.mkdir()
+    image_path.write_bytes(make_png_bytes(size=(4, 5)))
+    html_path = tmp_path / "book.html"
+    html_path.write_text(
+        '<html><head><title>Book</title><base href="images/"></head><body><img src="diagram.png" alt="Diagram"></body></html>',
+        encoding="utf-8",
+    )
+    document = FileSystemHtmlDocument(DocumentUri.from_filename(html_path))
+    document.read()
+
+    assert document.get_document_embedded_image(0).size == (4, 5)
+
+
+def test_html_document_preserves_alpha_for_local_embedded_image(tmp_path):
+    image_path = tmp_path / "transparent.png"
+    image_path.write_bytes(make_transparent_png_bytes())
+    html_path = tmp_path / "book.html"
+    html_path.write_text(
+        '<html><head><title>Book</title></head><body><img src="transparent.png" alt="Transparent"></body></html>',
+        encoding="utf-8",
+    )
+    document = FileSystemHtmlDocument(DocumentUri.from_filename(html_path))
+    document.read()
+
+    image = document.get_document_embedded_image(0)
+
+    assert image.mode == "RGBA"
+    assert image.to_pil().getpixel((1, 0)) == (0, 255, 0, 0)
+
+
+def test_html_document_resolves_file_uri_embedded_image(tmp_path):
+    image_path = tmp_path / "diagram.png"
+    image_path.write_bytes(make_png_bytes(size=(4, 5)))
+    html_path = tmp_path / "book.html"
+    html_path.write_text(
+        f'<html><head><title>Book</title></head><body><img src="{image_path.as_uri()}" alt="Diagram"></body></html>',
+        encoding="utf-8",
+    )
+    document = FileSystemHtmlDocument(DocumentUri.from_filename(html_path))
+    document.read()
+
+    assert document.get_document_embedded_image(0).size == (4, 5)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="UNC file URI resolution is Windows-specific")
+def test_html_document_preserves_unc_host_in_file_uri():
+    document = FileSystemHtmlDocument.__new__(FileSystemHtmlDocument)
+
+    image_path = document._resolve_image_path("file://server/share/pic.png")
+
+    assert str(image_path) == r"\\server\share\pic.png"
+
+
+def test_html_document_resolves_drive_style_embedded_image(tmp_path):
+    image_path = tmp_path / "diagram.png"
+    if not image_path.drive:
+        pytest.skip("Drive-style image paths are only meaningful on Windows")
+    image_path.write_bytes(make_png_bytes(size=(4, 5)))
+    html_path = tmp_path / "book.html"
+    html_path.write_text(
+        f'<html><head><title>Book</title></head><body><img src="{image_path.as_posix()}" alt="Diagram"></body></html>',
+        encoding="utf-8",
+    )
+    document = FileSystemHtmlDocument(DocumentUri.from_filename(html_path))
+    document.read()
+
+    assert document.get_document_embedded_image(0).size == (4, 5)
+
+
+def test_html_document_rejects_protocol_relative_embedded_image(tmp_path):
+    html_path = tmp_path / "book.html"
+    html_path.write_text(
+        '<html><head><title>Book</title></head><body><img src="//cdn.example.com/diagram.png" alt="Diagram"></body></html>',
+        encoding="utf-8",
+    )
+    document = FileSystemHtmlDocument(DocumentUri.from_filename(html_path))
+    document.read()
+
+    with pytest.raises(DocumentIOError, match="Remote images"):
+        document.get_document_embedded_image(0)
+
+
+def test_epub_document_resolves_package_embedded_image(tmp_path):
+    document = make_epub_document(
+        tmp_path,
+        '<html><body><h1>Intro</h1><p><img src="../images/pic.png" alt="Picture"></p></body></html>',
+        make_epub_image_item("pic", "images/pic.png", size=(6, 7)),
+    )
+
+    image_info = document.get_document_embedded_image_info(0)
+    image = document.get_document_embedded_image(0)
+
+    assert image_info.label == "Picture"
+    assert image.size == (6, 7)
+
+
+def test_epub_document_resolves_domain_like_package_relative_image(tmp_path):
+    document = make_epub_document(
+        tmp_path,
+        '<html><body><h1>Intro</h1><p><img src="foo.com/pic.png" alt="Picture"></p></body></html>',
+        make_epub_image_item("pic", "foo.com/pic.png", size=(5, 6)),
+    )
+
+    assert document.get_document_embedded_image(0).size == (5, 6)
+
+
+def test_epub_document_strips_query_and_fragment_before_unquoting_image_href(
+    tmp_path,
+):
+    document = make_epub_document(
+        tmp_path,
+        '<html><body><h1>Intro</h1><p><img src="../images/foo%23bar.png?cache=1#figure" alt="Picture"></p></body></html>',
+        make_epub_image_item("pic", "images/foo#bar.png", size=(6, 7)),
+    )
+
+    assert document.get_document_embedded_image(0).size == (6, 7)
+
+
+def test_epub_document_rejects_protocol_relative_embedded_image(tmp_path):
+    document = make_epub_document(
+        tmp_path,
+        '<html><body><h1>Intro</h1><p><img src="//cdn.example.com/pic.png" alt="Remote"></p></body></html>',
+        make_epub_image_item("pic", "images/pic.png", size=(6, 7)),
+    )
+
+    with pytest.raises(DocumentIOError, match="Remote images"):
+        document.get_document_embedded_image(0)
+
+
+def test_epub_document_does_not_match_embedded_image_by_partial_suffix(tmp_path):
+    document = make_epub_document(
+        tmp_path,
+        '<html><body><h1>Intro</h1><p><img src="cover.png" alt="Cover"></p></body></html>',
+        make_epub_image_item("backcover", "images/backcover.png", size=(3, 4)),
+        make_epub_image_item("cover", "images/cover.png", size=(6, 7)),
+    )
+
+    assert document.get_document_embedded_image(0).size == (6, 7)
+
+
+def test_epub_document_does_not_choose_ambiguous_basename_fallback(tmp_path):
+    document = make_epub_document(
+        tmp_path,
+        '<html><body><h1>Intro</h1><p><img src="pic.png" alt="Picture"></p></body></html>',
+        make_epub_image_item("pic1", "images/pic.png", size=(3, 4)),
+        make_epub_image_item("pic2", "figures/pic.png", size=(6, 7)),
+    )
+
+    with pytest.raises(DocumentIOError):
+        document.get_document_embedded_image(0)
+
+
+def test_epub_document_wraps_undecodable_embedded_image(tmp_path):
+    document = make_epub_document(
+        tmp_path,
+        '<html><body><h1>Intro</h1><p><img src="../images/bad.svg" alt="Bad"></p></body></html>',
+        make_epub_image_item(
+            "bad",
+            "images/bad.svg",
+            media_type="image/svg+xml",
+            content=b"<svg></svg>",
+        ),
+    )
+
+    with pytest.raises(DocumentIOError):
+        document.get_document_embedded_image(0)
+
+
+def test_image_io_serializes_rgba_as_jpeg():
+    image = ImageIO.from_pil(Image.new("RGBA", (2, 2), (255, 0, 0, 128)))
+
+    jpeg_bytes = image.as_bytes(format="JPEG")
+
+    assert jpeg_bytes.startswith(b"\xff\xd8")
+
+
+def test_image_io_preserves_palette_colors_for_byte_loaded_images():
+    image = ImageIO.from_bytes(make_palette_png_bytes())
+
+    assert image.mode == "RGB"
+    assert [image.to_pil().getpixel((x, 0)) for x in range(2)] == [
+        (255, 0, 0),
+        (0, 255, 0),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("mode", "pixels", "expected_data", "expected_alpha"),
+    (
+        (
+            "RGBA",
+            [(255, 0, 0, 255), (0, 255, 0, 0)],
+            bytes([255, 0, 0, 0, 255, 0]),
+            bytes([255, 0]),
+        ),
+        (
+            "LA",
+            [(20, 255), (100, 0)],
+            bytes([20, 20, 20, 100, 100, 100]),
+            bytes([255, 0]),
+        ),
+    ),
+)
+def test_image_io_uses_wx_alpha_buffer_for_images_with_alpha(
+    monkeypatch,
+    mode,
+    pixels,
+    expected_data,
+    expected_alpha,
+):
+    captured = {}
+
+    class FakeWxImage:
+        def ConvertToBitmap(self):
+            return "bitmap"
+
+    def fake_image_from_buffer(width, height, data, alpha=None):
+        captured["width"] = width
+        captured["height"] = height
+        captured["data"] = bytes(data)
+        captured["alpha"] = bytes(alpha) if alpha is not None else None
+        return FakeWxImage()
+
+    monkeypatch.setattr(
+        "bookworm.image_io.wx.ImageFromBuffer",
+        fake_image_from_buffer,
+    )
+    pil_image = Image.new(mode, (2, 1))
+    pil_image.putdata(pixels)
+    image = ImageIO.from_pil(pil_image)
+
+    assert image.to_wx_bitmap() == "bitmap"
+    assert captured == {
+        "width": 2,
+        "height": 1,
+        "data": expected_data,
+        "alpha": expected_alpha,
+    }
+
+
+def test_embedded_image_dialog_normalizes_save_format_suffix():
+    output_path, image_format = EmbeddedImageDialog.get_save_target("cover.webp", 0)
+    assert output_path.name == "cover.png"
+    assert image_format == "PNG"
+
+    output_path, image_format = EmbeddedImageDialog.get_save_target("cover.png", 1)
+    assert output_path.name == "cover.jpg"
+    assert image_format == "JPEG"
+
+
+def test_embedded_image_dialog_confirms_normalized_target_overwrite(tmp_path):
+    existing_target = tmp_path / "cover.png"
+    existing_target.write_bytes(b"existing")
+    selected_path = tmp_path / "cover.webp"
+
+    output_path, image_format = EmbeddedImageDialog.get_save_target(selected_path, 0)
+
+    assert output_path == existing_target
+    assert image_format == "PNG"
+    assert EmbeddedImageDialog.should_confirm_overwrite_after_suffix_normalization(
+        selected_path,
+        output_path,
+    )
+    assert not EmbeddedImageDialog.should_confirm_overwrite_after_suffix_normalization(
+        existing_target,
+        existing_target,
+    )
+    assert not EmbeddedImageDialog.should_confirm_overwrite_after_suffix_normalization(
+        tmp_path / "new.webp",
+        tmp_path / "new.png",
+    )
+
+
+def test_embedded_image_dialog_converts_cmyk_images_for_png_save():
+    image = Image.new("CMYK", (2, 2))
+
+    prepared_image = EmbeddedImageDialog.prepare_image_for_save(image, "PNG")
+    png_bytes = BytesIO()
+    prepared_image.save(png_bytes, format="PNG")
+
+    assert prepared_image.mode == "RGB"
+    assert png_bytes.getvalue().startswith(b"\x89PNG")
+
+
+def test_structural_navigation_speech_does_not_repeat_generic_image_label():
+    message, prefix = _get_structural_navigation_speech(
+        "[Image]",
+        "Image",
+        SemanticElementType.FIGURE,
+    )
+
+    assert message == "Image"
+    assert prefix == ""
+
+
+def test_reader_ctrl_enter_opens_embedded_image(reader, view):
+    document = SyntheticImageDocument(
+        "[Cover]",
+        {SemanticElementType.FIGURE: [(0, 7)]},
+        image_infos=(
+            ImageElementInfo(TextRange(0, 7), "cover.png", "Cover", "cover.png"),
+        ),
+        images=(ImageIO.from_bytes(make_png_bytes(size=(8, 9))),),
+    )
+    document.read()
+    reader.set_document(document)
+
+    assert reader.handle_special_action_for_position(0) is True
+    image, title, suggested_filename = view.image_dialog_args
+    assert image.size == (8, 9)
+    assert title == "Cover - Image View"
+    assert suggested_filename == "cover.png"
+
+
+def test_reader_ctrl_enter_activates_link_when_embedded_image_fails(reader, view):
+    opened_urls = []
+    invalid_actions = []
+    view.go_to_webpage = opened_urls.append
+    view.notify_invalid_action = lambda: invalid_actions.append(True)
+    document = SyntheticImageDocument(
+        "[Cover]",
+        {
+            SemanticElementType.FIGURE: [(0, 7)],
+            SemanticElementType.LINK: [(0, 7)],
+        },
+        image_infos=(
+            ImageElementInfo(
+                TextRange(0, 7),
+                "https://example.com/cover.png",
+                "Cover",
+                "cover.png",
+            ),
+        ),
+        image_error=DocumentIOError("Remote images are not supported"),
+        link_target=LinkTarget(url="https://example.com", is_external=True),
+    )
+    document.read()
+    reader.set_document(document)
+
+    assert reader.handle_special_action_for_position(0) is True
+    assert opened_urls == ["https://example.com"]
+    assert invalid_actions == []
+    assert view.image_dialog_args is None
+
+
+def test_reader_ctrl_enter_uses_document_order_after_backward_image_navigation(
+    reader, view
+):
+    document = SyntheticImageDocument(
+        "[One]\n[Two]",
+        {SemanticElementType.FIGURE: [(0, 5), (6, 11)]},
+        image_infos=(
+            ImageElementInfo(TextRange(0, 5), "One.png", "One", "One.png"),
+            ImageElementInfo(TextRange(6, 11), "Two.png", "Two", "Two.png"),
+        ),
+        images=(
+            ImageIO.from_bytes(make_png_bytes(size=(1, 1))),
+            ImageIO.from_bytes(make_png_bytes(size=(2, 1))),
+        ),
+    )
+    document.read()
+    reader.set_document(document)
+
+    reader.get_semantic_element(SemanticElementType.FIGURE, forward=False, anchor=20)
+    assert reader.handle_special_action_for_position(6) is True
+    image, title, suggested_filename = view.image_dialog_args
+    assert image.size == (2, 1)
+    assert title == "Two - Image View"
+    assert suggested_filename == "Two.png"

--- a/tests/test_embedded_images.py
+++ b/tests/test_embedded_images.py
@@ -950,7 +950,7 @@ def test_embedded_image_dialog_confirms_normalized_target_overwrite(tmp_path):
 def test_embedded_image_dialog_converts_cmyk_images_for_png_save():
     image = Image.new("CMYK", (2, 2))
 
-    prepared_image = EmbeddedImageDialog.prepare_image_for_save(image, "PNG")
+    prepared_image = ImageIO.prepare_pil_for_save(image, "PNG")
     png_bytes = BytesIO()
     prepared_image.save(png_bytes, format="PNG")
 

--- a/tests/test_embedded_images.py
+++ b/tests/test_embedded_images.py
@@ -304,6 +304,34 @@ def test_html_legacy_content_hash_uses_pre_image_navigation_text(tmp_path):
         document.close()
 
 
+def test_html_legacy_content_hash_stays_pre_image_navigation_after_current_hash(
+    tmp_path,
+):
+    html_path = tmp_path / "book.html"
+    html_path.write_text(
+        """
+        <html>
+            <head><title>Book</title></head>
+            <body><p>alpha omega</p></body>
+        </html>
+        """,
+        encoding="utf-8",
+    )
+    document = FileSystemHtmlDocument(DocumentUri.from_filename(html_path))
+    document.read()
+
+    try:
+        legacy_text = document.get_legacy_content()
+        current_hash = document.get_content_hash()
+
+        assert document.get_legacy_content_hash() == document._hash_document_text(
+            legacy_text
+        )
+        assert document.get_legacy_content_hash() != current_hash
+    finally:
+        document.close()
+
+
 def test_structured_html_parser_ignores_symbol_only_image_alt_text():
     parser = StructuredHtmlParser.from_string(
         '<html><body><img src="images/pic.png" alt="{%}"></body></html>'

--- a/tests/test_embedded_images.py
+++ b/tests/test_embedded_images.py
@@ -842,6 +842,14 @@ def test_image_io_serializes_rgba_as_jpeg():
     assert jpeg_bytes.startswith(b"\xff\xd8")
 
 
+def test_image_io_serializes_cmyk_as_png():
+    image = ImageIO.from_pil(Image.new("CMYK", (2, 2)))
+
+    png_bytes = image.as_bytes(format="PNG")
+
+    assert png_bytes.startswith(b"\x89PNG")
+
+
 def test_image_io_preserves_palette_colors_for_byte_loaded_images():
     image = ImageIO.from_bytes(make_palette_png_bytes())
 

--- a/tests/test_embedded_images.py
+++ b/tests/test_embedded_images.py
@@ -114,6 +114,7 @@ class SyntheticImageDocument(SinglePageDocument):
         images=(),
         image_error=None,
         link_target=None,
+        table_markup=None,
     ):
         super().__init__(DocumentUri(self.format, "", {}))
         self.text = text
@@ -122,6 +123,7 @@ class SyntheticImageDocument(SinglePageDocument):
         self.images = images
         self.image_error = image_error
         self.link_target = link_target
+        self.table_markup = table_markup
 
     def read(self):
         super().read()
@@ -148,6 +150,8 @@ class SyntheticImageDocument(SinglePageDocument):
         return {}
 
     def get_document_table_markup(self, table_index):
+        if self.table_markup is not None:
+            return self.table_markup
         raise NotImplementedError
 
     def get_document_embedded_image_info(self, image_index):
@@ -1042,6 +1046,31 @@ def test_reader_ctrl_enter_activates_link_when_embedded_image_fails(reader, view
     assert reader.handle_special_action_for_position(0) is True
     assert opened_urls == ["https://example.com"]
     assert invalid_actions == []
+    assert view.image_dialog_args is None
+
+
+def test_reader_ctrl_enter_uses_table_action_when_embedded_image_fails(reader, view):
+    shown_tables = []
+    view.show_html_dialog = lambda markup, title: shown_tables.append((markup, title))
+    view.notify_invalid_action = lambda: pytest.fail("unexpected invalid action")
+    document = SyntheticImageDocument(
+        "[Chart]",
+        {
+            SemanticElementType.FIGURE: [(0, 7)],
+            SemanticElementType.TABLE: [(0, 7)],
+        },
+        image_infos=(
+            ImageElementInfo(TextRange(0, 7), "chart.png", "Chart", "chart.png"),
+        ),
+        image_error=DocumentIOError("Remote images are not supported"),
+        table_markup="<table><tr><td>Chart</td></tr></table>",
+    )
+    document.read()
+    reader.set_document(document)
+
+    assert reader.handle_special_action_for_position(0) is True
+    assert shown_tables
+    assert "table" in shown_tables[0][0].lower()
     assert view.image_dialog_args is None
 
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,8 +1,7 @@
-import pytest
 
 from bookworm.database.models import DocumentPositionInfo
 from bookworm.document.uri import DocumentUri
-from conftest import asset, reader, engine, view
+
 
 def test_restore_position_for_converted_document(reader, asset, engine):
     """
@@ -20,8 +19,9 @@ def test_restore_position_for_converted_document(reader, asset, engine):
     record = DocumentPositionInfo.query.one()
     assert record is not None
     assert record.last_page == test_page
-    assert record.last_position == test_pos
+    assert record.last_position == reader.view_to_storage_position(test_pos, test_page)
     assert record.uri == original_uri
+
 
 def test_restore_position_for_directly_supported_document(reader, asset, engine):
     """
@@ -39,8 +39,9 @@ def test_restore_position_for_directly_supported_document(reader, asset, engine)
     record = DocumentPositionInfo.query.one()
     assert record is not None
     assert record.last_page == test_page
-    assert record.last_position == test_pos
+    assert record.last_position == reader.view_to_storage_position(test_pos, test_page)
     assert record.uri == epub_uri
+
 
 def test_document_uri_is_corrected_after_conversion(reader, asset):
     """
@@ -53,6 +54,7 @@ def test_document_uri_is_corrected_after_conversion(reader, asset):
 
     assert reader.document.uri == original_uri
 
+
 def test_restore_position_for_mobi_document(reader, asset, engine):
     """
     Provides an additional test case for another convertible format (.mobi)
@@ -60,14 +62,14 @@ def test_restore_position_for_mobi_document(reader, asset, engine):
     """
     original_uri = DocumentUri.from_filename(asset("epub30-spec.mobi"))
     reader.load(original_uri)
-    
+
     test_page = 0
     test_pos = 100
     reader.go_to_page(test_page, test_pos)
     reader.save_current_position()
-    
+
     record = DocumentPositionInfo.query.one()
     assert record is not None
     assert record.last_page == test_page
-    assert record.last_position == test_pos
+    assert record.last_position == reader.view_to_storage_position(test_pos, test_page)
     assert record.uri == original_uri


### PR DESCRIPTION
## Link to issue number:

Closed #282 

### Summary of the issue:

Bookworm can open books that contain embedded images, but those images were not exposed as places a reader could move to or open directly. Adding image markers also had to avoid shifting existing saved positions, since bookmarks, notes, highlights, and recent locations may already point into documents that previously had image-free text.

### Description of how this pull request fixes the issue:

This threads embedded image metadata through the structured text pipeline and the reader. Image markers are now part of the display text, while `TextPositionMap` keeps display positions separate from the storage text used for hashes and saved locations. From the reader, moving to an image and pressing `Ctrl+Enter` opens the image viewer with zoom, copy, and save actions.

Existing bookmarks, notes, highlights, and recent positions are migrated from the older image-free text model onto the new storage positions. Document content hashes also include embedded image data when it is available, so Bookworm can distinguish documents whose visible text is the same but whose embedded images changed.

Supported formats for this feature:

- HTML: `.html`, `.htm`, `.xhtml`
- Markdown: `.md`
- EPUB: `.epub`
- MOBI-family Kindle files: `.mobi`, `.azw`, `.azw3`

PDF is not supported by this embedded-image navigation and viewer work yet. Bookworm can still open PDFs through its existing PDF reader path, but PDF embedded image navigation is outside this PR.

### Testing performed:

- `uv run --no-sync pytest` (`125 passed`)
- For a quick interactive check: open a supported book with embedded images, use structural navigation to move to an image, press `Ctrl+Enter`, then check zoom, copy, and save in the image viewer.
- Reopen a document with bookmarks, notes, highlights, or recent positions near images and confirm the saved locations still land in the expected text.

### Known issues with pull request:

PDF support is intentionally left for later.