### PR TITLE
Fix RichEdit position mapping for non-BMP text

### DIFF
--- a/bookworm/annotation/__init__.py
+++ b/bookworm/annotation/__init__.py
@@ -1,4 +1,3 @@
-
 import wx
 
 from bookworm import config, speech
@@ -238,11 +237,7 @@ class AnnotationService(BookwormService):
         if not self.reader.ready:
             return
         # Convert the real position from the event to a clean position.
-        clean_position = (
-            self.view.control_to_view_position(event.Position)
-            if hasattr(self.view, "control_to_view_position")
-            else event.Position - 1
-        )
+        clean_position = self.view.control_to_view_position(event.Position)
         if clean_position < 0:
             return
         evtdata = {}
@@ -396,16 +391,8 @@ class AnnotationService(BookwormService):
         # We need a new TextAttr object to avoid modifying a shared default style.
         new_attr = wx.TextAttr()
         # We must get the existing style from the REAL position to preserve other attributes.
-        real_start = (
-            view.view_to_control_position(start)
-            if hasattr(view, "view_to_control_position")
-            else start + 1
-        )
-        real_end = (
-            view.view_to_control_position(end)
-            if hasattr(view, "view_to_control_position")
-            else end + 1
-        )
+        real_start = view.view_to_control_position(start)
+        real_end = view.view_to_control_position(end)
         view.contentTextCtrl.GetStyle(real_start, new_attr)
         new_attr.SetFontUnderlined(enable)
         # We must apply the new style to the REAL, offset positions.

--- a/bookworm/gui/book_viewer/__init__.py
+++ b/bookworm/gui/book_viewer/__init__.py
@@ -1,4 +1,3 @@
-
 import math
 import time
 import webbrowser
@@ -45,6 +44,7 @@ from bookworm.utils import gui_thread_safe
 from . import recents_manager
 from .menubar import BookRelatedMenuIds, MenubarProvider
 from .navigation import NavigationProvider
+from .position_mapping import TextCtrlPositionMap
 from .render_view import EmbeddedImageDialog
 from .state import StateProvider
 
@@ -68,8 +68,6 @@ STYLE_TO_WX_TEXT_ATTR_STYLES = {
     Style.DISPLAY_3: (wx.TextAttr.SetFontWeight, (400,)),
     Style.DISPLAY_4: (wx.TextAttr.SetFontWeight, (200,)),
 }
-
-TEXT_CTRL_OFFSET = 1
 
 
 def _get_structural_navigation_speech(text, element_label, element_type):
@@ -295,6 +293,7 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
         self._has_text_zoom = False
         self.__latest_structured_navigation_position = None
         self.__skip_next_image_earcon_position = None
+        self._text_position_map = TextCtrlPositionMap("")
         self.set_status(self._no_open_book_status)
         StateProvider.__init__(self)
         MenubarProvider.__init__(self)
@@ -507,6 +506,7 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
         self.reader.set_document(document)
 
     def set_content(self, content):
+        self._text_position_map = TextCtrlPositionMap(content)
         self.contentTextCtrl.Freeze()
         if self._has_text_zoom:
             current_style = wx.TextAttr(self.contentTextCtrl.GetDefaultStyle())
@@ -514,12 +514,10 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
             current_font_size = current_style.Font.GetPointSize()
         else:
             current_font_size = None
-        self.contentTextCtrl.SetValue("\n\n")
-        self.contentTextCtrl.SetInsertionPoint(1)
-        self.contentTextCtrl.SetDefaultStyle(
-            self.get_content_view_text_style(font_size=current_font_size)
-        )
-        self.contentTextCtrl.WriteText(content)
+        content_style = self.get_content_view_text_style(font_size=current_font_size)
+        self.contentTextCtrl.SetValue(self._text_position_map.to_text_ctrl_value())
+        self.contentTextCtrl.SetStyle(0, self.contentTextCtrl.GetLastPosition(), content_style)
+        self.contentTextCtrl.SetDefaultStyle(content_style)
         self.set_insertion_point(0)
         self.contentTextCtrl.Thaw()
 
