### PR TITLE
Clean up low-risk service, bookshelf, and utility code

### DIFF
--- a/bookworm/bookshelf/local_bookshelf/database.py
+++ b/bookworm/bookshelf/local_bookshelf/database.py
@@ -4,7 +4,7 @@ import typing
 
 from peewee import *
 from peewee import ColumnBase, EnclosedNodeList, NodeList
-from playhouse.apsw_ext import APSWDatabase, BooleanField, DateTimeField
+from playhouse.apsw_ext import APSWDatabase, DateTimeField as DateTimeField
 
 from bookworm.document.uri import DocumentUri
 from bookworm.image_io import ImageIO
@@ -99,8 +99,6 @@ class SqliteViewSchemaManager(SchemaManager):
     def _create_table(self, safe=True, **options):
         if not getattr(self.model, "view_select_builder", None):
             raise TypeError("view_select_builder method is required on view tables.")
-        meta = self.model._meta
-        columns = {field.column_name for field in meta.sorted_fields}
         is_temp = options.pop("temporary", False)
         ctx = self._create_context()
         ctx.literal("CREATE TEMPORARY VIEW " if is_temp else "CREATE VIEW ")

--- a/bookworm/bookshelf/local_bookshelf/dialogs.py
+++ b/bookworm/bookshelf/local_bookshelf/dialogs.py
@@ -16,13 +16,10 @@ from bookworm.gui.components import (
     SimpleDialog,
     make_sized_static_box,
 )
-from bookworm.logger import logger
 from bookworm.reader import EBookReader
 from bookworm.resources import sounds
 
-from .models import Category, Document, DocumentTag, Page, Tag
-
-log = logger.getChild(__name__)
+from .models import Category, Page
 
 
 class EditDocumentClassificationDialog(SimpleDialog):
@@ -66,7 +63,7 @@ class EditDocumentClassificationDialog(SimpleDialog):
             self.categoryCombo.SetStringSelection(self.given_category)
 
     def ShowModal(self):
