### PR TITLE
Improve Wikipedia article parsing and navigation

### DIFF
--- a/bookworm/document/formats/html.py
+++ b/bookworm/document/formats/html.py
@@ -1,4 +1,3 @@
-
 from __future__ import annotations
 
 from concurrent.futures import ProcessPoolExecutor
@@ -10,10 +9,12 @@ from urllib.request import url2pathname
 
 from lxml import etree
 from lxml import html as lxml_html
+from mediawiki import MediaWiki
 from more_itertools import first as get_first_element
 from more_itertools import zip_offset
 from yarl import URL
 
+from bookworm import app
 from bookworm.http_tools import HttpResource
 from bookworm.image_io import ImageIO
 from bookworm.logger import logger
@@ -45,6 +46,9 @@ log = logger.getChild(__name__)
 EXPIRE_TIMEOUT = 7 * 24 * 60 * 60
 REMOTE_IMAGES_UNSUPPORTED_ERROR = "Remote images are not supported"
 REMOTE_IMAGE_LOAD_ERROR = "Failed to load remote embedded image"
+WIKIPEDIA_ARTICLE_SOURCE_MARKER = 'name="bookworm-source" content="wikipedia-article"'
+WIKIPEDIA_HOST_SUFFIX = ".wikipedia.org"
+WIKIPEDIA_MOBILE_HOST_SUFFIX = ".m.wikipedia.org"
 
 
 def get_clean_html(html_string: str) -> (str, BookMetadata):
@@ -404,6 +408,8 @@ class WebHtmlDocument(BaseHtmlDocument):
         if (html_string := getattr(self, "html_string", None)) is not None:
             return html_string
         url = self.uri.path
+        if html_string := self._get_wikipedia_article_html(url):
+            return html_string
         try:
             req = HttpResource(url).download()
         except ConnectionError as e:
@@ -426,6 +432,8 @@ class WebHtmlDocument(BaseHtmlDocument):
         return lxml_html.tostring(html_tree, encoding="unicode")
 
     def parse_html(self):
+        if self._is_wikipedia_article_html(self.html_string):
+            return self.parse_to_full_text()
         return self.parse_to_clean_text()
 
     def _get_remote_embedded_image(self, src: str) -> ImageIO:
@@ -436,3 +444,96 @@ class WebHtmlDocument(BaseHtmlDocument):
         if image:
             return image
         raise DocumentIOError(REMOTE_IMAGE_LOAD_ERROR)
+
+    @classmethod
+    def _get_wikipedia_article_html(cls, url):
+        article_info = cls._get_wikipedia_article_info(url)
+        if article_info is None:
+            return None
+        language, title = article_info
+        try:
+            page = MediaWiki(lang=language, user_agent=app.user_agent()).page(
+                title=title,
+                auto_suggest=False,
+                preload=False,
+            )
+            article_html = page.html
+        except Exception:
+            log.warning(
+                f"Failed to retrieve Wikipedia article HTML for url: {url}",
+                exc_info=True,
+            )
+            return None
+        return cls._build_wikipedia_article_html(page.title, article_html, page.url)
+
+    @classmethod
+    def _get_wikipedia_article_info(cls, url):
+        try:
+            parsed_url = URL(url)
+        except ValueError:
+            return None
+        language = cls._get_wikipedia_language(parsed_url)
+        path = parsed_url.raw_path
+        if not language or parsed_url.query_string or not path.startswith("/wiki/"):
+            return None
+        title = urllib_parse.unquote(path.removeprefix("/wiki/")).strip()
+        return (language, title) if title else None
+
+    @staticmethod
+    def _get_wikipedia_language(parsed_url):
+        if parsed_url.scheme not in {"http", "https"}:
+            return ""
+        host = parsed_url.host or ""
+        if host.endswith(WIKIPEDIA_MOBILE_HOST_SUFFIX):
+            language = host.removesuffix(WIKIPEDIA_MOBILE_HOST_SUFFIX)
+        elif host.endswith(WIKIPEDIA_HOST_SUFFIX):
+            language = host.removesuffix(WIKIPEDIA_HOST_SUFFIX)
+        else:
+            return ""
+        return "" if not language or "." in language or language == "www" else language
+
+    @staticmethod
+    def _normalize_wikipedia_fragment(fragment):
+        return urllib_parse.quote(urllib_parse.unquote(fragment), safe="")
+
+    @classmethod
+    def _build_wikipedia_article_html(cls, title, article_html, page_url):
+        escaped_title = escape_html(title)
+        html_tree = lxml_html.fromstring(
+            f"<html><head><meta {WIKIPEDIA_ARTICLE_SOURCE_MARKER}>"
+            f"<title>{escaped_title} - Wikipedia</title></head>"
+            f"<body><h1>{escaped_title}</h1>{article_html}</body></html>"
+        )
+        html_tree.make_links_absolute(
+            base_url=page_url,
+            resolve_base_href=True,
+            handle_failures="discard",
+        )
+        current_url = URL(page_url)
+        for element in html_tree.xpath("//*[@id or @name]"):
+            for attr in ("id", "name"):
+                if anchor := element.get(attr):
+                    element.set(
+                        attr,
+                        cls._normalize_wikipedia_fragment(anchor),
+                    )
+        for maybe_internal_anchor in html_tree.xpath("//a[@href]"):
+            href = maybe_internal_anchor.get("href")
+            try:
+                target_url = URL(href)
+            except Exception:
+                continue
+            if (
+                target_url.host == current_url.host
+                and target_url.path == current_url.path
+                and target_url.fragment
+            ):
+                maybe_internal_anchor.set(
+                    "href",
+                    f"#{cls._normalize_wikipedia_fragment(target_url.fragment)}",
+                )
+        return lxml_html.tostring(html_tree, encoding="unicode")
+
+    @staticmethod
+    def _is_wikipedia_article_html(html_string):
+        return WIKIPEDIA_ARTICLE_SOURCE_MARKER in html_string