@@ -613,17 +611,14 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
             self.update_reading_progress()
 
     def _process_image_earcon_for_position(self, position):
-        skip_position = getattr(
-            self, "_BookViewerWindow__skip_next_image_earcon_position", None
-        )
+        skip_position = getattr(self, "_BookViewerWindow__skip_next_image_earcon_position", None)
         if skip_position is not None:
             self.__skip_next_image_earcon_position = None
             if skip_position == (self.reader.current_page, position):
                 return
-        if (
-            config.conf["reading"]["play_image_earcon_when_navigating_text"]
-            and self._is_position_in_or_on_line_with_image(position)
-        ):
+        if config.conf["reading"][
+            "play_image_earcon_when_navigating_text"
+        ] and self._is_position_in_or_on_line_with_image(position):
             sounds.image.play()
 
     def _is_position_in_or_on_line_with_image(self, position):
@@ -806,14 +801,18 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
     def highlight_range(self, start, end, foreground=wx.NullColour, background=wx.NullColour):
         line_start = self.get_containing_line(start)[0]
         attr = wx.TextAttr()
-        self.contentTextCtrl.GetStyle(line_start + TEXT_CTRL_OFFSET, attr)
+        self.contentTextCtrl.GetStyle(self.view_to_control_position(line_start), attr)
         attr.SetBackgroundColour(wx.YELLOW)
-        self.contentTextCtrl.SetStyle(start + TEXT_CTRL_OFFSET, end + TEXT_CTRL_OFFSET, attr)
+        self.contentTextCtrl.SetStyle(
+            self.view_to_control_position(start),
+            self.view_to_control_position(end),
+            attr,
+        )
 
     def clear_highlight(self, start=0, end=-1):
         textCtrl = self.contentTextCtrl
-        actual_start = start + TEXT_CTRL_OFFSET
-        actual_end = end if end < 0 else end + TEXT_CTRL_OFFSET
+        actual_start = self.view_to_control_position(start)
+        actual_end = end if end < 0 else self.view_to_control_position(end)
         if end < 0 or end >= self.get_last_position():
             actual_end = textCtrl.GetLastPosition()
         attr = wx.TextAttr()
@@ -834,9 +833,7 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
             # Translators: the label of the page content text area
             label_msg = _("Page {page} of {total}")
             label_msg = f"{label_msg} " + chr(0x00B7) + " {chapter}"
