### PR TITLE
Fix search result navigation behavior

### DIFF
--- a/bookworm/document/operations.py
+++ b/bookworm/document/operations.py
@@ -12,6 +12,8 @@ from io import StringIO
 import attr
 import regex as re
 
+from bookworm.structured_text import TextRange
+
 NEWLINE = "\n"
 
 
@@ -39,6 +41,11 @@ class SearchResult:
     page: int
     position: int
     section: str
+    match_range: TextRange = None
+
+    def __attrs_post_init__(self):
+        if self.match_range is None:
+            self.match_range = TextRange(self.position, self.position)
 
 
 def search(pattern, text):
@@ -53,7 +60,7 @@ def search(pattern, text):
         if len(snip) > 3:
             snip.pop(0)
             snip.pop(-1)
-        yield (start, " ".join(snip))
+        yield (TextRange(start, end), " ".join(snip))
 
 
 def export_to_plain_text(doc, target_filename):
@@ -82,9 +89,15 @@ def search_book(doc, request):
         for n in range(request.from_page, request.to_page + 1):
             resultset = []
             sect = doc[n].section.title
-            for pos, snip in search(pattern, doc.get_page_content(n)):
+            for match_range, snip in search(pattern, doc.get_page_content(n)):
                 resultset.append(
-                    SearchResult(excerpt=snip, page=n, position=pos, section=sect)
+                    SearchResult(
+                        excerpt=snip,
+                        page=n,
+                        position=match_range.start,
+                        section=sect,
+                        match_range=match_range,
+                    )
                 )
             yield resultset
     finally:
@@ -93,11 +106,20 @@ def search_book(doc, request):
 
 def search_single_page_document(text, request):
     pattern = _make_search_re_pattern(request)
-    start_pos, stop_pos = request.text_range
-    for pos, snip in search(pattern, text):
-        actual_text_pos = start_pos + pos
+    start_pos = request.text_range.start
+    for match_range, snip in search(pattern, text):
+        actual_match_range = TextRange(
+            start_pos + match_range.start,
+            start_pos + match_range.stop,
+        )
         yield [
-            SearchResult(excerpt=snip, page=0, position=actual_text_pos, section=""),
+            SearchResult(
+                excerpt=snip,
+                page=0,
+                position=actual_match_range.start,
+                section="",
+                match_range=actual_match_range,
+            ),
         ]
 
 

--- a/bookworm/gui/book_viewer/core_dialogs.py
+++ b/bookworm/gui/book_viewer/core_dialogs.py
@@ -38,6 +38,7 @@ class SearchResultsDialog(Dialog):
     def __init__(self, highlight_func, num_pages, *args, **kwargs):
         self.highlight_func = highlight_func
         self.num_pages = num_pages
+        self._search_results = []
         self.list_lock = threading.RLock()
         super().__init__(*args, **kwargs)
 
@@ -94,16 +95,10 @@ class SearchResultsDialog(Dialog):
     def onItemClick(self, event):
         idx = self.searchResultsListCtrl.GetFocusedItem()
         if idx != wx.NOT_FOUND:
-            page = (
-                self.searchResultsListCtrl.GetItemText(idx)
-                if not self.reader.document.is_single_page_document()
-                else 1
-            )
-            pos = self.searchResultsListCtrl.GetItemData(idx)
+            result = self._search_results[idx]
             self.Close()
             self.Destroy()
-            self.highlight_func(int(page) - 1, pos)
-            self.parent._last_search_index = idx
+            self.highlight_func(result, idx)
 
     def addResultSet(self, resultset):
         for result in resultset:
@@ -121,6 +116,7 @@ class SearchResultsDialog(Dialog):
 
     def addResultToList(self, result):
         count = self.searchResultsListCtrl.ItemCount
+        self._search_results.append(result)
         page_display_text = (
             str(result.page + 1) if not self.is_single_page_document else ""
         )

--- a/bookworm/gui/book_viewer/menubar.py
+++ b/bookworm/gui/book_viewer/menubar.py
@@ -11,7 +11,6 @@ from functools import partial
 from operator import ge, le
 from pathlib import Path
 
-import more_itertools
 import wx
 from slugify import slugify
 
