### PR TITLE
Support remote images in web documents

### DIFF
--- a/bookworm/document/formats/html.py
+++ b/bookworm/document/formats/html.py
@@ -43,6 +43,8 @@ from .. import DocumentCapability as DC
 log = logger.getChild(__name__)
 # Default cache timeout
 EXPIRE_TIMEOUT = 7 * 24 * 60 * 60
+REMOTE_IMAGES_UNSUPPORTED_ERROR = "Remote images are not supported"
+REMOTE_IMAGE_LOAD_ERROR = "Failed to load remote embedded image"
 
 
 def get_clean_html(html_string: str) -> (str, BookMetadata):
@@ -288,11 +290,14 @@ class BaseHtmlDocument(SinglePageDocument):
             except Exception as e:
                 raise DocumentIOError("Failed to decode embedded image") from e
         if not self._is_local_image_source(image_info.src):
-            raise DocumentIOError("Remote images are not supported")
+            return self._get_remote_embedded_image(image_info.src)
         image_path = self._resolve_image_path(image_info.src)
         if image := ImageIO.from_filename(image_path, preserve_mode=True):
             return image
         raise DocumentIOError(f"Failed to load embedded image: {image_path}")
+
+    def _get_remote_embedded_image(self, _src: str) -> ImageIO:
+        raise DocumentIOError(REMOTE_IMAGES_UNSUPPORTED_ERROR)
 
     def _get_embedded_image_content_hash_identity(self, image_info):
         src = image_info.src
@@ -334,7 +339,7 @@ class BaseHtmlDocument(SinglePageDocument):
         if self._image_base_url:
             resolved_src = urllib_parse.urljoin(self._image_base_url, src)
             if not self._is_local_image_source(resolved_src):
-                raise DocumentIOError("Remote images are not supported")
+                raise DocumentIOError(REMOTE_IMAGES_UNSUPPORTED_ERROR)
             return self._local_image_source_to_path(resolved_src)
         base_path = getattr(self, "filename", None) or self.get_file_system_path()
         return Path(base_path).parent / image_path
@@ -422,3 +427,12 @@ class WebHtmlDocument(BaseHtmlDocument):
 
     def parse_html(self):
         return self.parse_to_clean_text()
+
+    def _get_remote_embedded_image(self, src: str) -> ImageIO:
+        try:
+            image = ImageIO.from_bytes(HttpResource(src).download().get_bytes())
+        except Exception as e:
+            raise DocumentIOError(REMOTE_IMAGE_LOAD_ERROR) from e
+        if image:
+            return image
+        raise DocumentIOError(REMOTE_IMAGE_LOAD_ERROR)

--- a/tests/test_embedded_images.py
+++ b/tests/test_embedded_images.py
@@ -18,8 +18,9 @@ from bookworm.document import (
     Section,
     SinglePageDocument,
 )
+from bookworm.document.formats import html as html_format
 from bookworm.document.formats.epub import EpubDocument
-from bookworm.document.formats.html import FileSystemHtmlDocument
+from bookworm.document.formats.html import FileSystemHtmlDocument, WebHtmlDocument
 from bookworm.document.formats.odf import OdfPresentation
 from bookworm.document.uri import DocumentUri
 from bookworm.gui.book_viewer import _get_structural_navigation_speech
@@ -91,6 +92,19 @@ def make_epub_document(tmp_path, chapter_content, *items):
     epub.write_epub(epub_path, book, {})
     document = EpubDocument(DocumentUri.from_filename(epub_path))
     document.read()
+    return document
+
+
+def make_web_html_document(html):
+    document = WebHtmlDocument(
+        DocumentUri(
+            format="webpage",
+            path="https://example.com/page",
+            openner_args={},
+        )
+    )
+    document.html_string = html
+    document.parse_to_full_text()
     return document
 
 
@@ -630,6 +644,31 @@ def test_html_document_rejects_protocol_relative_embedded_image(tmp_path):
 
     with pytest.raises(DocumentIOError, match="Remote images"):
         document.get_document_embedded_image(0)
+
+
+def test_web_html_document_opens_remote_embedded_image(monkeypatch):
+    image_url = "https://cdn.example.com/diagram.png"
+    downloaded_urls = []
+
+    class FakeHttpResource:
+        def __init__(self, url):
+            downloaded_urls.append(url)
+
+        def download(self):
+            return SimpleNamespace(get_bytes=lambda: make_png_bytes(size=(4, 5)))
+
+    monkeypatch.setattr(html_format, "HttpResource", FakeHttpResource)
+    document = make_web_html_document(
+        f'<html><head><title>Web</title></head><body>'
+        f'<img src="{image_url}" alt="Diagram"></body></html>'
+    )
+
+    image_info = document.get_document_embedded_image_info(0)
+    image = document.get_document_embedded_image(0)
+
+    assert image_info.src == image_url
+    assert downloaded_urls == [image_url]
+    assert image.size == (4, 5)
 
 
 def test_epub_document_resolves_package_embedded_image(tmp_path):


### PR DESCRIPTION
## Link to issue number:

N/A

### Summary of the issue:

Web documents can expose remote embedded images, but opening those images currently fails with "Remote images are not supported".

### Description of how this pull request fixes the issue:

This adds a `BaseHtmlDocument` hook that preserves the existing default rejection for non-web formats, and lets `WebHtmlDocument` download and decode remote image bytes via `HttpResource`. The test uses a generic `WebHtmlDocument` fixture and mocks `HttpResource`, so the change is independent from the Wikipedia parsing/navigation work.

### Testing performed:

- `uv run --no-sync pytest tests/test_embedded_images.py -k "html_document or web_html_document"`
- `uv run --no-sync ruff check --select F,I bookworm/document/formats/html.py tests/test_embedded_images.py`
- `git diff --check`
- `uv run --no-sync pytest`

### Known issues with pull request:

None.
