### PR TITLE
Replace legacy browseable messages with wx WebView

### DIFF
--- a/bookworm/gui/book_viewer/menubar.py
+++ b/bookworm/gui/book_viewer/menubar.py
@@ -28,6 +28,7 @@ from bookworm.gui.book_viewer.core_dialogs import (
     SearchBookDialog,
     SearchResultsDialog,
 )
+from bookworm.gui.browseable_message import close_browseable_messages
 from bookworm.gui.components import AsyncSnakDialog, RobustProgressDialog
 from bookworm.gui.settings import PreferencesDialog
 from bookworm.i18n import is_rtl
@@ -1031,6 +1032,7 @@ class MenubarProvider:
     def onClose(self, evt):
         try:
             self.unloadCurrentEbook()
+            close_browseable_messages()
             self.Destroy()
             evt.Skip()
         except:

--- a/bookworm/gui/browseable_message.py
+++ b/bookworm/gui/browseable_message.py
@@ -1,58 +1,321 @@
-# -*- coding: utf-8 -*-
-# A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2008-2020 NV Access Limited, James Teh, Dinesh Kaushal, Davy Kager, André-Abush Clause,
-# Babbage B.V., Leonard de Ruijter, Michael Curran, Accessolutions, Julien Cochuyt
-# This file may be used under the terms of the GNU General Public License, version 2 or later.
-# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+# Portions adapted from NonVisual Desktop Access (NVDA).
+# Copyright (C) 2006-2026 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Mesar Hameed,
+# Joseph Lee, Thomas Stivers, Babbage B.V., Accessolutions, Julien Cochuyt,
+# Leonard de Ruijter, James Teh, Dinesh Kaushal, Davy Kager, André-Abush Clause,
+# Michael Curran, and Cyrille Bougot.
+# Modified for Bookworm on 2026-07-12 and 2026-07-13.
+# This file may be used under the terms of the GNU General Public License, version 2 or later,
+# as modified by the NVDA license.
+# For full terms and any additional permissions, see:
+# https://github.com/nvaccess/nvda/blob/master/copying.txt
 
-import os
-from ctypes import POINTER, addressof, byref, c_size_t, windll
+import re
+from collections.abc import Callable
+from copy import deepcopy
 from html import escape
+from typing import ClassVar
 
+import nh3
 import wx
-from comtypes import IUnknown, automation
+import wx.html2
+from platform_utils.clipboard import copy as copy_to_clipboard
 
+from bookworm import speech
 from bookworm.paths import resources_path
 
-# From urlmon.h
-URL_MK_UNIFORM = 1
+_MATHML_TAGS = {
+    "annotation",
+    "math",
+    "menclose",
+    "merror",
+    "mfenced",
+    "mfrac",
+    "mi",
+    "mmultiscripts",
+    "mlabeledtr",
+    "mn",
+    "mo",
+    "mover",
+    "mpadded",
+    "mphantom",
+    "mprescripts",
+    "mroot",
+    "mrow",
+    "ms",
+    "mspace",
+    "msqrt",
+    "mstyle",
+    "msub",
+    "msubsup",
+    "msup",
+    "mtable",
+    "mtd",
+    "mtext",
+    "mtr",
+    "munder",
+    "munderover",
+    "none",
+    "semantics",
+}
+_TABLE_TAGS = {"caption", "col", "colgroup", "table", "tbody", "td", "tfoot", "th", "thead", "tr"}
+# Keep the two styles used by Bookworm tables without exposing IE to arbitrary CSS values.
+_SAFE_STYLE_WIDTH = re.compile(
+    r"(?:0|\d+(?:\.\d+)?(?:%|px|em|rem))",
+    re.ASCII | re.IGNORECASE,
+)
 
-# Dialog box properties
-DIALOG_OPTIONS = "resizable:yes;help:no"
 