-        if (retval := super().ShowModal()) == wx.ID_OK:
+        if super().ShowModal() == wx.ID_OK:
             return (
                 self.categoryCombo.GetValue().strip(),
                 tuple(tg.strip() for tg in self.tagsTextCtrl.GetValue().split(" ")),
@@ -99,7 +96,7 @@ class AddFolderToLocalBookshelfDialog(SimpleDialog):
         self.addToFTSCheckbox.SetValue(True)
 
     def ShowModal(self):
-        if (retval := super().ShowModal()) == wx.ID_OK:
+        if super().ShowModal() == wx.ID_OK:
             selected_folder = self.folderCtrl.GetValue()
             if os.path.isdir(selected_folder):
                 return (
@@ -128,7 +125,7 @@ class SearchBookshelfDialog(SimpleDialog):
         self.shouldSearchInContent.SetValue(True)
 
     def ShowModal(self):
-        if (retval := super().ShowModal()) == wx.ID_OK:
+        if super().ShowModal() == wx.ID_OK:
             search_query = self.searchQueryTextCtrl.GetValue()
             if not search_query.strip():
                 return

--- a/bookworm/bookshelf/provider.py
+++ b/bookworm/bookshelf/provider.py
@@ -10,11 +10,8 @@ import attr
 from bookworm import typehints as t
 from bookworm.document import DocumentInfo
 from bookworm.image_io import ImageIO
-from bookworm.logger import logger
 from bookworm.paths import images_path
 from bookworm.signals import _signals
-
-log = logger.getChild(__name__)
 
 
 sources_updated = _signals.signal("bookshelf/source_updated")
@@ -120,7 +117,7 @@ class MetaSource(Source):
     """Represents a source that merely groups other sources."""
 
     def get_item_count(self):
-        return len([item for item in self.get_items() if item.is_valid()])
+        return sum(1 for item in self.get_items() if item.is_valid())
 
     def get_item_actions(self, item):
         raise NotImplementedError

--- a/bookworm/bookshelf/viewer_integration.py
+++ b/bookworm/bookshelf/viewer_integration.py
@@ -8,14 +8,13 @@ import wx
 from bookworm.commandline_handler import run_subcommand_in_a_new_process
 from bookworm.concurrency import call_threaded, threaded_worker
 from bookworm.document import DocumentIOError
-from bookworm.gui.settings import ReconciliationStrategies, SettingsPanel
+from bookworm.gui.settings import SettingsPanel
 from bookworm.logger import logger
 from bookworm.signals import reader_book_loaded
 
 from .local_bookshelf.dialogs import EditDocumentClassificationDialog
 from .local_bookshelf.models import Document
 from .local_bookshelf.tasks import issue_add_document_request
-from .window import BookshelfWindow
 
 log = logger.getChild(__name__)
 
@@ -123,5 +122,5 @@ class BookshelfMenu(wx.Menu):
         wx.CallAfter(
             self.Enable,
             StatefulBookshelfMenuIds.add_current_book_to_shelf,
-            not Document.select().where(Document.uri == sender.document.uri).count(),
+            not Document.select().where(Document.uri == sender.document.uri).exists(),
         )

--- a/bookworm/concurrency/__init__.py
+++ b/bookworm/concurrency/__init__.py
@@ -6,9 +6,7 @@ import inspect
 import multiprocessing as mp
 import os
 import sys
-import threading
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
-from contextlib import suppress
+from concurrent.futures import Future, ProcessPoolExecutor, ThreadPoolExecutor
 from enum import IntEnum
 from functools import partial, wraps
 from traceback import format_exception
@@ -17,7 +15,7 @@ import attr
 
 import bookworm.typehints as t
 from bookworm.logger import logger
-from bookworm.signals import app_shuttingdown, app_starting
+from bookworm.signals import app_shuttingdown
 
 log = logger.getChild(__name__)
 
@@ -37,7 +35,7 @@ def _shutdown_concurrent_workers(sender):
     process_worker.shutdown(wait=False)
 
 
-def call_threaded(func: t.Callable[..., None]) -> t.Callable[..., "Future"]:
+def call_threaded(func: t.Callable[..., None]) -> t.Callable[..., Future]:
     """Call `func` in a separate thread. It wraps the function
     in another function that returns a `concurrent.futures.Future`
     object when called.
@@ -158,7 +156,7 @@ class QueueProcess(mp.Process):
                     gen.close()
         except StopIteration:
             self.channel.done()
-        except Exception as e:
+        except Exception:
             self.channel.exception(*sys.exc_info())
 
     def close(self):

--- a/bookworm/concurrency/asyncio_utils.py
+++ b/bookworm/concurrency/asyncio_utils.py
@@ -6,9 +6,8 @@ import asyncio
 import threading
 from functools import wraps
 
-import bookworm.typehints as t
 from bookworm.logger import logger
-from bookworm.signals import app_shuttingdown, app_starting
+from bookworm.signals import app_shuttingdown
 
 log = logger.getChild(__name__)
 
@@ -36,7 +35,6 @@ def start_asyncio_event_loop():
         return
 
     def _thread_target():
-        global ASYNCIO_EVENT_LOOP
         log.info("Starting asyncio event loop")
         asyncio.set_event_loop(ASYNCIO_EVENT_LOOP)
         ASYNCIO_EVENT_LOOP.run_forever()

--- a/bookworm/config/__init__.py
+++ b/bookworm/config/__init__.py
@@ -47,7 +47,7 @@ class ConfigProvider:
         validated = self.config.validate(
             self.validator, copy=True, preserve_errors=True
         )
-        if validated == True:
+        if validated is True:
             self.config.write()
         else:
             log.error("Failed to validate config.")
@@ -66,6 +66,5 @@ def setup_config():
 
 
 def save():
-    global conf
     if conf is not None:
         conf.config.write()

--- a/bookworm/config/spec.py
+++ b/bookworm/config/spec.py
@@ -3,7 +3,7 @@
 from io import StringIO
 
 config_spec = StringIO(
-    f"""
+    """
 [general]
     language = string(default="default")
     announce_ui_messages = boolean(default=True)

--- a/bookworm/database/__init__.py
+++ b/bookworm/database/__init__.py
@@ -5,7 +5,6 @@ Persistent storage using SQLlite3
 """
 import os
 from pathlib import Path
-import sqlite3
 import sys
 
 from alembic import command

--- a/bookworm/i18n/core.py
+++ b/bookworm/i18n/core.py
@@ -3,13 +3,10 @@
 import gettext
 import locale as pylocale
 import os
-from collections import OrderedDict
-from contextlib import suppress
 from pathlib import Path
 
 from bookworm import app, config, paths
 from bookworm.logger import logger
-from bookworm.signals import app_started
 from bookworm.user import get_user_locale
 from bookworm.user import set_app_locale as _set_app_locale
 
@@ -54,7 +51,7 @@ def get_available_locales(force_update=False):
 
 def set_locale(locale_identifier):
     log.debug(f"Setting application locale to {locale_identifier}.")
-    available_locales = tuple(get_available_locales().values())
+    get_available_locales()
     if locale_identifier in _AVAILABLE_LOCALES:
         localeinfo = _AVAILABLE_LOCALES[locale_identifier]
     else:
@@ -70,10 +67,10 @@ def set_locale(locale_identifier):
         os.environ["LANG"] = localeinfo.pylang
         _set_app_locale(localeinfo)
         app.current_language = localeinfo
-    except Exception as e:
+    except Exception:
         if lang != "en":
             log.error(
-                f"An error was occured while initializing i18n system.", exc_info=True
+                "An error was occured while initializing i18n system.", exc_info=True
             )
         os.environ["LANG"] = "en"
         _set_app_locale(LocaleInfo("en"))

--- a/bookworm/i18n/localeinfo.py
+++ b/bookworm/i18n/localeinfo.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-import locale
-
 import babel.numbers
-from babel import Locale, UnknownLocaleError, default_locale, parse_locale
+from babel import Locale, UnknownLocaleError
 from babel.dates import format_date as babel_format_date
 from babel.dates import format_datetime as babel_format_datetime
 from languagecodes import iso_639_alpha2

--- a/bookworm/i18n/wx_i18n.py
+++ b/bookworm/i18n/wx_i18n.py
@@ -3,10 +3,8 @@
 import wx
 from more_itertools import first_true
 
-from bookworm import app, paths
+from bookworm import paths
 from bookworm.logger import logger
-
-from .localeinfo import LocaleInfo
 
 log = logger.getChild(__name__)
 

--- a/bookworm/logger.py
+++ b/bookworm/logger.py
@@ -5,7 +5,6 @@ from logging.handlers import RotatingFileHandler
 import sys
 
 from bookworm import app, paths
-from bookworm.runtime import IS_IN_MAIN_PROCESS
 
 APP_LOG_FILE = app.name
 ERROR_LOG_FILE = "error"

--- a/bookworm/otau.py
+++ b/bookworm/otau.py
@@ -61,7 +61,7 @@ class UpdateInfo(RootModel[t.Dict[UpdateChannel, VersionInfo]]):
 
     @property
     def channels(self) -> Tuple[UpdateChannel]:
-        return tuple(self.root.keys())
+        return tuple(self.root)
 
     def get_update_info_for_channel(self, channel_identifier: str) -> VersionInfo:
         if channel_identifier is None:

--- a/bookworm/paths.py
+++ b/bookworm/paths.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 
 import logging
-import platform
 from functools import wraps
 from pathlib import Path
 

--- a/bookworm/service/base.py
+++ b/bookworm/service/base.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import wx
 
 from bookworm import typehints as t
-from bookworm.logger import logger
 
-log = logger.getChild(__name__)
+if TYPE_CHECKING:
+    from bookworm.gui.book_viewer import BookViewerWindow
+    from bookworm.gui.settings import SettingsPanel
 
 
 class BookwormService:
@@ -18,7 +21,7 @@ class BookwormService:
     has_gui: bool = False
     config_spec: t.Dict[str, str] = None
 
-    def __init__(self, view: "BookViewer"):
+    def __init__(self, view: BookViewerWindow):
         self.view = view
         self.reader = view.reader
         self.__post_init__()
@@ -43,7 +46,7 @@ class BookwormService:
 
     def get_settings_panels(
         self,
-    ) -> t.Iterable[t.Tuple[int, str, "bookworm.gui.settings.SettingPanel", str]]:
+    ) -> t.Iterable[t.Tuple[int, str, type[SettingsPanel], str]]:
         """Return a list of SettingsPanelBlueprint."""
         return ()
 

--- a/bookworm/service/handler.py
+++ b/bookworm/service/handler.py
@@ -38,10 +38,9 @@ BUILTIN_SERVICES = (
 class ServiceHandler:
     """A singleton to manage services."""
 
-    registered_services = []
-
     def __init__(self, view):
         self.view = view
+        self.registered_services = []
         app_shuttingdown.connect(self.on_shutdown, weak=False)
 
     def register_builtin_services(self):

--- a/bookworm/typehints.py
+++ b/bookworm/typehints.py
@@ -2,8 +2,7 @@
 
 """Type hints used by other modules."""
 
-from io import FileIO
-from os import PathLike
+from os import PathLike as PathLike
 from typing import *
 
 TranslatableStr = NewType("TranslatableStr", str)

--- a/bookworm/utils/string.py
+++ b/bookworm/utils/string.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import codecs
 from functools import lru_cache
-from io import BytesIO, StringIO
+from io import BytesIO
 from xml.sax.saxutils import escape
 
 import attr
@@ -62,7 +62,7 @@ class TextContentDecoder:
     @classmethod
     def from_filename(
         cls,
-        filename: os.PathLike,
+        filename: t.PathLike,
         prefered_encoding="utf-8",
         fallback_encoding=FALLBACK_ENCODING,
     ):
@@ -70,7 +70,7 @@ class TextContentDecoder:
             return cls(file.read(), prefered_encoding, fallback_encoding)
 
     def get_text(self):
-        text, encoding = self.get_text_and_explain()
+        text, _ = self.get_text_and_explain()
         return text
 
     def get_text_and_explain(self) -> tuple[str, str]:

--- a/tests/test_otau.py
+++ b/tests/test_otau.py
@@ -5,13 +5,13 @@ from bookworm.otau import UpdateChannel, is_newer_version
 
 def test_is_not_valid_identifier():
     with pytest.raises(TypeError):
-        channel = UpdateChannel("test")
+        UpdateChannel("test")
 
 
 def test_is_valid_identifier():
     valid_identifiers = ("", "a", "b", "rc")
     for identifier in valid_identifiers:
-        channel = UpdateChannel(identifier)
+        UpdateChannel(identifier)
 
 
 def test_is_major_version():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,3 @@
-import pytest
-
 from bookworm.utils import get_url_spans
 
 


### PR DESCRIPTION
## Link to issue number:

N/A

### Summary of the issue:

A few small cleanup issues add unnecessary state sharing, extra query work, unused imports, and minor noise in tests and helper modules.

### Description of how this pull request fixes the issue:

- Keeps `ServiceHandler.registered_services` on each handler instance.
- Simplifies bookshelf dialog return handling and source item counting.
- Uses an existence query when checking whether the current document is already on the bookshelf.
- Simplifies update channel helper code and removes unused test assignments.
- Removes unused imports and variables across shared config, i18n, concurrency, logging, path, typing, and string utility modules.
- Tightens a couple of type annotations without changing runtime behavior.

### Testing performed:

TBD

### Known issues with pull request:

No known issues.