--- a/bookworm/structured_text/structured_html_parser.py
+++ b/bookworm/structured_text/structured_html_parser.py
@@ -1,4 +1,3 @@
-
 from __future__ import annotations
 
 import re
@@ -296,7 +295,7 @@ class StructuredHtmlParser(Inscriptis):
             start_index,
             end_index,
         )
-        for image_info, annotation in zip(table_image_infos, image_annotations):
+        for image_info, annotation in zip(table_image_infos, image_annotations, strict=False):
             text_range = self._get_placeholder_range_from_annotation(
                 text,
                 annotation,
@@ -433,6 +432,15 @@ class StructuredHtmlParser(Inscriptis):
         annotations = {}
         for anot in self.get_annotations():
             if anot.metadata == IMAGE_ANNOTATION:
+                continue
+            if (
+                anot.metadata == SemanticElementType.LINK
+                and (
+                    anot.start,
+                    anot.end,
+                )
+                not in self.link_range_to_target
+            ):
                 continue
             annotations.setdefault(anot.metadata, []).append((anot.start, anot.end))
         if self._image_elements:

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -104,3 +104,43 @@ def test_named_anchor_without_href_is_not_a_semantic_link():
     ]
 
     assert link_texts == ["jump"]
+
+
+def test_table_links_without_reliable_targets_are_not_semantic_links():
+    parser = StructuredHtmlParser.from_string(
+        """
+        <html><body>
+            <table>
+                <tr>
+                    <td><a href="https://example.com/table">table link</a></td>
+                </tr>
+            </table>
+        </body></html>
+        """
+    )
+
+    assert parser.link_targets == {}
+    assert SemanticElementType.LINK not in parser.semantic_elements
+    assert len(parser.semantic_elements[SemanticElementType.TABLE]) == 1
+
+
+def test_table_links_do_not_misalign_with_non_rendered_links():
+    parser = StructuredHtmlParser.from_string(
+        """
+        <html><body>
+            <table>
+                <tr>
+                    <td>
+                        <a href="https://example.com/hidden">
+                            <span style="display:none">hidden</span>
+                        </a>
+                        <a href="https://example.com/visible">visible link</a>
+                    </td>
+                </tr>
+            </table>
+        </body></html>
+        """
+    )
+
+    assert parser.link_targets == {}
+    assert SemanticElementType.LINK not in parser.semantic_elements

