### PR TITLE
Preserve reading position when focusing the table of contents

### DIFF
--- a/bookworm/gui/book_viewer/__init__.py
+++ b/bookworm/gui/book_viewer/__init__.py
@@ -634,17 +634,17 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
 
     def onTocTreeFocus(self, event):
         event.Skip(True)
-        if not self.reader.document.is_single_page_document():
+        if not self.reader.ready or not self.reader.document.is_single_page_document():
             return
+        insertion_point = self.get_insertion_point()
         condition = (
-            self.reader.ready
-            and self.reader.active_section is not None
-            and self.get_insertion_point() not in self.reader.active_section.text_range
+            self.reader.active_section is not None
+            and insertion_point not in self.reader.active_section.text_range
         )
         if condition:
-            self.reader.active_section = self.reader.document.get_section_at_position(
-                self.get_insertion_point()
-            )
+            section = self.reader.document.get_section_at_position(insertion_point)
+            self.reader.set_active_section(section, update_view=False)
+            self.tocTreeSetSelection(section)
             event.GetEventObject().SetFocus()
 
     def onTOCItemClick(self, event):

--- a/bookworm/reader.py
+++ b/bookworm/reader.py
@@ -573,12 +573,15 @@ class EBookReader:
 
     @active_section.setter
     def active_section(self, value: Section):
+        self.set_active_section(value)
+
+    def set_active_section(self, value: Section, *, update_view: bool = True):
         if (self.active_section is not None) and (
             value.unique_identifier == self.active_section.unique_identifier
         ):
             return
         self.__state["active_section"] = value
-        if self.document.has_toc_tree():
+        if update_view and self.document.has_toc_tree():
             self.view.set_state_on_section_change(value)
         reader_section_changed.send(self, active=value)
 
@@ -683,6 +686,9 @@ class EBookReader:
     def go_to_first_of_section(self, section: Section = None):
         section = section or self.active_section
         self.current_page = section.pager.first
+        if self.document.is_single_page_document() and section.text_range is not None:
+            target_pos = self.view.get_containing_line(section.text_range.start + 1)[0]
+            self.view.set_insertion_point(target_pos)
 
     def go_to_last_of_section(self, section: Section = None):
         section = section or self.active_section

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -2,10 +2,11 @@ from types import SimpleNamespace
 
 import pytest
 
+from bookworm.document import SINGLE_PAGE_DOCUMENT_PAGER, Section
 from bookworm.gui import book_viewer
 from bookworm.gui.book_viewer import BookViewerWindow
 from bookworm.gui.book_viewer.position_mapping import TextCtrlPositionMap
-from bookworm.structured_text import SemanticElementType
+from bookworm.structured_text import SemanticElementType, TextRange
 from bookworm.structured_text.structured_html_parser import StructuredHtmlParser
 
 
@@ -33,6 +34,19 @@ class SetContentHarness(PositionMappingHarness):
     def get_content_view_text_style(self, font_size=None):
         assert font_size is None
         return self.content_style
+
+
+class TocFocusHarness:
+    def __init__(self, insertion_point, reader):
+        self.insertion_point = insertion_point
+        self.reader = reader
+        self.selected_sections = []
+
+    def get_insertion_point(self):
+        return self.insertion_point
+
+    def tocTreeSetSelection(self, section):  # noqa: N802
+        self.selected_sections.append(section)
 
 
 class StyleRecordingTextCtrl:
@@ -93,6 +107,21 @@ class ContainingLineTextCtrl:
         return self.line_start, self.line_end
 
 
+class FakeFocusEvent:
+    def __init__(self):
+        self.skipped = False
+        self.focused = False
+
+    def Skip(self, skip=True):  # noqa: N802
+        self.skipped = skip
+
+    def GetEventObject(self):  # noqa: N802
+        return self
+
+    def SetFocus(self):  # noqa: N802
+        self.focused = True
+
+
 def line_bounds(text, pos):
     pos = max(0, min(pos, len(text)))
     start = text.rfind("\n", 0, pos) + 1
@@ -104,6 +133,48 @@ def line_bounds(text, pos):
 
 def noop(*_args, **_kwargs):
     pass