-# dwDialogFlags for ShowHTMLDialogEx from mshtmhst.h
-HTMLDLG_NOUI = 0x0010
-HTMLDLG_MODAL = 0x0020
-HTMLDLG_MODELESS = 0x0040
-HTMLDLG_PRINT_TEMPLATE = 0x0080
-HTMLDLG_VERIFY = 0x0100
+def _filter_html_attribute(tag: str, attribute: str, value: str) -> str | None:
+    if tag == "img" and attribute == "src":
+        # EPUB content must not make background network requests from the message WebView.
+        return None
+    if attribute != "style":
+        return value
+    if len(value) > 128:
+        return None
+
+    declarations = []
+    for raw_declaration in value.split(";"):
+        declaration = raw_declaration.strip()
+        if not declaration:
+            continue
+        name, separator, declaration_value = declaration.partition(":")
+        if not separator:
+            return None
+        name = name.strip().lower()
+        declaration_value = declaration_value.strip().lower()
+        if not (
+            (name == "text-align" and declaration_value in {"center", "left", "right"})
+            or (name == "width" and _SAFE_STYLE_WIDTH.fullmatch(declaration_value))
+        ):
+            return None
+        declarations.append(f"{name}:{declaration_value}")
+    return ";".join(declarations) or None
 
 
-def browseable_message(message, title=None, is_html=False):
-    """Present a message to the user that can be read in browse mode.
-    The message will be presented in an HTML document.
-    @param message: The message in either html or text.
-    @type message: str
-    @param title: The title for the message.
-    @type title: str
-    @param is_html: Whether the message is html
-    @type is_html: boolean
+_HTML_ATTRIBUTES = deepcopy(nh3.ALLOWED_ATTRIBUTES)
+_HTML_ATTRIBUTES.setdefault("*", set()).update({"dir", "id", "lang", "role", "title"})
+for _tag in _TABLE_TAGS:
+    _HTML_ATTRIBUTES.setdefault(_tag, set()).add("style")
+_HTML_ATTRIBUTES["table"].update(
+    {"bgcolor", "border", "cellpadding", "cellspacing", "height", "width"}
+)
+for _tag in ("col", "colgroup", "td", "th", "tr"):
+    _HTML_ATTRIBUTES.setdefault(_tag, set()).update({"bgcolor", "height", "valign", "width"})
+_HTML_ATTRIBUTES["th"].add("abbr")
+_HTML_ATTRIBUTES.setdefault("math", set()).update({"display", "xmlns"})
+_HTML_ATTRIBUTES.setdefault("annotation", set()).add("encoding")
+for _tag in ("mi", "mn", "mo", "mtext"):
+    _HTML_ATTRIBUTES.setdefault(_tag, set()).add("mathvariant")
+_HTML_ATTRIBUTES.setdefault("mo", set()).update({"form", "stretchy"})
+_HTML_ATTRIBUTES.setdefault("mspace", set()).add("width")
+_HTML_ATTRIBUTES.setdefault("menclose", set()).add("notation")
+_HTML_ATTRIBUTES.setdefault("mfenced", set()).update({"close", "open", "separators"})
+_HTML_ATTRIBUTES.setdefault("mfrac", set()).update(
+    {"bevelled", "denomalign", "linethickness", "numalign"}
+)
+_HTML_ATTRIBUTES.setdefault("mstyle", set()).update({"displaystyle", "mathvariant", "scriptlevel"})
+_HTML_ATTRIBUTES.setdefault("mtd", set()).update(
+    {"columnalign", "columnspan", "rowalign", "rowspan"}
+)
+_HTML_ATTRIBUTES.setdefault("mover", set()).add("accent")
+_HTML_ATTRIBUTES.setdefault("munder", set()).add("accentunder")
+_HTML_ATTRIBUTES.setdefault("munderover", set()).update({"accent", "accentunder"})
+_HTML_CLEANER = nh3.Cleaner(
+    tags=nh3.ALLOWED_TAGS | _MATHML_TAGS | _TABLE_TAGS,
+    attributes=_HTML_ATTRIBUTES,
+    attribute_filter=_filter_html_attribute,
+    generic_attribute_prefixes={"aria-"},
+    tag_attribute_values={
+        "math": {"xmlns": {"http://www.w3.org/1998/Math/MathML"}},
+    },
+    filter_style_properties={"text-align", "width"},
+)
+
+
+class HtmlMessageDialog(wx.Dialog):
+    """Render a complete HTML document in a modeless WebView dialog."""
+
+    _ACTION_URL_PREFIX = "nvda-action://"
+    _DEFAULT_WEBVIEW_SIZE = (350, 300)
+    _DIALOG_STYLE = (
+        wx.DEFAULT_DIALOG_STYLE
+        | wx.RESIZE_BORDER
+        | wx.MAXIMIZE_BOX
+        | wx.MINIMIZE_BOX
+        | wx.DIALOG_NO_PARENT
+    )
+    _web_view_backend = (
+        wx.html2.WebViewBackendIE if wx.Platform == "__WXMSW__" else wx.html2.WebViewBackendDefault
+    )
+    _instances: ClassVar[set["HtmlMessageDialog"]] = set()
+
+    def __init__(self, parent: wx.Window | None, message: str, title: str):
+        self._action_handlers: dict[str, Callable[[], None]] = {}
+        self._button_sizer: wx.BoxSizer | None = None
+        super().__init__(parent, title=title, style=self._DIALOG_STYLE)
+
+        self._message_control = wx.html2.WebView.New(self, backend=self._web_view_backend)
+        self._message_control.SetInitialSize(self.FromDIP(wx.Size(*self._DEFAULT_WEBVIEW_SIZE)))
+        self._message_control.EnableContextMenu(False)
+        self._message_control.EnableHistory(False)
+        self._message_control.Bind(wx.html2.EVT_WEBVIEW_NAVIGATING, self._on_navigating)
+
+        self._main_sizer = wx.BoxSizer(wx.VERTICAL)
+        self._main_sizer.Add(
+            self._message_control,
+            proportion=1,
+            border=self.FromDIP(10),
+            flag=wx.ALL | wx.EXPAND,
+        )
+        self.SetSizer(self._main_sizer)
+        self.set_message(message)
+        self.Fit()
+        self.CenterOnScreen()
+
+        escape_id = wx.NewIdRef()
+        self.Bind(wx.EVT_MENU, lambda _event: self.Close(), id=escape_id)
+        self.SetAcceleratorTable(
+            wx.AcceleratorTable([wx.AcceleratorEntry(wx.ACCEL_NORMAL, wx.WXK_ESCAPE, escape_id)])
+        )
+        self.EnableCloseButton(True)
+        self.Bind(wx.EVT_SHOW, self._on_show)
+        self.Bind(wx.EVT_CLOSE, self._on_close)
+        self.Bind(wx.EVT_WINDOW_DESTROY, self._on_destroy, self)
+        self._instances.add(self)
+
+    def register_action(self, action: str, handler: Callable[[], None]) -> "HtmlMessageDialog":
+        """Register a handler for an ``nvda-action://<action>`` URL."""
+        self._action_handlers[action] = handler
+        return self
+
+    def add_button(
+        self,
+        button_id: int,
+        label: str,
+        callback: Callable[[wx.CommandEvent], None] | None = None,
+        *,
+        closes_dialog: bool = True,
+    ) -> "HtmlMessageDialog":
+        button = wx.Button(self, button_id, label)
+
+        def on_button(event: wx.CommandEvent) -> None:
+            if callback is not None:
+                callback(event)
+            if closes_dialog:
+                self.Close()
+
+        button.Bind(wx.EVT_BUTTON, on_button)
+        if self._button_sizer is None:
+            self._button_sizer = wx.BoxSizer(wx.HORIZONTAL)
+            self._main_sizer.Add(
+                self._button_sizer,
+                border=self.FromDIP(10),
+                flag=wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.ALIGN_RIGHT,
+            )
+        self._button_sizer.Add(button, border=self.FromDIP(5), flag=wx.LEFT)
+        self.Layout()
+        self.Fit()
+        return self
+
+    def set_message(self, message: str) -> "HtmlMessageDialog":
+        self._message_control.SetPage(message, "")
+        return self
+
+    def _on_navigating(self, event: wx.html2.WebViewEvent) -> None:
+        url = event.GetURL()
+        lower_url = url.lower()
+        if lower_url.startswith("data:text/html"):
+            # Edge fires this URL for SetPage; allow it so content loads.
+            return
+        event.Veto()
+        if lower_url.startswith(self._ACTION_URL_PREFIX):
+            action = url[len(self._ACTION_URL_PREFIX) :]
+            if action == "close":
+                self.Close()
+            elif handler := self._action_handlers.get(action):
+                handler()
+        elif lower_url.startswith(("http://", "https://")):
+            wx.LaunchDefaultBrowser(url)
+
+    def _on_show(self, event: wx.ShowEvent) -> None:
+        if event.IsShown():
+            self.Raise()
+            self._message_control.SetFocus()
+        event.Skip()
+
+    def _on_close(self, _event: wx.CloseEvent) -> None:
+        self.Hide()
+        self.Destroy()
+
+    def _on_destroy(self, event: wx.WindowDestroyEvent) -> None:
+        self._instances.discard(self)
+        event.Skip()
+
+    @classmethod
+    def close_all(cls) -> None:
+        for dialog in tuple(cls._instances):
+            dialog.Close()
+
+
+def _copy_browseable_message_to_clipboard(text: str) -> None:
+    copy_to_clipboard(text)
+    # Translators: Reported when the content of a browseable message is copied to the clipboard.
+    speech.announce(_("Copied to clipboard"))
+
+
+def browseable_message(
+    message: str,
+    title: str | None = None,
+    is_html: bool = False,
+    close_button: bool = False,
+    copy_button: bool = False,
+    sanitize_html_func: Callable[[str], str] = _HTML_CLEANER.clean,
+) -> None:
+    """Present a message in an HTML document that a screen reader can browse.
+
+    ``sanitize_html_func`` must sanitize any HTML that may contain translated or
+    user-provided content.
     """