-            if config.conf["general"]["include_page_label"] and (
-                page_label := page.get_label()
-            ):
+            if config.conf["general"]["include_page_label"] and (page_label := page.get_label()):
                 page_number = f"{page_number} ({page_label})"
         return label_msg.format(
             page=page_number,
@@ -853,7 +850,10 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
         # If nothing is selected, start can be -1. Handle this gracefully.
         if start == -1:
             return TextRange(self.get_insertion_point(), self.get_insertion_point())
-        return TextRange(start - TEXT_CTRL_OFFSET, end - TEXT_CTRL_OFFSET)
+        return TextRange(
+            self.control_to_view_position(start),
+            self.control_to_view_position(end),
+        )
 
     def get_containing_line(self, pos):
         """
@@ -864,9 +864,12 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
         # 1. Convert clean input position to a real position for the control.
         # 2. Get the real line boundaries from the control.
         # 3. Convert the real boundaries back to clean boundaries for the caller.
-        real_pos = pos + TEXT_CTRL_OFFSET
+        real_pos = self.view_to_control_position(pos)
         real_start, real_end = self.contentTextCtrl.GetContainingLine(real_pos)
-        return real_start - TEXT_CTRL_OFFSET, real_end - TEXT_CTRL_OFFSET
+        return (
+            self.control_to_view_position(real_start),
+            self.control_to_view_position(real_end),
+        )
 
     def set_text_direction(self, rtl=False):
         style = self.contentTextCtrl.GetDefaultStyle()
@@ -892,23 +895,26 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
             dlg.ShowModal()
 
     def get_line_number(self, pos=None):
-        # WHY: Use our own gatekeeper if pos is not provided.
-        # Convert the clean position to a real one before querying the control.
-        pos = pos or self.get_insertion_point()
-        __, __, line_number = self.contentTextCtrl.PositionToXY(pos + TEXT_CTRL_OFFSET)
+        if pos is None:
+            pos = self.get_insertion_point()
+        control_pos = self.view_to_control_position(pos)
+        __, __, line_number = self.contentTextCtrl.PositionToXY(control_pos)
         return line_number
 
     def get_start_of_line(self, line_number):
         # WHY: Get the real position from the control, then convert to clean.
         real_pos = self.contentTextCtrl.XYToPosition(0, line_number)
-        return max(0, real_pos - TEXT_CTRL_OFFSET)
+        return max(0, self.control_to_view_position(real_pos))
 
     def select_text(self, fpos, tpos):
         self.contentTextCtrl.SetFocusFromKbd()
-        self.contentTextCtrl.SetSelection(fpos + TEXT_CTRL_OFFSET, tpos + TEXT_CTRL_OFFSET)
+        self.contentTextCtrl.SetSelection(
+            self.view_to_control_position(fpos),
+            self.view_to_control_position(tpos),
+        )
 
     def set_insertion_point(self, to, set_focus_to_text_ctrl=True):
-        actual_position = to + TEXT_CTRL_OFFSET
+        actual_position = self.view_to_control_position(to)
         self.contentTextCtrl.ShowPosition(actual_position)
         self.contentTextCtrl.SetInsertionPoint(actual_position)
         if set_focus_to_text_ctrl:
@@ -925,34 +931,26 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
             attr_func(style, *args)
             for start, stop in style_info[style_type]:
                 self.contentTextCtrl.SetStyle(
-                    start + TEXT_CTRL_OFFSET, stop + TEXT_CTRL_OFFSET, style
+                    self.view_to_control_position(start),
+                    self.view_to_control_position(stop),
+                    style,
                 )
 
     def get_insertion_point(self):
-        return self.contentTextCtrl.GetInsertionPoint() - TEXT_CTRL_OFFSET
+        return self.control_to_view_position(self.contentTextCtrl.GetInsertionPoint())
 
-    @staticmethod
-    def control_to_view_position(pos):
-        return pos - TEXT_CTRL_OFFSET
+    def control_to_view_position(self, pos):
+        return self._text_position_map.control_to_view_position(pos)
 
-    @staticmethod
-    def view_to_control_position(pos):
-        return pos + TEXT_CTRL_OFFSET
+    def view_to_control_position(self, pos):
+        return self._text_position_map.view_to_control_position(pos)
 
     def get_last_position(self):
-        # WHY: The structure is `\n[content]\n`. The real length is `len(content) + 2`.
-        # The clean length is `len(content)`. So we must subtract 2.
-        # We don't use the offset constant here because we are accounting for
-        # the character at the beginning AND the one at the end.
-        return self.contentTextCtrl.GetLastPosition() - 2
+        return self._text_position_map.last_position
 
     def get_text_by_range(self, start, end):
         """Get text by indexes. If end is less than 0 return the text from `start` to the end of the text."""
-        actual_start = start + TEXT_CTRL_OFFSET
-        actual_end = end if end < 0 else end + TEXT_CTRL_OFFSET
-        if end >= self.get_last_position():
-            actual_end = self.contentTextCtrl.GetLastPosition() - TEXT_CTRL_OFFSET
-        return self.contentTextCtrl.GetRange(actual_start, actual_end)
+        return self._text_position_map.get_text_by_range(start, end)
 
     def get_text_from_user(self, title, label, style=wx.OK | wx.CANCEL | wx.CENTER, value=""):
         dlg = wx.TextEntryDialog(self, label, title, style=style, value=value)

--- a/bookworm/gui/book_viewer/position_mapping.py
+++ b/bookworm/gui/book_viewer/position_mapping.py
@@ -1,0 +1,65 @@
+"""Position mapping between Bookworm text offsets and wx text control offsets."""
+
+from __future__ import annotations
+
+import re
+from bisect import bisect_left
+from dataclasses import dataclass, field
+
+TEXT_CTRL_LEADING_OFFSET = 1
+RE_NON_BMP_CHAR = re.compile(r"[\U00010000-\U0010ffff]")
+
+
+@dataclass(frozen=True, slots=True)
+class TextCtrlPositionMap:
+    """Maps Bookworm text offsets to wx/RichEdit native offsets.
+
+    Bookworm indexes Python strings by code point. RichEdit caret and styling APIs
+    count non-BMP characters as two UTF-16 code units and the displayed control
+    value also contains a leading sentinel newline. The sentinel line maps to
+    clean position -1; document text positions start at 0.
+    """
+
+    text: str
+    non_bmp_positions: tuple[int, ...] = field(init=False, repr=False)
+    non_bmp_native_positions: tuple[int, ...] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        non_bmp_positions = tuple(match.start() for match in RE_NON_BMP_CHAR.finditer(self.text))
+        object.__setattr__(self, "non_bmp_positions", non_bmp_positions)
+        object.__setattr__(
+            self,
+            "non_bmp_native_positions",
+            tuple(position + offset for offset, position in enumerate(non_bmp_positions)),
+        )
+
+    @property
+    def last_position(self) -> int:
+        return len(self.text)
+
+    def to_text_ctrl_value(self) -> str:
+        # RichEdit counts non-BMP chars as two native positions and otherwise truncates
+        # the same number of trailing code points from text assigned through wx.
+        padding = "\n" * len(self.non_bmp_positions)
+        prefix = "\n" * TEXT_CTRL_LEADING_OFFSET
+        return f"{prefix}{self.text}\n{padding}"
+
+    def view_to_control_position(self, pos: int) -> int:
+        if pos < 0:
+            return 0
+        clean_pos = max(0, min(pos, len(self.text)))
+        extra_native_units = bisect_left(self.non_bmp_positions, clean_pos)
+        return clean_pos + extra_native_units + TEXT_CTRL_LEADING_OFFSET
+
+    def control_to_view_position(self, pos: int) -> int:
+        if pos < TEXT_CTRL_LEADING_OFFSET:
+            return pos - TEXT_CTRL_LEADING_OFFSET
+        native_pos = pos - TEXT_CTRL_LEADING_OFFSET
+        clean_pos = native_pos - bisect_left(self.non_bmp_native_positions, native_pos)
+        return max(0, min(clean_pos, len(self.text)))
+
+    def get_text_by_range(self, start: int, end: int) -> str:
+        start = max(0, start)
+        if end < 0:
+            return self.text[start:]
+        return self.text[start : min(end, len(self.text))]

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -4,12 +4,93 @@ import pytest
 
 from bookworm.gui import book_viewer
 from bookworm.gui.book_viewer import BookViewerWindow
+from bookworm.gui.book_viewer.position_mapping import TextCtrlPositionMap
 from bookworm.structured_text import SemanticElementType
 from bookworm.structured_text.structured_html_parser import StructuredHtmlParser
 
 
 class StructuralNavigationHarness:
     navigate_to_structural_element = BookViewerWindow.navigate_to_structural_element
+
+
+class PositionMappingHarness:
+    control_to_view_position = BookViewerWindow.control_to_view_position
+    view_to_control_position = BookViewerWindow.view_to_control_position
+    get_insertion_point = BookViewerWindow.get_insertion_point
+    get_containing_line = BookViewerWindow.get_containing_line
+    get_line_number = BookViewerWindow.get_line_number
+
+
+class SetContentHarness(PositionMappingHarness):
+    set_content = BookViewerWindow.set_content
+    set_insertion_point = BookViewerWindow.set_insertion_point
+
+    def __init__(self, content_style):
+        self._has_text_zoom = False
+        self.content_style = content_style
+        self.contentTextCtrl = StyleRecordingTextCtrl()
+
+    def get_content_view_text_style(self, font_size=None):
+        assert font_size is None
+        return self.content_style
+
+
+class StyleRecordingTextCtrl:
+    def __init__(self):
+        self.calls = []
+        self.value = ""
+
+    def Freeze(self):
+        self.calls.append(("Freeze",))
+
+    def Thaw(self):
+        self.calls.append(("Thaw",))
+
+    def SetDefaultStyle(self, style):
+        self.calls.append(("SetDefaultStyle", style))
+
+    def SetValue(self, value):
+        self.value = value
+        self.calls.append(("SetValue", value))
+
+    def GetLastPosition(self):
+        return len(self.value)
+
+    def SetStyle(self, start, stop, style):
+        self.calls.append(("SetStyle", start, stop, style))
+
+    def ShowPosition(self, pos):
+        self.calls.append(("ShowPosition", pos))
+
+    def SetInsertionPoint(self, pos):
+        self.calls.append(("SetInsertionPoint", pos))
+
+    def SetFocusFromKbd(self):
+        self.calls.append(("SetFocusFromKbd",))
+
+
+class LineNumberTextCtrl:
+    def __init__(self, insertion_point=0):
+        self.insertion_point = insertion_point
+        self.position_queries = []
+
+    def GetInsertionPoint(self):
+        return self.insertion_point
+
+    def PositionToXY(self, pos):
+        self.position_queries.append(pos)
+        return 0, 0, pos
+
+
+class ContainingLineTextCtrl:
+    def __init__(self, line_start, line_end):
+        self.line_start = line_start
+        self.line_end = line_end
+        self.position_queries = []
+
+    def GetContainingLine(self, pos):
+        self.position_queries.append(pos)
+        return self.line_start, self.line_end
 
 
 def line_bounds(text, pos):
@@ -23,6 +104,70 @@ def line_bounds(text, pos):
 
 def noop(*_args, **_kwargs):
     pass
+
+
+def test_position_mapping_handles_non_bmp_rich_edit_offsets():
+    text = "\U0001d445a\U0001d446\U0001d447bc"
+    position_map = TextCtrlPositionMap(text)
+
+    assert position_map.control_to_view_position(0) == -1
+    assert position_map.view_to_control_position(-1) == 0
+
+    expected_control_positions = [1, 3, 4, 6, 8, 9, 10]
+    assert [
+        position_map.view_to_control_position(position) for position in range(len(text) + 1)
+    ] == expected_control_positions
+
+    for view_position, control_position in enumerate(expected_control_positions):
+        assert position_map.control_to_view_position(control_position) == view_position
+
+    trailing_sentinel_position = position_map.view_to_control_position(len(text)) + 1
+    assert position_map.control_to_view_position(trailing_sentinel_position) == len(text)
+    assert position_map.to_text_ctrl_value() == f"\n{text}\n\n\n\n"
+
+
+def test_line_lookup_maps_non_bmp_text_positions_to_native_control_positions():
+    text = "exercise with \U0001d445\U0001d446\U0001d447 before heading\nHeading\nbody"
+    heading_start = text.index("Heading")
+    non_bmp_before_heading = 3
+    control_heading_start = 1 + heading_start + non_bmp_before_heading
+    viewer = PositionMappingHarness()
+    viewer._text_position_map = TextCtrlPositionMap(text)
+    viewer.contentTextCtrl = ContainingLineTextCtrl(
+        control_heading_start,
+        control_heading_start + len("Heading"),
+    )
+
+    assert viewer.get_containing_line(heading_start) == (
+        heading_start,
+        heading_start + len("Heading"),
+    )
+    assert viewer.contentTextCtrl.position_queries == [control_heading_start]
+
+
+def test_get_line_number_uses_raw_caret_when_position_is_omitted():
+    viewer = PositionMappingHarness()
+    viewer._text_position_map = TextCtrlPositionMap("first line")
+    viewer.contentTextCtrl = LineNumberTextCtrl(insertion_point=0)
+
+    assert viewer.get_line_number() == 0
+    assert viewer.contentTextCtrl.position_queries == [0]
+
+
+def test_set_content_reapplies_text_style_after_setting_control_value():
+    text = "intro \U0001d445\U0001d446"
+    content_style = object()
+    viewer = SetContentHarness(content_style)
+
+    viewer.set_content(text)
+
+    text_ctrl_value = TextCtrlPositionMap(text).to_text_ctrl_value()
+    assert viewer.contentTextCtrl.value == text_ctrl_value
+    assert viewer.contentTextCtrl.calls[1:4] == [
+        ("SetValue", text_ctrl_value),
+        ("SetStyle", 0, len(text_ctrl_value), content_style),
+        ("SetDefaultStyle", content_style),
+    ]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Link to issue number:

N/A

### Summary of the issue:

Bookworm's viewer stores and works with document text positions as Python string offsets, but the Windows RichEdit-backed content control reports caret, selection, line, and styling positions as native control offsets.

The previous viewer code mostly handled the extra leading sentinel newline with a fixed `+1/-1` offset. That is not sufficient when the page contains non-BMP characters, such as mathematical Unicode letters or emoji, because RichEdit counts those characters as two UTF-16 code units while Python string indexing counts them as one code point.

This could shift positions after the first non-BMP character and affect operations that depend on accurate offsets, including structured navigation, line lookup, selection, highlighting, annotation styling, and caret-based checks.

### Description of how this pull request fixes the issue:

This PR adds a dedicated `TextCtrlPositionMap` for converting between Bookworm view positions and native text control positions.

The mapper handles:

- the leading sentinel newline used by the viewer;
- non-BMP characters counting as extra native RichEdit positions;
- mapping the sentinel control position back to clean position `-1`;
- mapping trailing sentinel/padding positions back to the document text end;
- returning text slices from the original Python text instead of relying on text-control range extraction.

`BookViewerWindow` now owns a position map for the currently loaded page and routes position-sensitive operations through it, including insertion point conversion, selection ranges, line boundary lookup, line-number lookup, highlighting, text styling, text range reads, and last-position reporting.

Page loading was also adjusted to use the mapped text-control value. For RichEdit, this includes padding newlines for non-BMP characters to avoid trailing content being dropped when text is assigned through `SetValue()`. Since `SetValue()` does not preserve the desired style for already-loaded text, the viewer reapplies the computed content style across the loaded control range and then restores the default style for later operations.

Annotation visual styling and caret handling now use the viewer's conversion methods directly. The old fallback paths that manually applied `event.Position - 1` or `start + 1` / `end + 1` were removed.

### Testing performed:

Manual testing checklist:

- [ ] Open an EPUB page containing non-BMP characters, such as mathematical Unicode letters.
- [ ] Use structural navigation around headings after those characters and confirm the caret lands on the expected heading/line.
- [ ] Move the caret with text wrapping disabled and confirm normal Up/Down navigation remains responsive.
- [ ] Move to the top of a page and press Up twice; confirm previous-page navigation still works.
- [ ] Navigate onto a line containing an embedded image and confirm the image earcon plays only when expected.
- [ ] Add or view bookmarks/highlights/comments on text after non-BMP characters and confirm annotation indicators/styles align with the correct text.
- [ ] Change font size/zoom or appearance settings, then change pages; confirm loaded page text keeps the configured style.
- [ ] Open a normal EPUB page without non-BMP characters and confirm ordinary reading/navigation behavior is unchanged.

### Known issues with pull request:
