### PR TITLE
Include empty-alt images in image navigation

### DIFF
--- a/bookworm/structured_text/structured_html_parser.py
+++ b/bookworm/structured_text/structured_html_parser.py
@@ -93,12 +93,24 @@ INSCRIPTIS_CONFIG = ParserConfig(
 )
 
 
+def should_include_empty_alt_images_in_navigation():
+    try:
+        from bookworm import config
+
+        return config.conf["reading"].as_bool(
+            "include_empty_alt_images_in_image_navigation"
+        )
+    except (AttributeError, KeyError, TypeError, ValueError):
+        return True
+
+
 class StructuredHtmlParser(Inscriptis):
     """Subclass of ```inscriptis.Inscriptis``` to provide the position of structural elements."""
 
     __slots__ = [
         "_display_text",
         "_image_elements",
+        "_include_empty_alt_images",
         "_storage_text",
         "_table_elements",
         "_text_position_map",
@@ -121,19 +133,27 @@ class StructuredHtmlParser(Inscriptis):
         html_string = ftfy.fix_text(html_string, config)
         return remove_excess_blank_lines(html_string)
 
-    def __init__(self, *args, include_images=True, **kwargs):
+    def __init__(self, *args, include_images=True, include_empty_alt_images=None, **kwargs):
         self.link_range_to_target = {}
         self.anchors = {}
         self.html_id_ranges = {}
         self.styled_elements = {}
         self._table_elements = []
         self._image_elements = []
+        self._include_empty_alt_images = (
+            should_include_empty_alt_images_in_navigation()
+            if include_empty_alt_images is None
+            else bool(include_empty_alt_images)
+        )
         self._display_text = ""
         self._storage_text = ""
         self._text_position_map = TextPositionMap.identity(0)
         kwargs.setdefault("config", INSCRIPTIS_CONFIG)
         if include_images and args:
-            self._prepare_image_elements(args[0])
+            self._prepare_image_elements(
+                args[0],
+                include_empty_alt_images=self._include_empty_alt_images,
+            )
         super().__init__(*args, **kwargs)
         self._display_text = remove_excess_blank_lines(INSCRIPTIS_GET_TEXT(self))
         self._storage_text, self._text_position_map = TextPositionMap.from_collapsed_ranges(
@@ -168,7 +188,10 @@ class StructuredHtmlParser(Inscriptis):
         if (
             tree.tag == "img"
             and (src := tree.attrib.get("src", ""))
-            and self._is_navigable_image(tree)
+            and self._is_navigable_image(
+                tree,
+                include_empty_alt_images=self._include_empty_alt_images,
+            )
         ):
             label = self._get_image_label(tree)
             placeholder = self._get_image_placeholder(label)
@@ -208,20 +231,23 @@ class StructuredHtmlParser(Inscriptis):
             return 0
 
     @classmethod
-    def _prepare_image_elements(cls, tree):
+    def _prepare_image_elements(cls, tree, *, include_empty_alt_images=False):
         for image in tree.iter("img"):
-            if not cls._is_navigable_image(image):
+            if not cls._is_navigable_image(
+                image,
+                include_empty_alt_images=include_empty_alt_images,
+            ):
                 continue
             label = cls._get_image_label(image)
             placeholder = cls._get_image_placeholder(label)
             image.text = placeholder if image.text is None else f"{placeholder} {image.text}"
 
     @classmethod
-    def _is_navigable_image(cls, image):
+    def _is_navigable_image(cls, image, *, include_empty_alt_images=False):
         return (
             bool(image.attrib.get("src", ""))
             and not cls._is_hidden_image(image)
-            and not cls._is_decorative_image(image)
+            and (include_empty_alt_images or not cls._is_decorative_image(image))
         )
 
     @classmethod
@@ -307,7 +333,14 @@ class StructuredHtmlParser(Inscriptis):
             image_info.text_range.stop = text_range.stop
 
     def _get_table_image_infos(self, table):
-        table_image_count = sum(1 for image in table.iter("img") if self._is_navigable_image(image))
+        table_image_count = sum(
+            1
+            for image in table.iter("img")
+            if self._is_navigable_image(
+                image,
+                include_empty_alt_images=self._include_empty_alt_images,
+            )
+        )
         if not table_image_count:
             return ()
         return self._image_elements[-table_image_count:]
@@ -394,16 +427,27 @@ class StructuredHtmlParser(Inscriptis):
         return html_content
 
     @classmethod
-    def from_string(cls, html_string, *, include_images=True):
+    def from_string(cls, html_string, *, include_images=True, include_empty_alt_images=None):
         html_content = cls.preprocess_html_string(html_string)
         return cls(
             html_parser.fromstring(html_content),
             include_images=include_images,
+            include_empty_alt_images=include_empty_alt_images,
         )
 
     @classmethod
-    def from_lxml_html_tree(cls, lxml_html_tree, *, include_images=True):
-        return cls(lxml_html_tree, include_images=include_images)
+    def from_lxml_html_tree(
+        cls,
+        lxml_html_tree,
+        *,
+        include_images=True,
+        include_empty_alt_images=None,
+    ):
+        return cls(
+            lxml_html_tree,
+            include_images=include_images,
+            include_empty_alt_images=include_empty_alt_images,
+        )
 
     def get_text(self):
         return self._display_text

--- a/bookworm/text_to_speech/tts_config.py
+++ b/bookworm/text_to_speech/tts_config.py
@@ -107,6 +107,7 @@ tts_config_spec = {
         ask_to_switch_voice_to_current_book_language="boolean(default=True)",
         enable_global_media_keys="boolean(default=False)",
         play_image_earcon_when_navigating_text="boolean(default=True)",
+        include_empty_alt_images_in_image_navigation="boolean(default=True)",
     ),
     "speech": dict(
         engine="string(default='sapi5')",

--- a/bookworm/text_to_speech/tts_gui.py
+++ b/bookworm/text_to_speech/tts_gui.py
@@ -78,6 +78,16 @@ class ReadingPanel(SettingsPanel):
             choices=[_("Cursor position"), _("Beginning of page")],
         )
         # Translators: the label of a group of controls in the reading page
+        # related to structural navigation.
+        navigationBox = self.make_static_box(_("Navigation"))
+        wx.CheckBox(
+            navigationBox,
+            -1,
+            # Translators: the label of a checkbox
+            _("Include images with empty alternative text in image navigation"),
+            name="reading.include_empty_alt_images_in_image_navigation",
+        )
+        # Translators: the label of a group of controls in the reading page
         # of the settings related to behavior during reading  aloud
         miscBox = self.make_static_box(_("During Reading Aloud"))
         wx.CheckBox(

--- a/tests/test_embedded_images.py
+++ b/tests/test_embedded_images.py
@@ -381,7 +381,8 @@ def test_structured_html_parser_skips_images_with_empty_alt_text():
             <img src="images/decorative.png" alt="">
             <img src="images/content.png" alt="Content">
         </body></html>
-        """
+        """,
+        include_empty_alt_images=False,
     )
 
     text = parser.get_text()
@@ -389,6 +390,23 @@ def test_structured_html_parser_skips_images_with_empty_alt_text():
 
     assert [text[start:stop] for start, stop in ranges] == ["[Content]"]
     assert parser.get_image_info(0).src == "images/content.png"
+
+
+def test_structured_html_parser_includes_images_with_empty_alt_text_by_default():
+    parser = StructuredHtmlParser.from_string(
+        """
+        <html><body>
+            <img src="images/empty.png" alt="">
+            <img src="images/content.png" alt="Content">
+        </body></html>
+        """
+    )
+
+    text = parser.get_text()
+    ranges = parser.semantic_elements[SemanticElementType.FIGURE]
+
+    assert [text[start:stop] for start, stop in ranges] == ["[Image]", "[Content]"]
+    assert parser.get_image_info(0).src == "images/empty.png"
 
 
 def test_structured_html_parser_keeps_empty_alt_images_with_title():
@@ -526,7 +544,8 @@ def test_structured_html_parser_keeps_figure_ranges_and_image_info_in_lockstep()
                 </tr>
             </table>
         </body></html>
-        """
+        """,
+        include_empty_alt_images=False,
     )
 
     text = parser.get_text()


### PR DESCRIPTION
﻿## Link to issue number:

N/A

### Summary of the issue:

Some books incorrectly mark regular content images with `alt=""`. In EPUB/HTML accessibility semantics, empty alternative text means the image is decorative and can be ignored by assistive technology. When publishers use it incorrectly for normal illustrations, Bookworm skips those images during image navigation, so users cannot reach them with image navigation.

This is a document authoring issue, but it affects real books where illustrations are important to the reading experience.

### Description of how this pull request fixes the issue:

This adds a Reading setting, enabled by default, to include images with empty alternative text in image navigation.

The behavior is handled in `StructuredHtmlParser`, where image placeholders and image semantic ranges are generated. A checkbox is added under Reading > Navigation so users can turn this behavior off when they prefer strict decorative-image filtering.

### Testing performed:

1. Open a book that contains content images marked with `alt=""`.
2. Confirm the new Reading > Navigation option is enabled by default.
3. Reopen the document.
4. Use image navigation and verify images with empty alternative text are reachable.
5. Turn the option off, reopen the same document, and verify images that only have `alt=""` are skipped.
6. Verify images with normal alt text, title text, or figure captions remain reachable.

### Known issues with pull request:

Changing this setting only affects documents opened after the change. Already-open documents need to be reopened because image navigation ranges are generated when the document is loaded.