-    htmlFileName = os.fspath(resources_path("message.html"))
-    moniker = POINTER(IUnknown)()
-    windll.urlmon.CreateURLMonikerEx(0, htmlFileName, byref(moniker), URL_MK_UNIFORM)
-    if not title:
+    if title is None:
         # Translators: The title for the dialog used to present general messages in browse mode.
         title = _("Message")
+
     if not is_html:
-        message = f"<pre>{escape(message)}</pre>"
-    dialogString = f"{title};{message}"
-    dialogArguements = automation.VARIANT(dialogString)
-    windll.mshtml.ShowHTMLDialogEx(
-        wx.GetApp().mainFrame.GetHandle(),
-        moniker,
-        HTMLDLG_MODELESS,
-        c_size_t(addressof(dialogArguements)),
-        DIALOG_OPTIONS,
-        None,
+        message_sanitized = f"<pre>{escape(message)}</pre>"
+    else:
+        message_sanitized = sanitize_html_func(message)
+
+    template = resources_path("message.html").read_text(encoding="utf-8")
+    templated_message = template.replace("{{TITLE}}", escape(title)).replace(
+        "{{MESSAGE}}", message_sanitized
     )
+    dialog = HtmlMessageDialog(None, templated_message, title)
+
+    if copy_button:
+        dialog.add_button(
+            wx.ID_COPY,
+            # Translators: The label of a button to copy the text of the window to the clipboard.
+            _("&Copy"),
+            callback=lambda _event: _copy_browseable_message_to_clipboard(
+                dialog._message_control.GetPageText()
+            ),
+            closes_dialog=False,
+        )
+        dialog.register_action(
+            "copy",
+            lambda: _copy_browseable_message_to_clipboard(dialog._message_control.GetPageText()),
+        )
+    if close_button:
+        dialog.add_button(
+            wx.ID_CLOSE,
+            # Translators: The label of a button that closes the browseable message window.
+            _("&Close"),
+        )
+
+    dialog.Show()
+
+
+def close_browseable_messages() -> None:
+    """Close all modeless browseable messages before the application exits."""
+    HtmlMessageDialog.close_all()

--- a/bookworm/gui/browseable_message.py
+++ b/bookworm/gui/browseable_message.py
@@ -230,7 +230,7 @@ class HtmlMessageDialog(wx.Dialog):
             return
         event.Veto()
         if lower_url.startswith(self._ACTION_URL_PREFIX):
-            action = url[len(self._ACTION_URL_PREFIX) :]
+            action = url[len(self._ACTION_URL_PREFIX) :].rstrip("/")
             if action == "close":
                 self.Close()
             elif handler := self._action_handlers.get(action):

--- a/bookworm/reader.py
+++ b/bookworm/reader.py
@@ -919,7 +919,8 @@ class EBookReader:
         title = _("Table View")
         if (table_caption := HTMLParser(table_markup).css_first("caption")) is not None:
             caption_text = table_caption.text().strip(string.whitespace).replace("\n", " ")
-            title = f"{caption_text} · {title}"
+            if caption_text:
+                title = f"{caption_text} · {title}"
         self.view.show_html_dialog(table_markup, title=title)
 
     def _show_image(self, image, image_info):

--- a/bookworm/resources/message.html
+++ b/bookworm/resources/message.html
@@ -1,31 +1,37 @@
-
 <!doctype html>
-<HTML style="width : 350; height: 300">
-<HEAD>
-<TITLE></TITLE>
-<SCRIPT LANGUAGE=javascript>
 <!--
-function escapeKeyPress(e) {
-	e = e || window.event;
-	if(e.keyCode == 27){ // code for escape
-		window.close();
-	}
-};
-
-function windowOnLoad() {
-	// #5875: string.prototype.split strips the tail when a limit is supplied,
-	// so use a regexp instead.
-	var args = window.dialogArguments.match(/^(.*?);([\s\S]*)$/);
-	// args[0] is the whole string.
-	if (args && args.length == 3){
-		document.title= args[1];
-		messageID.innerHTML= args[2];
-	}
-} 
-//-->
-</SCRIPT>
-</HEAD>
-<BODY tabindex='0' id='main_body' style="margin:1em" LANGUAGE=javascript onload="return windowOnLoad()" onkeypress="return escapeKeyPress()" >
-<div id=messageID></div>
+Adapted from NVDA message.html at commit 126e72c8e3f869a400e1ce81b8b69a9df9fdc1b9.
+Copyright (C) 2026 NV Access Limited and contributors.
+Licensed under GPL-2.0-or-later as modified by the NVDA license:
+https://github.com/nvaccess/nvda/blob/master/copying.txt
+-->
+<html>
+<head>
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta charset="utf-8">
+	<title>{{TITLE}}</title>
+	<style>
+		body {
+			margin: 1em;
+			overflow-wrap: break-word;
+			word-wrap: break-word;
+		}
+		pre {
+			white-space: pre-wrap;
+			word-wrap: break-word;
+		}
+	</style>
+	<script>
+		document.addEventListener('keydown', function (e) {
+			if (e.key === 'Escape') {
+				window.location.href = 'nvda-action://close';
+			} else if (e.altKey && (e.key === 'C' || e.key === 'c')) {
+				window.location.href = 'nvda-action://copy';
+			}
+		});
+	</script>
+</head>
+<body>
+	<div id="messageDiv">{{MESSAGE}}</div>
 </body>
 </html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ dependencies = [
     "msoffcrypto-tool==5.4.2",
     "multidict==6.4.3",
     "neosynth==3.2.0;sys_platform=='win32'",
+    "nh3==0.3.2",
     "numpy==1.26.4",
     "odfpy==1.4.1",
     "olefile==0.47",

--- a/tests/test_browseable_message.py
+++ b/tests/test_browseable_message.py
@@ -1,0 +1,159 @@
+from types import SimpleNamespace
+
+import wx
+
+from bookworm.gui import browseable_message as browseable_message_module
+
+
+class FakeWebViewEvent:
+    def __init__(self, url: str):
+        self.url = url
+        self.vetoed = False
+
+    def GetURL(self) -> str:  # noqa: N802 - Mirrors wx.WebViewEvent.
+        return self.url
+
+    def Veto(self) -> None:  # noqa: N802 - Mirrors wx.WebViewEvent.
+        self.vetoed = True
+
+
+def test_browseable_message_copy_uses_visible_page_text(monkeypatch):
+    dialogs = []
+    copied = []
+
+    class FakeMessageControl:
+        def GetPageText(self):  # noqa: N802 - Mirrors wx.WebView.
+            return "Visible table text"
+
+    class FakeDialog:
+        def __init__(self, _parent, _message, _title):
+            self._message_control = FakeMessageControl()
+            self.copy_button = None
+            self.actions = {}
+            dialogs.append(self)
+
+        def add_button(self, _button_id, _label, callback=None, *, closes_dialog=True):
+            self.copy_button = (callback, closes_dialog)
+
+        def register_action(self, action, handler):
+            self.actions[action] = handler
+
+        def Show(self):  # noqa: N802 - Mirrors wx.Dialog.
+            pass
+
+    monkeypatch.setattr(browseable_message_module, "HtmlMessageDialog", FakeDialog)
+    monkeypatch.setattr(
+        browseable_message_module,
+        "_copy_browseable_message_to_clipboard",
+        copied.append,
+    )
+
+    browseable_message_module.browseable_message(
+        "<p>Message</p>",
+        is_html=True,
+        copy_button=True,
+    )
+
+    dialog = dialogs[0]
+    copy_callback, closes_dialog = dialog.copy_button
+    assert closes_dialog is False
+
+    copy_callback(None)
+    dialog.actions["copy"]()
+    assert copied == ["Visible table text", "Visible table text"]
+
+
+def test_html_sanitizer_preserves_table_mathml_and_removes_active_content():
+    cleaned = browseable_message_module._HTML_CLEANER.clean(
+        """
+        <table style="width: 100%; text-align: center"
+               border="1" cellspacing="2" onclick="alert(1)">
+          <tr><td aria-label="Formula">
+            <math xmlns="http://www.w3.org/1998/Math/MathML" display="inline"
+                  aria-label="x squared">
+              <semantics><mfrac><mi mathvariant="italic">x</mi><mn>2</mn></mfrac>
+                <annotation encoding="application/x-tex">x/2</annotation>
+              </semantics>
+            </math>
+            <script>alert(2)</script>
+            <img src="https://example.com/beacon.png" alt="Cover">
+          </td><td style="width: expression(alert(3))">unsafe width</td>
+          </tr>
+        </table>
+        """
+    )
+
+    assert '<table style="width:100%;text-align:center" border="1" cellspacing="2">' in cleaned
+    assert '<td aria-label="Formula">' in cleaned
+    assert '<math xmlns="http://www.w3.org/1998/Math/MathML"' in cleaned
+    assert '<mfrac><mi mathvariant="italic">x</mi><mn>2</mn></mfrac>' in cleaned
+    assert '<annotation encoding="application/x-tex">x/2</annotation>' in cleaned
+    assert '<img alt="Cover">' in cleaned
+    assert not any(
+        unsafe in cleaned
+        for unsafe in ("https://example.com/beacon.png", "expression", "onclick", "alert(2)")
+    )
+
+
+def test_browseable_message_escapes_plain_text(monkeypatch):
+    dialogs = []
+
+    class FakeDialog:
+        def __init__(self, _parent, message, title):
+            dialogs.append(SimpleNamespace(message=message, title=title))
+
+        def Show(self):  # noqa: N802 - Mirrors wx.Dialog.
+            pass
+
+    monkeypatch.setattr(browseable_message_module, "HtmlMessageDialog", FakeDialog)
+
+    browseable_message_module.browseable_message("first\n<b>second</b>", title="Text")
+
+    assert "<pre>first\n&lt;b&gt;second&lt;/b&gt;</pre>" in dialogs[0].message
+
+
+def test_html_message_dialog_lays_out_native_buttons_below_webview():
+    app = wx.GetApp() or wx.App(False)
+    dialog = browseable_message_module.HtmlMessageDialog(
+        None,
+        "<html><body>Message</body></html>",
+        "Layout test",
+    )
+    try:
+        dialog.add_button(wx.ID_COPY, "&Copy", closes_dialog=False)
+        webview_rect = dialog._message_control.GetRect()
+        button_rect = dialog.FindWindowById(wx.ID_COPY).GetRect()
+
+        assert button_rect.y >= webview_rect.y + webview_rect.height
+    finally:
+        dialog.Destroy()
+        app.ProcessPendingEvents()
+
+
+def test_html_message_dialog_routes_actions_and_external_links(monkeypatch):
+    closed = []
+    copied = []
+    opened = []
+    dialog = SimpleNamespace(
+        _ACTION_URL_PREFIX="nvda-action://",
+        _action_handlers={"copy": lambda: copied.append(True)},
+        Close=lambda: closed.append(True),
+    )
+    monkeypatch.setattr(wx, "LaunchDefaultBrowser", opened.append)
+
+    copy_event = FakeWebViewEvent("nvda-action://copy")
+    browseable_message_module.HtmlMessageDialog._on_navigating(dialog, copy_event)
+    close_event = FakeWebViewEvent("nvda-action://close")
+    browseable_message_module.HtmlMessageDialog._on_navigating(dialog, close_event)
+    link_event = FakeWebViewEvent("https://example.com/path")
+    browseable_message_module.HtmlMessageDialog._on_navigating(dialog, link_event)
+    data_event = FakeWebViewEvent("data:text/html;charset=utf-8,content")
+    browseable_message_module.HtmlMessageDialog._on_navigating(dialog, data_event)
+
+    assert copied == [True]
+    assert closed == [True]
+    assert opened == ["https://example.com/path"]
+    assert copy_event.vetoed
+    assert close_event.vetoed
+    assert link_event.vetoed
+    assert data_event.vetoed is False

--- a/tests/test_browseable_message.py
+++ b/tests/test_browseable_message.py
@@ -141,9 +141,9 @@ def test_html_message_dialog_routes_actions_and_external_links(monkeypatch):
     )
     monkeypatch.setattr(wx, "LaunchDefaultBrowser", opened.append)
 
-    copy_event = FakeWebViewEvent("nvda-action://copy")
+    copy_event = FakeWebViewEvent("nvda-action://copy/")
     browseable_message_module.HtmlMessageDialog._on_navigating(dialog, copy_event)
-    close_event = FakeWebViewEvent("nvda-action://close")
+    close_event = FakeWebViewEvent("nvda-action://close/")
     browseable_message_module.HtmlMessageDialog._on_navigating(dialog, close_event)
     link_event = FakeWebViewEvent("https://example.com/path")
     browseable_message_module.HtmlMessageDialog._on_navigating(dialog, link_event)

--- a/tests/test_embedded_images.py
+++ b/tests/test_embedded_images.py
@@ -1188,6 +1188,7 @@ def test_reader_ctrl_enter_uses_table_action_when_embedded_image_fails(reader, v
     assert reader.handle_special_action_for_position(0) is True
     assert shown_tables
     assert "table" in shown_tables[0][0].lower()
+    assert shown_tables[0][1] == "Table View"
     assert view.image_dialog_args is None
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -271,6 +271,7 @@ dependencies = [
     { name = "msoffcrypto-tool" },
     { name = "multidict" },
     { name = "neosynth", marker = "sys_platform == 'win32'" },
+    { name = "nh3" },
     { name = "numpy" },
     { name = "odfpy" },
     { name = "olefile" },
@@ -382,6 +383,7 @@ requires-dist = [
     { name = "msoffcrypto-tool", specifier = "==5.4.2" },
     { name = "multidict", specifier = "==6.4.3" },
     { name = "neosynth", marker = "sys_platform == 'win32'", specifier = "==3.2.0" },
+    { name = "nh3", specifier = "==0.3.2" },
     { name = "numpy", specifier = "==1.26.4" },
     { name = "odfpy", specifier = "==1.4.1" },
     { name = "olefile", specifier = "==0.47" },
@@ -1251,6 +1253,39 @@ sdist = { url = "https://files.pythonhosted.org/packages/23/29/0ecb0b3370860a584
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2d/15/cf4d67efdfd23d1b77335f317644500ccdd0644e538991a1d84cb01a08fd/neosynth-3.2.0-cp311-none-win32.whl", hash = "sha256:1b938b8c8a11f0b76b73a2ab012a72b6c5760dc91926b51dd28a904828f9249e", size = 167455, upload-time = "2022-11-09T15:38:45.002Z" },
     { url = "https://files.pythonhosted.org/packages/9e/13/f8a35feef92e44231bbcbd0443e1b57d3ad60ca81f3eee51e1234b1757fe/neosynth-3.2.0-cp311-none-win_amd64.whl", hash = "sha256:8d9bf01e9fa2afb3a6634c0f8524b0ac8500a4561cf5cc0012ea74d2731945ba", size = 180000, upload-time = "2022-11-09T15:38:46.523Z" },
+]
+
+[[package]]
+name = "nh3"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/a5/34c26015d3a434409f4d2a1cd8821a06c05238703f49283ffeb937bef093/nh3-0.3.2.tar.gz", hash = "sha256:f394759a06df8b685a4ebfb1874fb67a9cbfd58c64fc5ed587a663c0e63ec376", size = 19288, upload-time = "2025-10-30T11:17:45.948Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/01/a1eda067c0ba823e5e2bb033864ae4854549e49fb6f3407d2da949106bfb/nh3-0.3.2-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:d18957a90806d943d141cc5e4a0fefa1d77cf0d7a156878bf9a66eed52c9cc7d", size = 1419839, upload-time = "2025-10-30T11:17:09.956Z" },
+    { url = "https://files.pythonhosted.org/packages/30/57/07826ff65d59e7e9cc789ef1dc405f660cabd7458a1864ab58aefa17411b/nh3-0.3.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:45c953e57028c31d473d6b648552d9cab1efe20a42ad139d78e11d8f42a36130", size = 791183, upload-time = "2025-10-30T11:17:11.99Z" },
+    { url = "https://files.pythonhosted.org/packages/af/2f/e8a86f861ad83f3bb5455f596d5c802e34fcdb8c53a489083a70fd301333/nh3-0.3.2-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2c9850041b77a9147d6bbd6dbbf13eeec7009eb60b44e83f07fcb2910075bf9b", size = 829127, upload-time = "2025-10-30T11:17:13.192Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/77aef4daf0479754e8e90c7f8f48f3b7b8725a3b8c0df45f2258017a6895/nh3-0.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:403c11563e50b915d0efdb622866d1d9e4506bce590ef7da57789bf71dd148b5", size = 997131, upload-time = "2025-10-30T11:17:14.677Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ee/fd8140e4df9d52143e89951dd0d797f5546004c6043285289fbbe3112293/nh3-0.3.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:0dca4365db62b2d71ff1620ee4f800c4729849906c5dd504ee1a7b2389558e31", size = 1068783, upload-time = "2025-10-30T11:17:15.861Z" },
+    { url = "https://files.pythonhosted.org/packages/87/64/bdd9631779e2d588b08391f7555828f352e7f6427889daf2fa424bfc90c9/nh3-0.3.2-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0fe7ee035dd7b2290715baf29cb27167dddd2ff70ea7d052c958dbd80d323c99", size = 994732, upload-time = "2025-10-30T11:17:17.155Z" },
+    { url = "https://files.pythonhosted.org/packages/79/66/90190033654f1f28ca98e3d76b8be1194505583f9426b0dcde782a3970a2/nh3-0.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a40202fd58e49129764f025bbaae77028e420f1d5b3c8e6f6fd3a6490d513868", size = 975997, upload-time = "2025-10-30T11:17:18.77Z" },
+    { url = "https://files.pythonhosted.org/packages/34/30/ebf8e2e8d71fdb5a5d5d8836207177aed1682df819cbde7f42f16898946c/nh3-0.3.2-cp314-cp314t-win32.whl", hash = "sha256:1f9ba555a797dbdcd844b89523f29cdc90973d8bd2e836ea6b962cf567cadd93", size = 583364, upload-time = "2025-10-30T11:17:20.286Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ae/95c52b5a75da429f11ca8902c2128f64daafdc77758d370e4cc310ecda55/nh3-0.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:dce4248edc427c9b79261f3e6e2b3ecbdd9b88c267012168b4a7b3fc6fd41d13", size = 589982, upload-time = "2025-10-30T11:17:21.384Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/bd/c7d862a4381b95f2469704de32c0ad419def0f4a84b7a138a79532238114/nh3-0.3.2-cp314-cp314t-win_arm64.whl", hash = "sha256:019ecbd007536b67fdf76fab411b648fb64e2257ca3262ec80c3425c24028c80", size = 577126, upload-time = "2025-10-30T11:17:22.755Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3e/f5a5cc2885c24be13e9b937441bd16a012ac34a657fe05e58927e8af8b7a/nh3-0.3.2-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7064ccf5ace75825bd7bf57859daaaf16ed28660c1c6b306b649a9eda4b54b1e", size = 1431980, upload-time = "2025-10-30T11:17:25.457Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f7/529a99324d7ef055de88b690858f4189379708abae92ace799365a797b7f/nh3-0.3.2-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8745454cdd28bbbc90861b80a0111a195b0e3961b9fa2e672be89eb199fa5d8", size = 820805, upload-time = "2025-10-30T11:17:26.98Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/62/19b7c50ccd1fa7d0764822d2cea8f2a320f2fd77474c7a1805cb22cf69b0/nh3-0.3.2-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72d67c25a84579f4a432c065e8b4274e53b7cf1df8f792cf846abfe2c3090866", size = 803527, upload-time = "2025-10-30T11:17:28.284Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ca/f022273bab5440abff6302731a49410c5ef66b1a9502ba3fbb2df998d9ff/nh3-0.3.2-cp38-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:13398e676a14d6233f372c75f52d5ae74f98210172991f7a3142a736bd92b131", size = 1051674, upload-time = "2025-10-30T11:17:29.909Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f7/5728e3b32a11daf5bd21cf71d91c463f74305938bc3eb9e0ac1ce141646e/nh3-0.3.2-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:03d617e5c8aa7331bd2659c654e021caf9bba704b109e7b2b28b039a00949fe5", size = 1004737, upload-time = "2025-10-30T11:17:31.205Z" },
+    { url = "https://files.pythonhosted.org/packages/53/7f/f17e0dba0a99cee29e6cee6d4d52340ef9cb1f8a06946d3a01eb7ec2fb01/nh3-0.3.2-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f2f55c4d2d5a207e74eefe4d828067bbb01300e06e2a7436142f915c5928de07", size = 911745, upload-time = "2025-10-30T11:17:32.945Z" },
+    { url = "https://files.pythonhosted.org/packages/42/0f/c76bf3dba22c73c38e9b1113b017cf163f7696f50e003404ec5ecdb1e8a6/nh3-0.3.2-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb18403f02b655a1bbe4e3a4696c2ae1d6ae8f5991f7cacb684b1ae27e6c9f7", size = 797184, upload-time = "2025-10-30T11:17:34.226Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a1/73d8250f888fb0ddf1b119b139c382f8903d8bb0c5bd1f64afc7e38dad1d/nh3-0.3.2-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6d66f41672eb4060cf87c037f760bdbc6847852ca9ef8e9c5a5da18f090abf87", size = 838556, upload-time = "2025-10-30T11:17:35.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/09/deb57f1fb656a7a5192497f4a287b0ade5a2ff6b5d5de4736d13ef6d2c1f/nh3-0.3.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f97f8b25cb2681d25e2338148159447e4d689aafdccfcf19e61ff7db3905768a", size = 1006695, upload-time = "2025-10-30T11:17:37.071Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/61/8f4d41c4ccdac30e4b1a4fa7be4b0f9914d8314a5058472f84c8e101a418/nh3-0.3.2-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:2ab70e8c6c7d2ce953d2a58102eefa90c2d0a5ed7aa40c7e29a487bc5e613131", size = 1075471, upload-time = "2025-10-30T11:17:38.225Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c6/966aec0cb4705e69f6c3580422c239205d5d4d0e50fac380b21e87b6cf1b/nh3-0.3.2-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:1710f3901cd6440ca92494ba2eb6dc260f829fa8d9196b659fa10de825610ce0", size = 1002439, upload-time = "2025-10-30T11:17:39.553Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c8/97a2d5f7a314cce2c5c49f30c6f161b7f3617960ade4bfc2fd1ee092cb20/nh3-0.3.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:91e9b001101fb4500a2aafe3e7c92928d85242d38bf5ac0aba0b7480da0a4cd6", size = 987439, upload-time = "2025-10-30T11:17:40.81Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/95/2d6fc6461687d7a171f087995247dec33e8749a562bfadd85fb5dbf37a11/nh3-0.3.2-cp38-abi3-win32.whl", hash = "sha256:169db03df90da63286e0560ea0efa9b6f3b59844a9735514a1d47e6bb2c8c61b", size = 589826, upload-time = "2025-10-30T11:17:42.239Z" },
+    { url = "https://files.pythonhosted.org/packages/64/9a/1a1c154f10a575d20dd634e5697805e589bbdb7673a0ad00e8da90044ba7/nh3-0.3.2-cp38-abi3-win_amd64.whl", hash = "sha256:562da3dca7a17f9077593214a9781a94b8d76de4f158f8c895e62f09573945fe", size = 596406, upload-time = "2025-10-30T11:17:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/7e/a96255f63b7aef032cbee8fc4d6e37def72e3aaedc1f72759235e8f13cb1/nh3-0.3.2-cp38-abi3-win_arm64.whl", hash = "sha256:cf5964d54edd405e68583114a7cba929468bcd7db5e676ae38ee954de1cfc104", size = 584162, upload-time = "2025-10-30T11:17:44.96Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Link to issue number:

Related to #363.

Supersedes #364.

### Summary of the issue:

The legacy HTML dialog limits content presentation and can leave independent message windows open after Bookworm exits.

Empty captions used for table accessibility also produce an incorrect `" · Table View"` window title.

### Description of how this pull request fixes the issue:

- Replaces the legacy dialog with `wx.html2.WebView`.
- Improves text wrapping, keyboard handling, copy and close actions, and external link handling.
- Adds minimal HTML filtering while preserving tables, MathML, ARIA attributes, and safe presentation styles.
- Prevents empty table captions from affecting the window title.
- Closes all independent message windows when Bookworm exits.

This supersedes #364 while preserving the table accessibility behavior introduced for #363.

### Testing performed:

Manual testing.

### Known issues with pull request:

None known.