@@ -722,7 +721,7 @@ class SearchMenu(BaseMenu):
         # Translators: the initial title of the search results dialog
         # shown when the search process is not done yet
         dlg = SearchResultsDialog(
-            self.highlight_search_result,
+            self._highlight_search_result_from_dialog,
             num_pages,
             self.view,
             title=_("Searching For '{term}'").format(term=term),
@@ -751,29 +750,81 @@ class SearchMenu(BaseMenu):
             self._latest_search_results = tuple(results)
             self.maintain_state(True)
 
-    def go_to_search_result(self, foreword=True):
-        result = None
-        page, (sol, eol) = self.reader.current_page, self.view.get_containing_line(
-            self.view.get_insertion_point()
-        )
-        if foreword:
-            filter_func = lambda sr: (
-                ((sr.page == page) and (sr.position > eol)) or (sr.page > page)
-            )
-        else:
-            filter_func = lambda sr: (
-                ((sr.page == page) and (sr.position < sol)) or (sr.page < page)
-            )
-        result_iter = filter(filter_func, self._latest_search_results)
+    def _highlight_search_result_from_dialog(self, result, result_index):
+        self._last_search_index = result_index
+        self.highlight_search_result(result)
+
+    def _get_current_search_result_index(self):
+        result_index = self._last_search_index
+        if result_index is None:
+            return None
         try:
-            if foreword:
-                result = more_itertools.first(result_iter)
-            else:
-                result = more_itertools.last(result_iter)
-        except ValueError:
+            result = self._latest_search_results[result_index]
+        except IndexError:
+            return None
+        if result.page != self.reader.current_page:
+            return None
+        if result.position == self.view.get_insertion_point():
+            return result_index
+        with suppress(AttributeError):
+            selection_range = self.view.get_selection_range()
+            if (
+                selection_range.start != selection_range.stop
+                and selection_range == result.match_range
+            ):
+                return result_index
+        return None
+
+    def _get_search_result_candidate(self, foreword=True):
+        if not self._latest_search_results:
+            return None
+        current_result_index = self._get_current_search_result_index()
+        if current_result_index is not None:
+            index = current_result_index + (1 if foreword else -1)
+            if 0 <= index < len(self._latest_search_results):
+                return index, self._latest_search_results[index]
+            return None
+
+        page = self.reader.current_page
+        position = self.view.get_insertion_point()
+        index_range = (
+            range(len(self._latest_search_results))
+            if foreword
+            else range(len(self._latest_search_results) - 1, -1, -1)
+        )
+        for index in index_range:
+            result = self._latest_search_results[index]
+            if (
+                foreword
+                and (
+                    ((result.page == page) and (result.position > position))
+                    or (result.page > page)
+                )
+            ) or (
+                not foreword
+                and (
+                    ((result.page == page) and (result.position < position))
+                    or (result.page < page)
+                )
+            ):
+                return index, result
+        return None
+
+    def go_to_search_result(self, foreword=True):
+        result_candidate = self._get_search_result_candidate(foreword)
+        if result_candidate is None:
             sounds.navigation.play()
+            if foreword:
+                # Translators: spoken message when there is no next search result.
+                msg = _("No next search result for '{term}'")
+            else:
+                # Translators: spoken message when there is no previous search result.
+                msg = _("No previous search result for '{term}'")
+            speech.announce(msg.format(term=self._recent_search_term), True)
         else:
-            self.highlight_search_result(result.page, result.position)
+            result_index, result = result_candidate
+            self._last_search_index = result_index
+            self.highlight_search_result(result)
             reading_position_change.send(
                 self.view,
                 position=result.position,
@@ -788,7 +839,7 @@ class SearchMenu(BaseMenu):
 
     def _reset_search_history(self):
         self._latest_search_results = ()
-        self._last_search_index = 0
+        self._last_search_index = None
         self._recent_search_term = ""
         self._last_search_request = None
 
@@ -802,9 +853,17 @@ class SearchMenu(BaseMenu):
             self.Enable(item_id, enable)
 
     @gui_thread_safe
-    def highlight_search_result(self, page_number, pos):
+    def highlight_search_result(self, result_or_page, pos=None):
+        if pos is None:
+            page_number = result_or_page.page
+            start, end = result_or_page.match_range
+            line_position = result_or_page.position if start == end else None
+        else:
+            page_number = result_or_page
+            line_position = pos
         self.reader.go_to_page(page_number)
-        start, end = self.view.get_containing_line(pos)
+        if line_position is not None:
+            start, end = self.view.get_containing_line(line_position)
         self.view.select_text(start, end)
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,6 +1,16 @@
 from types import SimpleNamespace
 
+import pytest
+
 from bookworm.document import SINGLE_PAGE_DOCUMENT_PAGER, Section
+from bookworm.document.operations import (
+    SearchRequest,
+    SearchResult,
+    search_single_page_document,
+)
+from bookworm.gui.book_viewer import menubar as menubar_module
+from bookworm.gui.book_viewer.core_dialogs import SearchResultsDialog
+from bookworm.gui.book_viewer.menubar import SearchMenu
 from bookworm.gui.components import PageRangeControl
 from bookworm.structured_text import TextRange
 
@@ -8,6 +18,66 @@ from bookworm.structured_text import TextRange
 class SearchRangeHarness:
     get_text_range = PageRangeControl.get_text_range
     _get_text_range_for_section = PageRangeControl._get_text_range_for_section
+
+
+class SearchMenuHarness:
+    _get_current_search_result_index = SearchMenu._get_current_search_result_index
+    _highlight_search_result_from_dialog = (
+        SearchMenu._highlight_search_result_from_dialog
+    )
+    _get_search_result_candidate = SearchMenu._get_search_result_candidate
+    go_to_search_result = SearchMenu.go_to_search_result
+    highlight_search_result = SearchMenu.highlight_search_result.__wrapped__
+
+    def __init__(
+        self,
+        insertion_point,
+        results,
+        selection_range=None,
+        last_search_index=None,
+        line_ranges_by_page=None,
+    ):
+        self._latest_search_results = results
+        self._last_search_index = last_search_index
+        self._recent_search_term = "Android"
+        self.pages = []
+        self.selected = []
+        self.reader = SimpleNamespace(current_page=0)
+        self._line_ranges_by_page = line_ranges_by_page or {0: (0, 30)}
+
+        def go_to_page(page):
+            self.reader.current_page = page
+            self.pages.append(page)
+
+        self.reader.go_to_page = go_to_page
+        self.view = SimpleNamespace(
+            get_insertion_point=lambda: insertion_point,
+            get_containing_line=lambda _pos: self._line_ranges_by_page[
+                self.reader.current_page
+            ],
+            select_text=lambda start, end: self.selected.append((start, end)),
+        )
+        if selection_range is not None:
+            self.view.get_selection_range = lambda: selection_range
+
+
+class SearchResultsDialogHarness:
+    onItemClick = SearchResultsDialog.onItemClick
+
+    def __init__(self, focused_index, results, highlight_func):
+        self._search_results = results
+        self.highlight_func = highlight_func
+        self.closed = False
+        self.destroyed = False
+        self.searchResultsListCtrl = SimpleNamespace(
+            GetFocusedItem=lambda: focused_index,
+        )
+
+    def Close(self):  # noqa: N802
+        self.closed = True
+
+    def Destroy(self):  # noqa: N802
+        self.destroyed = True
 
 
 class FakeSectionChoice:
@@ -50,3 +120,180 @@ def test_single_page_section_search_range_covers_selected_section_subtree():
     control.sectionChoice = FakeSectionChoice(selected_section)
 
     assert control.get_text_range() == TextRange(10, 70)
+
+
+def make_search_result(position, page=0, match_length=6):
+    return SearchResult(
+        excerpt="",
+        page=page,
+        position=position,
+        section="",
+        match_range=TextRange(position, position + match_length),
+    )
+
+
+def test_single_page_search_result_records_absolute_match_range():
+    request = SearchRequest(
+        term=r"Andr\w+",
+        is_regex=True,
+        case_sensitive=False,
+        whole_word=False,
+        text_range=TextRange(10, 24),
+    )
+
+    result = next(search_single_page_document("xx Android yy", request))[0]
+
+    assert result.position == 13
+    assert result.match_range == TextRange(13, 20)
+
+
+def stub_search_navigation_feedback(monkeypatch):
+    calls = SimpleNamespace(reading_events=[], navigation_sound=[], speech=[])
+    monkeypatch.setattr(menubar_module, "_", lambda text: text, raising=False)
+    monkeypatch.setattr(
+        menubar_module.reading_position_change,
+        "send",
+        lambda *args, **kwargs: calls.reading_events.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        menubar_module.sounds,
+        "navigation",
+        SimpleNamespace(play=lambda: calls.navigation_sound.append(True)),
+    )
+    monkeypatch.setattr(
+        menubar_module.speech,
+        "announce",
+        lambda *args, **kwargs: calls.speech.append((args, kwargs)),
+    )
+    return calls
+
+
+@pytest.mark.parametrize(
+    ("foreword", "insertion_point", "expected_position"),
+    [
+        (True, 5, 8),
+        (False, 15, 8),
+    ],
+)
+def test_search_result_navigation_uses_cursor_position_for_same_line_results(
+    monkeypatch,
+    foreword,
+    insertion_point,
+    expected_position,
+):
+    feedback = stub_search_navigation_feedback(monkeypatch)
+    results = tuple(make_search_result(pos) for pos in (2, 8, 20))
+    menu = SearchMenuHarness(insertion_point, results)
+
+    menu.go_to_search_result(foreword=foreword)
+
+    assert menu.pages == [0]
+    assert menu.selected == [(expected_position, expected_position + 6)]
+    assert menu._last_search_index == 1
+    assert feedback.reading_events[0][1]["position"] == expected_position
+
+
+@pytest.mark.parametrize(
+    ("foreword", "expected_position", "expected_index"),
+    [
+        (True, 20, 2),
+        (False, 2, 0),
+    ],
+)
+def test_search_result_navigation_advances_from_selected_same_line_result(
+    monkeypatch,
+    foreword,
+    expected_position,
+    expected_index,
+):
+    feedback = stub_search_navigation_feedback(monkeypatch)
+    results = tuple(make_search_result(pos) for pos in (2, 8, 20))
+    menu = SearchMenuHarness(
+        insertion_point=30,
+        results=results,
+        selection_range=results[1].match_range,
+        last_search_index=1,
+    )
+
+    menu.go_to_search_result(foreword=foreword)
+
+    assert menu.pages == [0]
+    assert menu.selected == [(expected_position, expected_position + 6)]
+    assert menu._last_search_index == expected_index
+    assert feedback.reading_events[0][1]["position"] == expected_position
+
+
+@pytest.mark.parametrize(
+    ("foreword", "insertion_point", "last_search_index", "expected_last_index"),
+    [
+        (True, 30, 2, 2),
+        (False, 30, 0, 0),
+        (True, 25, None, None),
+        (False, 0, None, None),
+    ],
+)
+def test_search_result_navigation_stops_when_no_result_in_direction(
+    monkeypatch,
+    foreword,
+    insertion_point,
+    last_search_index,
+    expected_last_index,
+):
+    feedback = stub_search_navigation_feedback(monkeypatch)
+    results = tuple(make_search_result(pos) for pos in (2, 8, 20))
+    selection_range = (
+        results[last_search_index].match_range
+        if last_search_index is not None
+        else None
+    )
+    menu = SearchMenuHarness(
+        insertion_point=insertion_point,
+        results=results,
+        selection_range=selection_range,
+        last_search_index=last_search_index,
+    )
+
+    menu.go_to_search_result(foreword=foreword)
+
+    assert menu.pages == []
+    assert menu.selected == []
+    assert menu._last_search_index == expected_last_index
+    assert feedback.reading_events == []
+    assert feedback.navigation_sound == [True]
+    expected_speech = (
+        "No next search result for 'Android'"
+        if foreword
+        else "No previous search result for 'Android'"
+    )
+    assert feedback.speech == [((expected_speech, True), {})]
+
+
+def test_search_results_dialog_selection_updates_menu_search_index():
+    results = tuple(make_search_result(pos) for pos in (2, 8, 20))
+    menu = SearchMenuHarness(insertion_point=30, results=results)
+    dialog = SearchResultsDialogHarness(
+        focused_index=1,
+        results=results,
+        highlight_func=menu._highlight_search_result_from_dialog,
+    )
+
+    dialog.onItemClick(None)
+
+    assert menu._last_search_index == 1
+    assert menu.selected == [(8, 14)]
+    assert dialog.closed
+    assert dialog.destroyed
+
+
+def test_zero_width_search_result_fallback_line_uses_target_page():
+    result = make_search_result(position=5, page=1, match_length=0)
+    menu = SearchMenuHarness(
+        insertion_point=0,
+        results=(result,),
+        line_ranges_by_page={0: (0, 10), 1: (40, 60)},
+    )
+
+    menu.highlight_search_result(result)
+
+    assert menu.pages == [1]
+    assert menu.selected == [(40, 60)]


### PR DESCRIPTION
## Link to issue number:

N/A

### Summary of the issue:

Find Next and Find Previous did not consistently move between individual search matches, especially when multiple results appeared on the same line. When no result existed in the requested direction, the cursor could still move without a clear user-facing message.

### Description of how this pull request fixes the issue:

This updates search result navigation so F3 and Shift+F3 move to the next or previous actual search match and select the matched text.

If there is no next or previous result, Bookworm now keeps the cursor and selection unchanged, plays the existing navigation feedback sound, and announces a short localizable message.

The search results dialog also updates the current search result state, so Find Next/Previous continues from the result selected in the dialog.

### Testing performed:

Manual testing performed for:
- F3 / Shift+F3 across multiple matches on the same line.
- F3 / Shift+F3 after selecting a result from the search results dialog.
- No next / previous result behavior, including cursor not moving and feedback being announced.
- Regex search results, including zero-width match fallback behavior.

Also ran:
- `uv run --no-sync pytest tests\test_search.py -q`
- `uv run --no-sync pytest -q`

### Known issues with pull request:

None known.