### PR TITLE
Install NSIS with Scoop in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,9 +85,18 @@ jobs:
           uv run invoke dev
 
       - name: Install NSIS
-        uses: repolevedavaj/install-nsis@v1.2.0
-        with:
-          nsis-version: '3.11'
+        shell: pwsh
+        run: |
+          iwr -useb get.scoop.sh -outfile install.ps1
+          .\install.ps1 -RunAsAdmin
+          scoop update
+          scoop bucket add extras
+          scoop install extras/nsis
+          $scoopShims = Join-Path $env:USERPROFILE 'scoop\shims'
+          $env:PATH = "$scoopShims;$env:PATH"
+          $scoopShims | Out-File -FilePath $env:GITHUB_PATH -Append
+          makensis -VERSION
+          makensis -HDRINFO
 
       - name: Build the project
         run: |


### PR DESCRIPTION
﻿## Link to issue number:

N/A

### Summary of the issue:

The CI build currently installs NSIS through `repolevedavaj/install-nsis`, which also downloads the unused EnVar plugin. That plugin download is now failing behind a Cloudflare challenge and blocks the Windows build jobs before packaging starts.

### Description of how this pull request fixes the issue:

Replace the NSIS install action with the NSIS project's Scoop-based GitHub Actions install flow.

The workflow now installs the latest `extras/nsis` package, adds Scoop shims to the GitHub Actions path, and prints `makensis` version/header info before running the existing build step.

### Testing performed:

Checked the workflow diff and verified there are no whitespace errors.

### Known issues with pull request:

The full installer build must be validated by GitHub Actions on the Windows runner.
