### PR TITLE
Fix saved position restore for bookshelf documents

### DIFF
--- a/bookworm/reader.py
+++ b/bookworm/reader.py
@@ -506,7 +506,8 @@ class EBookReader:
         self._migrate_current_document_positions()
         # the current_page is set after the document position info and related models are created in order to allow dependent services to access the current_book
         self.current_page = 0
-        if open_args := self.document.uri.openner_args:
+        open_args = self.document.uri.openner_args
+        if any(key in open_args for key in ("page", "position")):
             page = int(open_args.get("page", 0))
             pos = int(open_args.get("position", 0))
             self.go_to_page(page, pos)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -55,6 +55,23 @@ def test_document_uri_is_corrected_after_conversion(reader, asset):
     assert reader.document.uri == original_uri
 
 
+def test_fallback_uri_does_not_override_saved_position(reader, tmp_path):
+    path = tmp_path / "book.txt"
+    path.write_text("0123456789abcdef", encoding="utf-8")
+    uri = DocumentUri.from_filename(path)
+    uri.fallback_uri = DocumentUri.from_filename(path)
+
+    reader.load(uri)
+    reader.go_to_page(0, 7)
+    reader.save_current_position()
+    reader.unload()
+
+    reader.load(uri)
+
+    assert reader.view.get_insertion_point() == 7
+    reader.unload()
+
+
 def test_restore_position_for_mobi_document(reader, asset, engine):
     """
     Provides an additional test case for another convertible format (.mobi)


### PR DESCRIPTION
## Link to issue number:

N/A

### Summary of the issue:

Books opened from the bookshelf could start at the beginning instead of the last saved reading position when their URI contained `fallback_uri`.

### Description of how this pull request fixes the issue:

Only `page` and `position` opener arguments now trigger an explicit jump on load. Other opener arguments, such as `fallback_uri`, no longer bypass saved-position restore.

### Testing performed:

Manual regression check: opened a document through a URI containing `fallback_uri`, saved position 7, unloaded it, reopened the same URI, and confirmed the reader restored to position 7 instead of jumping to 0.

### Known issues with pull request:

None.