### PR TITLE
Fix section-limited search in single-page documents

### DIFF
--- a/bookworm/gui/components.py
+++ b/bookworm/gui/components.py
@@ -172,19 +172,28 @@ class PageRangeControl(sc.SizedPanel):
         return from_page, to_page
 
     def get_text_range(self) -> Optional[TextRange]:
-        # #170: Search results were not showing for documents which had no TOC.
-        # if there is only 1 section we assume that it is the full document and return its text range
-        # This actually turns out to fix #195 as well which was most likely a regression from the change that fixed the search results for text documents
-        if len(self.doc) == 1:
-            return self.doc.toc_tree.text_range
         if selected_item := self.sectionChoice.GetSelection():
             section = self.sectionChoice.GetClientData(selected_item)
-            start_pos, stop_pos = section.text_range
-            if section.has_children:
-                stop_pos = section.last_child.text_range.stop
-            return TextRange(start_pos, stop_pos)
-        else:
+            return self._get_text_range_for_section(section)
+        return self.doc.toc_tree.text_range
+
+    def _get_text_range_for_section(self, section):
+        if section is self.doc.toc_tree or section.text_range is None:
             return self.doc.toc_tree.text_range
+        start_pos = section.text_range.start
+        stop_pos = self.doc.toc_tree.text_range.stop
+        descendants = {id(child) for child in section.iter_children()}
+        sections = tuple(self.doc.toc_tree.iter_children())
+        for _section_index, candidate in enumerate(sections):
+            if candidate is section:
+                break
+        else:
+            return TextRange(*section.text_range)
+        for next_section in sections[_section_index + 1 :]:
+            if id(next_section) not in descendants and next_section.text_range is not None:
+                stop_pos = next_section.text_range.start
+                break
+        return TextRange(start_pos, max(start_pos, stop_pos))
 
 
 class ImageViewControl(wx.Control):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,52 @@
+from types import SimpleNamespace
+
+from bookworm.document import SINGLE_PAGE_DOCUMENT_PAGER, Section
+from bookworm.gui.components import PageRangeControl
+from bookworm.structured_text import TextRange
+
+
+class SearchRangeHarness:
+    get_text_range = PageRangeControl.get_text_range
+    _get_text_range_for_section = PageRangeControl._get_text_range_for_section
+
+
+class FakeSectionChoice:
+    def __init__(self, section):
+        self.section = section
+
+    def GetSelection(self):  # noqa: N802
+        return object()
+
+    def GetClientData(self, _item):  # noqa: N802
+        return self.section
+
+
+def test_single_page_section_search_range_covers_selected_section_subtree():
+    root = Section(
+        title="Document",
+        pager=SINGLE_PAGE_DOCUMENT_PAGER,
+        text_range=TextRange(0, 100),
+    )
+    selected_section = Section(
+        title="Selected",
+        pager=SINGLE_PAGE_DOCUMENT_PAGER,
+        text_range=TextRange(10, 10),
+    )
+    child_section = Section(
+        title="Child",
+        pager=SINGLE_PAGE_DOCUMENT_PAGER,
+        text_range=TextRange(30, 30),
+    )
+    next_section = Section(
+        title="Next",
+        pager=SINGLE_PAGE_DOCUMENT_PAGER,
+        text_range=TextRange(70, 70),
+    )
+    root.append(selected_section)
+    selected_section.append(child_section)
+    root.append(next_section)
+    control = SearchRangeHarness()
+    control.doc = SimpleNamespace(toc_tree=root)
+    control.sectionChoice = FakeSectionChoice(selected_section)
+
+    assert control.get_text_range() == TextRange(10, 70)


### PR DESCRIPTION
## Link to issue number:

N/A

### Summary of the issue:

Searching within a specific section did not work correctly for single-page documents with a table of contents, such as EPUB/HTML-derived documents.

When a section was selected in the search dialog, Bookworm still searched the full document because `PageRangeControl.get_text_range()` returned the root document range whenever the document had only one page.

### Description of how this pull request fixes the issue:

This changes the section search range calculation so that, when a specific section is selected, Bookworm searches from that section's start position up to the next non-descendant section.

If no section-specific range can be determined, the existing fallback behavior is preserved.

### Testing performed:

- `uv run --no-sync pytest tests/test_search.py -q` -> 1 passed
- `uv run --no-sync pytest -q` -> 134 passed

### Known issues with pull request:

None known.