--- a/tests/test_wikipedia.py
+++ b/tests/test_wikipedia.py
@@ -1,0 +1,122 @@
+from types import SimpleNamespace
+
+import pytest
+
+from bookworm import app
+from bookworm.document import LinkTarget
+from bookworm.document.formats import html as html_format
+from bookworm.document.formats.html import WebHtmlDocument
+from bookworm.document.uri import DocumentUri
+from bookworm.structured_text import SemanticElementType
+
+
+def make_wikipedia_document(html):
+    document = WebHtmlDocument(
+        DocumentUri(
+            format="webpage",
+            path="https://en.wikipedia.org/wiki/Sample",
+            openner_args={},
+        )
+    )
+    document.html_string = html
+    document.parse_html()
+    return document
+
+
+def test_wikipedia_article_html_preserves_links_anchors_and_tables():
+    html = WebHtmlDocument._build_wikipedia_article_html(
+        "Sample",
+        """
+        <p>
+            <a href="/wiki/Linked_article">article link</a>
+            <a href="#Details">details link</a>
+            <a href="/wiki/Sample#%E6%AD%B7%E5%8F%B2">history link</a>
+        </p>
+        <h2 id="Details">Details</h2>
+        <h2 id="&#x6b77;&#x53f2;">&#x6b77;&#x53f2;</h2>
+        <table>
+            <tr><th>Language</th></tr>
+            <tr><td>Python</td></tr>
+            <tr><td><a href="/wiki/Table_link">table link</a></td></tr>
+        </table>
+        """,
+        "https://en.wikipedia.org/wiki/Sample",
+    )
+    document = make_wikipedia_document(html)
+    text = document.get_content()
+    semantic_structure = document.get_document_semantic_structure()
+
+    link_targets = {
+        text[start:stop]: document.resolve_link((start, stop))
+        for start, stop in semantic_structure[SemanticElementType.LINK]
+    }
+
+    assert link_targets["article link"] == LinkTarget(
+        url="https://en.wikipedia.org/wiki/Linked_article",
+        is_external=True,
+    )
+    assert link_targets["details link"].is_external is False
+    start, stop = link_targets["details link"].position
+    assert text[start:stop].strip() == "Details"
+    assert link_targets["history link"].is_external is False
+    start, stop = link_targets["history link"].position
+    assert text[start:stop].strip() == "\u6b77\u53f2"
+    assert len(semantic_structure[SemanticElementType.TABLE]) == 1
+    table_markup = document.get_document_table_markup(0)
+    assert "<th>Language</th>" in table_markup
+    assert "<td>Python</td>" in table_markup
+    assert "<td>table link</td>" in table_markup
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://en.wikipedia.org/wiki/Sample", ("en", "Sample")),
+        ("https://en.m.wikipedia.org/wiki/Sample", ("en", "Sample")),
+        (
+            "https://zh-min-nan.wikipedia.org/wiki/Sample%20title",
+            ("zh-min-nan", "Sample title"),
+        ),
+        ("https://en.wikipedia.org/wiki/Foo%2520Bar", ("en", "Foo%20Bar")),
+        ("https://en.wikipedia.org/wiki/Sample?oldformat=true", None),
+        ("https://foo.en.wikipedia.org/wiki/Sample", None),
+        ("https://www.wikipedia.org/wiki/Sample", None),
+        ("ftp://en.wikipedia.org/wiki/Sample", None),
+    ],
+)
+def test_wikipedia_article_info_accepts_article_urls_only(url, expected):
+    assert WebHtmlDocument._get_wikipedia_article_info(url) == expected
+
+
+def test_wikipedia_article_lookup_uses_app_user_agent_and_does_not_preload(monkeypatch):
+    page_calls = []
+
+    class FakeMediaWiki:
+        def __init__(self, lang, user_agent):
+            self.lang = lang
+            self.user_agent = user_agent
+
+        def page(self, **kwargs):
+            page_calls.append((self.lang, self.user_agent, kwargs))
+            return SimpleNamespace(
+                title="Sample",
+                html="<p>Article</p>",
+                url="https://en.wikipedia.org/wiki/Sample",
+            )
+
+    monkeypatch.setattr(html_format, "MediaWiki", FakeMediaWiki)
+
+    html = WebHtmlDocument._get_wikipedia_article_html("https://en.wikipedia.org/wiki/Sample")
+
+    assert page_calls == [
+        (
+            "en",
+            app.user_agent(),
+            {
+                "title": "Sample",
+                "auto_suggest": False,
+                "preload": False,
+            },
+        )
+    ]
+    assert "Article" in html


### PR DESCRIPTION
## Link to issue number:

N/A

### Summary of the issue:

Wikipedia articles opened from a URL were parsed like generic web pages. That could lose useful article structure, weaken table support, and make same-article section links less reliable.

There was also a link safety issue in HTML tables: Bookworm could expose a visible link annotation even when it did not have a reliably matched target URL.

### Description of how this pull request fixes the issue:

Detect Wikipedia article URLs, including mobile Wikipedia URLs, and fetch the article HTML through the MediaWiki API using Bookworm's user agent. Wikipedia articles are then parsed in full-text mode so headings, tables, links, and anchors are preserved more closely to the source article.

This also normalizes Wikipedia anchors and same-article fragments so section links resolve inside the current article, while links to other articles remain external links. URL title parsing now avoids double-decoding percent-escaped article titles.

For table links, unresolved link annotations are no longer exposed as activatable links. This avoids opening the wrong URL when the parser cannot safely match a visible link range to its target.

### Testing performed:

- Manual smoke test with `uv run invoke run`: opened a Wikipedia article from a URL and checked that the app loaded the article successfully with Wikipedia/Wikimedia resources being requested.
- `uv run --no-sync pytest tests/test_navigation.py tests/test_wikipedia.py`
- `uv run --no-sync ruff check --select F,I bookworm/document/formats/html.py bookworm/structured_text/structured_html_parser.py tests/test_navigation.py tests/test_wikipedia.py`
- `git diff --check`
- `uv run --no-sync pytest`

### Known issues with pull request:

Some table links without reliable target mapping may no longer be activatable. This is intentional for now to avoid opening the wrong URL.