+
+
+def make_section(title, start, stop):
+    return Section(
+        title=title,
+        pager=SINGLE_PAGE_DOCUMENT_PAGER,
+        text_range=TextRange(start, stop),
+    )
+
+
+def test_toc_focus_syncs_tree_without_moving_single_page_reading_position():
+    old_section = make_section("Old", 0, 10)
+    current_section = make_section("Current", 40, 80)
+    insertion_point = 50
+
+    class FakeReader:
+        ready = True
+        active_section = old_section
+
+        def __init__(self):
+            self.set_active_section_calls = []
+            self.document = SimpleNamespace(
+                is_single_page_document=lambda: True,
+                get_section_at_position=lambda _position: current_section,
+            )
+
+        def set_active_section(self, section, update_view=True):
+            self.set_active_section_calls.append((section, update_view))
+            self.active_section = section
+
+    reader = FakeReader()
+    viewer = TocFocusHarness(insertion_point, reader)
+    event = FakeFocusEvent()
+
+    BookViewerWindow.onTocTreeFocus(viewer, event)
+
+    assert event.skipped
+    assert event.focused
+    assert reader.active_section is current_section
+    assert reader.set_active_section_calls == [(current_section, False)]
+    assert viewer.selected_sections == [current_section]
+    assert viewer.insertion_point == insertion_point
 
 
 def test_position_mapping_handles_non_bmp_rich_edit_offsets():

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,6 +1,62 @@
+from types import SimpleNamespace
 
 from bookworm.database.models import DocumentPositionInfo
+from bookworm.document import SINGLE_PAGE_DOCUMENT_PAGER, Section
 from bookworm.document.uri import DocumentUri
+from bookworm.structured_text import TextRange
+
+
+def make_section(title, start, stop):
+    return Section(
+        title=title,
+        pager=SINGLE_PAGE_DOCUMENT_PAGER,
+        text_range=TextRange(start, stop),
+    )
+
+
+def test_set_active_section_can_skip_view_section_change(reader):
+    current_section = make_section("Current", 0, 10)
+    target_section = make_section("Target", 20, 40)
+    reader.document = SimpleNamespace(has_toc_tree=lambda: True)
+    reader._EBookReader__state = {"active_section": current_section}
+
+    reader.set_active_section(target_section, update_view=False)
+
+    assert reader.active_section is target_section
+    assert reader.view.state_on_section_change is None
+
+
+def test_go_to_first_of_section_moves_to_section_start_in_single_page_document(reader):
+    section = make_section("Target", 20, 40)
+    reader.document = SimpleNamespace(is_single_page_document=lambda: True)
+    reader._EBookReader__state = {
+        "active_section": section,
+        "current_page_index": section.pager.first,
+    }
+    reader.view.get_containing_line = lambda _position: (18, 30)
+
+    reader.go_to_first_of_section()
+
+    assert reader.view.get_insertion_point() == 18
+
+
+def test_go_to_first_of_section_ignores_missing_single_page_section_range(reader):
+    section = Section(title="Target", pager=SINGLE_PAGE_DOCUMENT_PAGER)
+    reader.document = SimpleNamespace(is_single_page_document=lambda: True)
+    reader._EBookReader__state = {
+        "active_section": section,
+        "current_page_index": section.pager.first,
+    }
+    reader.view.set_insertion_point(7)
+
+    def fail_line_lookup(_position):
+        raise AssertionError("No section range should mean no line lookup")
+
+    reader.view.get_containing_line = fail_line_lookup
+
+    reader.go_to_first_of_section()
+
+    assert reader.view.get_insertion_point() == 7
 
 
 def test_restore_position_for_converted_document(reader, asset, engine):


### PR DESCRIPTION
## Link to issue number:

N/A

### Summary of the issue:

In single-page documents, moving focus from the content view to the table of contents could also move the text cursor to the start of the current section. This made a normal Tab focus change alter the reading position.

### Description of how this pull request fixes the issue:

The table-of-contents focus handler now only syncs the active section and selected TOC item. It no longer uses the section-change path that moves the content cursor.

Explicit navigation still moves to the section start when a section has a text range.

### Testing performed:

Automated tests:

- Reader and navigation tests passed.
- Full test suite passed.

Manual test:

1. Started Bookworm from source.
2. Opened an EPUB with a multi-level table of contents.
3. Moved the text cursor to a nested section in the content view.
4. Pressed Tab to move focus to the table of contents.
5. Confirmed the matching TOC item was selected without changing the reading position.
6. Pressed Enter on the selected TOC item.
7. Confirmed explicit TOC activation still navigated to the start of that section.
8. Closed Bookworm cleanly.

### Known issues with pull request:

None known.