### PR TITLE
Improve embedded image viewer keyboard handling

### DIFF
--- a/bookworm/gui/book_viewer/render_view.py
+++ b/bookworm/gui/book_viewer/render_view.py
@@ -166,14 +166,18 @@ class EmbeddedImageDialog(wx.Dialog):
     def _build_controls(self):
         sizer = wx.BoxSizer(wx.VERTICAL)
         toolbar = wx.ToolBar(self, -1, style=wx.TB_FLAT | wx.TB_HORIZONTAL)
-        self._add_tool(toolbar, wx.ID_ZOOM_IN, _("Zoom In"), wx.ART_PLUS)
-        self._add_tool(toolbar, wx.ID_ZOOM_OUT, _("Zoom Out"), wx.ART_MINUS)
-        self._add_tool(toolbar, self.ID_RESET_ZOOM, _("Actual Size"), wx.ART_GO_HOME)
+        self._add_tool(toolbar, wx.ID_ZOOM_IN, _("Zoom In"), wx.ART_PLUS, "Ctrl+=")
+        self._add_tool(toolbar, wx.ID_ZOOM_OUT, _("Zoom Out"), wx.ART_MINUS, "Ctrl+-")
+        self._add_tool(
+            toolbar, self.ID_RESET_ZOOM, _("Actual Size"), wx.ART_GO_HOME, "Ctrl+0"
+        )
         toolbar.AddSeparator()
-        self._add_tool(toolbar, wx.ID_SAVE, _("Save As"), wx.ART_FILE_SAVE)
-        self._add_tool(toolbar, wx.ID_COPY, _("Copy"), wx.ART_COPY)
+        self._add_tool(toolbar, wx.ID_SAVE, _("Save As"), wx.ART_FILE_SAVE, "Ctrl+S")
+        self._add_tool(toolbar, wx.ID_COPY, _("Copy"), wx.ART_COPY, "Ctrl+C")
         toolbar.AddSeparator()
-        self._add_tool(toolbar, wx.ID_CLOSE, _("Close"), wx.ART_CLOSE)
+        self._add_tool(
+            toolbar, wx.ID_CLOSE, _("Close"), wx.ART_CLOSE, "Esc, Ctrl+W, Alt+C"
+        )
         toolbar.Realize()
         sizer.Add(toolbar, 0, wx.EXPAND)
 
@@ -198,10 +202,11 @@ class EmbeddedImageDialog(wx.Dialog):
         self.Bind(wx.EVT_TOOL, self.onCopyImage, id=wx.ID_COPY)
         self.Bind(wx.EVT_TOOL, lambda event: self.Close(), id=wx.ID_CLOSE)
 
-    def _add_tool(self, toolbar, tool_id, label, art_id):
+    def _add_tool(self, toolbar, tool_id, label, art_id, shortcut=None):
         bitmap = wx.ArtProvider.GetBitmap(art_id, wx.ART_TOOLBAR, (16, 16))
         toolbar.AddTool(tool_id, label, bitmap)
-        toolbar.SetToolShortHelp(tool_id, label)
+        short_help = label if shortcut is None else f"{label} ({shortcut})"
+        toolbar.SetToolShortHelp(tool_id, short_help)
 
     def _normalize_suggested_filename(self, suggested_filename):
         filename = Path(suggested_filename or "image.png").name or "image.png"

--- a/bookworm/gui/book_viewer/render_view.py
+++ b/bookworm/gui/book_viewer/render_view.py
@@ -295,11 +295,16 @@ class EmbeddedImageDialog(wx.Dialog):
     def onCharHook(self, event):
         keycode = event.GetKeyCode()
         modifiers = event.GetModifiers()
-        if keycode == wx.WXK_ESCAPE:
+        if keycode == wx.WXK_ESCAPE or (
+            keycode == ord("C") and modifiers == wx.MOD_ALT
+        ):
             self.Close()
             return
         if modifiers != wx.MOD_CONTROL:
             event.Skip()
+            return
+        if keycode == ord("W"):
+            self.Close()
             return
         if keycode == ord("="):
             self.set_zoom(1)

--- a/bookworm/gui/text_ctrl_mixin.py
+++ b/bookworm/gui/text_ctrl_mixin.py
@@ -8,11 +8,11 @@ from bookworm import config
 log = logger.getChild(__name__)
 
 
-NAV_FOREWORD_KEYS = {
-    wx.WXK_SPACE,
+ACTION_ACTIVATION_KEYS = {
     wx.WXK_RETURN,
     wx.WXK_NUMPAD_ENTER,
 }
+NAV_FOREWORD_KEYS = ACTION_ACTIVATION_KEYS | {wx.WXK_SPACE}
 NAV_BACKWORD_KEYS = {
     wx.WXK_BACK,
 }
@@ -97,6 +97,13 @@ class ContentViewCtrlMixin(wx.TextCtrl):
             event.GetKeyCode() == wx.WXK_WINDOWS_MENU
         ):
             # This event is redundant
+            return True
+        # Keep native RichEdit from beeping; KEY_UP still runs the activation.
+        elif (
+            evtType == wx.EVT_CHAR_HOOK.typeId
+            and event.GetModifiers() == wx.MOD_CONTROL
+            and event.GetKeyCode() in ACTION_ACTIVATION_KEYS
+        ):
             return True
         elif (
             isinstance(event, wx.KeyEvent)


### PR DESCRIPTION
## Link to issue number:

N/A

### Summary of the issue:

The embedded image viewer did not support common close shortcuts such as Ctrl+W or Alt+C.

When opening an embedded image from the document view with Ctrl+Enter, the native text control could also handle the key event and play a Windows system beep after Bookworm had already opened the viewer.

The image viewer toolbar also did not expose the available keyboard shortcuts in its native tooltips.

### Description of how this pull request fixes the issue:

This updates the embedded image viewer so Ctrl+W and Alt+C close the dialog.

It also consumes Ctrl+Enter and Ctrl+Numpad Enter at the text control char-hook stage, while keeping the existing key-up activation path unchanged. This prevents the native RichEdit beep without changing image, link, or table activation behavior.

Toolbar tooltips now include the corresponding shortcuts for zooming, saving, copying, and closing the image viewer.

### Testing performed:

1. Open a document containing embedded images.
2. Navigate to an image and press Ctrl+Enter.
3. Confirm the image viewer opens without a system beep.
4. Confirm Ctrl+W closes the image viewer.
5. Reopen the image viewer and confirm Alt+C closes it.
6. Confirm Escape still closes the image viewer.
7. Confirm existing image viewer shortcuts such as zoom, save, and copy still work.
8. Hover over the image viewer toolbar buttons and confirm their tooltips show the relevant shortcuts.
9. Maximize the image viewer and confirm the toolbar remains visually unchanged.

### Known issues with pull request:

None known.