### PR TITLE
Improve automatic OCR for continuous reading

### DIFF
--- a/bookworm/gui/book_viewer/__init__.py
+++ b/bookworm/gui/book_viewer/__init__.py
@@ -32,6 +32,7 @@ from bookworm.signals import (
     reader_book_loaded,
     reader_book_unloaded,
     reading_position_change,
+    should_auto_navigate_to_next_page,
 )
 from bookworm.structured_text import (
     SEMANTIC_ELEMENT_OUTPUT_OPTIONS,
@@ -503,9 +504,9 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
 
     def open_document(self, document):
         self.unloadCurrentEbook()
-        self.reader.set_document(document)
+        self.load_document(document)
 
-    def set_content(self, content):
+    def set_content(self, content, set_focus_to_text_ctrl=True):
         self._text_position_map = TextCtrlPositionMap(content)
         self.contentTextCtrl.Freeze()
         if self._has_text_zoom:
@@ -518,7 +519,7 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
         self.contentTextCtrl.SetValue(self._text_position_map.to_text_ctrl_value())
         self.contentTextCtrl.SetStyle(0, self.contentTextCtrl.GetLastPosition(), content_style)
         self.contentTextCtrl.SetDefaultStyle(content_style)
-        self.set_insertion_point(0)
+        self.set_insertion_point(0, set_focus_to_text_ctrl)
         self.contentTextCtrl.Thaw()
 
     def set_title(self, title):
@@ -596,10 +597,15 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
             config.conf["general"]["use_continuous_reading"]
             and event.Position == self.contentTextCtrl.GetLastPosition()
         ):
-            if (time.monotonic() - self._last_page_turn_time) <= 0.75:
-                return
-            self.reader.go_to_next()
-            self._last_page_turn_time = time.monotonic()
+            should_navigate = all(
+                retval
+                for _, retval in should_auto_navigate_to_next_page.send(self)
+            )
+            if should_navigate:
+                if (time.monotonic() - self._last_page_turn_time) <= 0.75:
+                    return
+                self.reader.go_to_next()
+                self._last_page_turn_time = time.monotonic()
         wx.CallAfter(keep_awake)
 
     def _after_caret_moved(self):

--- a/bookworm/ocr/__init__.py
+++ b/bookworm/ocr/__init__.py
@@ -104,5 +104,6 @@ class OCRService(_OCRManagerMixin, BookwormService):
         return OCR_KEYBOARD_SHORTCUTS
 
     def shutdown(self):
+        self.menu._cancel_automatic_ocr()
         if (dlg := getattr(self.menu, "_wait_dlg", None)) is not None:
             dlg.Dismiss()

--- a/bookworm/ocr/ocr_menu.py
+++ b/bookworm/ocr/ocr_menu.py
@@ -34,15 +34,11 @@ from bookworm.signals import (
     reader_book_loaded,
     reader_book_unloaded,
     reader_page_changed,
+    should_auto_navigate_to_next_page,
 )
 from bookworm.utils import gui_thread_safe
 
 from .ocr_dialogs import OCROptionsDialog
-
-try:
-    from bookworm.text_to_speech import should_auto_navigate_to_next_page
-except ImportError:
-    should_auto_navigate_to_next_page = None
 
 
 log = logger.getChild(__name__)
@@ -118,6 +114,7 @@ class OCRMenu(wx.Menu):
         self.service = service
         self.view = service.view
         self._ocr_cancelled = threading.Event()
+        self._automatic_ocr_futures = {}
         image2textId = wx.NewIdRef()
 
         # Add menu items
@@ -174,31 +171,27 @@ class OCRMenu(wx.Menu):
         reader_page_changed.connect(
             self._on_reader_page_changed, sender=self.service.reader
         )
-        if should_auto_navigate_to_next_page:
-            should_auto_navigate_to_next_page.connect(
-                self.on_should_auto_navigate_to_next_page, sender=self.view
-            )
+        should_auto_navigate_to_next_page.connect(
+            self.on_should_auto_navigate_to_next_page, sender=self.view
+        )
 
     def _get_ocr_options(self, from_cache=True, **dlg_kw):
-        last_stored_opts = self.service.stored_options
-        if not from_cache:
-            self.service.stored_options = None
-            self.service.saved_scanned_pages.clear()
-        if self.service.stored_options is not None:
+        if from_cache and self.service.stored_options is not None:
             return self.service.stored_options
-        else:
-            opts = self._get_ocr_options_from_dlg(
-                last_stored_options=last_stored_opts, **dlg_kw
-            )
-            if opts is not None and opts.store_options:
-                self.service.stored_options = opts
-            else:
-                self.service.stored_options = None
-            return opts
+        engine, opts = self._get_ocr_options_from_dlg(
+            last_stored_options=self.service.stored_options,
+            **dlg_kw,
+        )
+        if opts is None:
+            return None
+        self._cancel_automatic_ocr()
+        self.service.current_ocr_engine = engine
+        self.service.saved_scanned_pages.clear()
+        self.service.stored_options = opts if opts.store_options else None
+        return opts
 
     def _get_ocr_options_from_dlg(self, last_stored_options=None, **dlg_kw):
-        self.service._init_ocr_engine()
-        engine = self.service.current_ocr_engine
+        engine = self.service.get_first_available_ocr_engine()
         langs = engine.get_sorted_languages()
         if not langs:
             wx.MessageBox(
@@ -210,7 +203,7 @@ class OCRMenu(wx.Menu):
                 _("No Languages for OCR"),
                 style=wx.ICON_ERROR,
             )
-            return
+            return engine, None
         dlg = OCROptionsDialog(
             parent=self.view,
             title=_("OCR Options"),
@@ -220,8 +213,7 @@ class OCRMenu(wx.Menu):
             is_multilingual=engine.__supports_more_than_one_recognition_language__,
             **dlg_kw,
         )
-        self.service.saved_scanned_pages.clear()
-        return dlg.ShowModal()
+        return engine, dlg.ShowModal()
 
     def onScanCurrentPage(self, event):
         self._ocr_cancelled.clear()
@@ -230,19 +222,11 @@ class OCRMenu(wx.Menu):
             return speech.announce(_("Canceled"), True)
         reader = self.service.reader
         if reader.current_page in self.service.saved_scanned_pages:
-            self.view.set_content(self.service.saved_scanned_pages[reader.current_page])
+            self._show_cached_ocr(reader.current_page)
+            if self.auto_scan_item.IsChecked():
+                self._ensure_automatic_ocr(reader.current_page + 1)
             return
-        image = reader.document.get_page_image(
-            reader.current_page,
-            ocr_opts.zoom_factor,
-        )
-        ocr_request = OcrRequest(
-            languages=ocr_opts.languages,
-            image=image,
-            image_processing_pipelines=ocr_opts.image_processing_pipelines,
-            cookie=reader.current_page,
-            engine_options=ocr_opts.engine_options,
-        )
+        ocr_request = self._make_page_ocr_request(reader.current_page, ocr_opts)
 
         def _ocr_callback(ocr_result):
             page_number = ocr_result.cookie
@@ -251,23 +235,111 @@ class OCRMenu(wx.Menu):
             if page_number == self.view.reader.current_page:
                 self.view.set_content(content)
                 self.view.set_text_direction(ocr_request.language.is_rtl)
+                if self.auto_scan_item.IsChecked():
+                    self._ensure_automatic_ocr(page_number + 1)
 
         self._run_ocr(ocr_request, _ocr_callback)
 
-    def _run_ocr(self, ocr_request, callback):
+    def _make_page_ocr_request(self, page_number, ocr_opts):
+        image = self.service.reader.document.get_page_image(
+            page_number,
+            ocr_opts.zoom_factor,
+        )
+        return OcrRequest(
+            languages=ocr_opts.languages,
+            image=image,
+            image_processing_pipelines=ocr_opts.image_processing_pipelines,
+            cookie=page_number,
+            engine_options=ocr_opts.engine_options,
+        )
+
+    def _run_ocr(self, ocr_request, callback, engine=None):
         ocr_started.send(sender=self.view)
         # Show a modal dialog
         sounds.ocr_start.play()
         future_callback = functools.partial(self._process_ocr_result, callback)
+        engine = engine or self.service.current_ocr_engine
         self._wait_dlg = AsyncSnakDialog(
             task=functools.partial(
-                self.service.current_ocr_engine.preprocess_and_recognize, ocr_request
+                engine.preprocess_and_recognize,
+                ocr_request,
             ),
             done_callback=future_callback,
             message=_("Running OCR, please wait..."),
             dismiss_callback=self._on_ocr_cancelled,
             parent=self.view,
         )
+
+    def _show_cached_ocr(self, page_number, set_focus_to_text_ctrl=True):
+        self.view.set_content(
+            self.service.saved_scanned_pages[page_number],
+            set_focus_to_text_ctrl,
+        )
+        if options := self.service.stored_options:
+            self.view.set_text_direction(options.languages[0].is_rtl)
+
+    def _announce_automatic_ocr_failure(self, page_number):
+        if page_number == self.service.reader.current_page:
+            speech.announce(_("Automatic OCR failed."))
+
+    def _ensure_automatic_ocr(self, page_number):
+        reader = self.service.reader
+        document = reader.document
+        if not self.auto_scan_item.IsChecked() or page_number not in document:
+            return
+        if page_number in self.service.saved_scanned_pages:
+            distance = page_number - reader.current_page
+            if distance == 0:
+                self._show_cached_ocr(page_number)
+            if distance in (0, 1):
+                self._ensure_automatic_ocr(page_number + 1)
+            return
+        key = (document, page_number)
+        if key in self._automatic_ocr_futures:
+            return
+        ocr_opts = self.service.stored_options
+        if ocr_opts is None:
+            return
+        try:
+            ocr_request = self._make_page_ocr_request(page_number, ocr_opts)
+        except Exception:
+            log.exception("Could not prepare automatic OCR for page %s.", page_number + 1)
+            self._announce_automatic_ocr_failure(page_number)
+            return
+        future = threaded_worker.submit(
+            self.service.current_ocr_engine.preprocess_and_recognize,
+            ocr_request,
+        )
+        self._automatic_ocr_futures[key] = future
+        future.add_done_callback(functools.partial(self._process_automatic_ocr_result, key))
+
+    @gui_thread_safe
+    def _process_automatic_ocr_result(self, key, task):
+        if self._automatic_ocr_futures.get(key) is not task:
+            return
+        self._automatic_ocr_futures.pop(key)
+        document, page_number = key
+        reader = self.service.reader
+        if document is not reader.document or not self.auto_scan_item.IsChecked():
+            return
+        try:
+            ocr_result = task.result()
+        except Exception:
+            log.exception("Automatic OCR failed for page %s.", page_number + 1)
+            self._announce_automatic_ocr_failure(page_number)
+            return
+        self.service.saved_scanned_pages[page_number] = ocr_result.recognized_text
+        distance = page_number - reader.current_page
+        if distance == 0:
+            self._show_cached_ocr(page_number, set_focus_to_text_ctrl=False)
+        if distance in (0, 1):
+            self._ensure_automatic_ocr(page_number + 1)
+
+    def _cancel_automatic_ocr(self, keep=()):
+        for key, future in list(self._automatic_ocr_futures.items()):
+            if key not in keep:
+                future.cancel()
+                self._automatic_ocr_futures.pop(key)
 
     def onAutoScanPages(self, event):
         event.Skip()
@@ -286,13 +358,21 @@ class OCRMenu(wx.Menu):
             speech.announce(_("Automatic OCR is enabled"))
             if self.view.is_empty():
                 self.onScanCurrentPage(event)
+            else:
+                self._ensure_automatic_ocr(self.service.reader.current_page + 1)
         else:
+            self._cancel_automatic_ocr()
             speech.announce(_("Automatic OCR is disabled"))
 
     def onScanToTextFile(self, event):
         ocr_opts = self._get_ocr_options(from_cache=False, force_save=True)
         if ocr_opts is None:
             return
+        if self.auto_scan_item.IsChecked():
+            page_number = self.service.reader.current_page
+            self._ensure_automatic_ocr(
+                page_number if self.view.is_empty() else page_number + 1
+            )
         # Get output file path
         filename = f"{self.view.reader.current_book.title}.txt"
         saveExportedFD = wx.FileDialog(
@@ -354,7 +434,12 @@ class OCRMenu(wx.Menu):
             wx.CallAfter(self.view.contentTextCtrl.SetFocus)
 
     def onChangeOCROptions(self, event):
-        self._get_ocr_options(from_cache=False)
+        opts = self._get_ocr_options(
+            from_cache=False,
+            force_save=self.auto_scan_item.IsChecked(),
+        )
+        if opts is not None and self.auto_scan_item.IsChecked():
+            self._ensure_automatic_ocr(self.service.reader.current_page)
 
     def onScanImageFile(self, event):
         wildcard = []
@@ -396,7 +481,7 @@ class OCRMenu(wx.Menu):
                     style=wx.ICON_ERROR,
                 )
                 return
-            options = self._get_ocr_options_from_dlg(force_save=True)
+            engine, options = self._get_ocr_options_from_dlg(force_save=True)
             if not options:
                 return
 
@@ -411,7 +496,7 @@ class OCRMenu(wx.Menu):
                     ocr_result=ocr_result,
                     image_name=Path(filename).stem,
                 )
-                wx.CallAfter(self.view.load_document, recog_document)
+                wx.CallAfter(self.view.open_document, recog_document)
 
             factor = options.zoom_factor
             resized_image = image.to_pil().resize(
@@ -421,8 +506,9 @@ class OCRMenu(wx.Menu):
                 languages=options.languages,
                 image=ImageIO.from_pil(resized_image),
                 image_processing_pipelines=options.image_processing_pipelines,
+                engine_options=options.engine_options,
             )
-            self._run_ocr(ocr_request, _ocr_callback)
+            self._run_ocr(ocr_request, _ocr_callback, engine=engine)
 
     @gui_thread_safe
     def _process_ocr_result(self, callback, task):
@@ -480,13 +566,28 @@ class OCRMenu(wx.Menu):
             self.Enable(item_id, can_render)
 
     def _on_reader_unloaded(self, sender):
+        self._cancel_automatic_ocr()
         self.service.stored_options = None
         self.service.saved_scanned_pages.clear()
         self.auto_scan_item.Check(False)
 
     def _on_reader_page_changed(self, sender, current, prev):
         if self.auto_scan_item.IsChecked():
-            self.onScanCurrentPage(None)
+            document = sender.document
+            self._cancel_automatic_ocr(
+                {(document, page) for page in range(current.index, current.index + 3)}
+            )
+            self._ensure_automatic_ocr(current.index)
 
     def on_should_auto_navigate_to_next_page(self, sender):
-        return not self.auto_scan_item.IsChecked()
+        if not self.auto_scan_item.IsChecked():
+            return True
+        reader = self.service.reader
+        current_page = reader.current_page
+        if sender.is_empty() and current_page not in self.service.saved_scanned_pages:
+            return False
+        next_page = current_page + 1
+        return (
+            next_page not in reader.document
+            or next_page in self.service.saved_scanned_pages
+        )

--- a/bookworm/signals.py
+++ b/bookworm/signals.py
@@ -22,6 +22,9 @@ reader_book_loaded = _signals.signal("reader/loaded")
 reader_book_unloaded = _signals.signal("reader/unloaded")
 reader_page_changed = _signals.signal("reader/page_changed")
 reader_section_changed = _signals.signal("reader/section_changed")
+should_auto_navigate_to_next_page = _signals.signal(
+    "tts/should-auto-navigate-to-next-page"
+)
 
 # Configuration
 config_updated = _signals.signal("config/updated")

--- a/bookworm/text_to_speech/__init__.py
+++ b/bookworm/text_to_speech/__init__.py
@@ -22,6 +22,7 @@ from bookworm.signals import (
     reader_book_unloaded,
     reader_page_changed,
     reading_position_change,
+    should_auto_navigate_to_next_page,
 )
 from bookworm.speech_engines import TTS_ENGINES
 from bookworm.speechdriver import DummySpeechEngine, speech_engine_state_changed
@@ -48,9 +49,6 @@ from .tts_gui import (
 log = logger.getChild(__name__)
 
 # Custom signals
-should_auto_navigate_to_next_page = _signals.signal(
-    "tts/should-auto-navigate-to-next-page"
-)
 restart_speech = _signals.signal("tts/restart-speech")
 
 # Utterance types

--- a/tests/test_ocr_menu.py
+++ b/tests/test_ocr_menu.py
@@ -1,0 +1,83 @@
+from types import SimpleNamespace
+
+import pytest
+
+from bookworm.ocr import ocr_menu
+
+
+def test_automatic_ocr_displays_current_page_and_keeps_two_pages_prefetched():
+    document = object()
+    cached_pages = {}
+    displayed = []
+    prefetched = []
+
+    def show_cached(page_number, set_focus_to_text_ctrl=True):
+        assert not set_focus_to_text_ctrl
+        displayed.append(cached_pages[page_number])
+
+    menu = SimpleNamespace(
+        _automatic_ocr_futures={},
+        auto_scan_item=SimpleNamespace(IsChecked=lambda: True),
+        service=SimpleNamespace(
+            reader=SimpleNamespace(document=document, current_page=4),
+            saved_scanned_pages=cached_pages,
+        ),
+        _show_cached_ocr=show_cached,
+        _ensure_automatic_ocr=prefetched.append,
+    )
+
+    for page_number in (4, 5, 6):
+        result = SimpleNamespace(
+            recognized_text=f"page {page_number}",
+        )
+        task = SimpleNamespace(result=lambda result=result: result)
+        key = (document, page_number)
+        menu._automatic_ocr_futures[key] = task
+        ocr_menu.OCRMenu._process_automatic_ocr_result.__wrapped__(menu, key, task)
+
+    assert cached_pages == {4: "page 4", 5: "page 5", 6: "page 6"}
+    assert displayed == ["page 4"]
+    assert prefetched == [5, 6]
+
+
+def test_automatic_ocr_waits_for_the_next_page_before_auto_navigation():
+    cached_pages = {4: "current"}
+    menu = SimpleNamespace(
+        auto_scan_item=SimpleNamespace(IsChecked=lambda: True),
+        service=SimpleNamespace(
+            reader=SimpleNamespace(document=range(10), current_page=4),
+            saved_scanned_pages=cached_pages,
+        ),
+    )
+    view = SimpleNamespace(is_empty=lambda: False)
+
+    assert not ocr_menu.OCRMenu.on_should_auto_navigate_to_next_page(menu, view)
+
+    cached_pages[5] = "next"
+    assert ocr_menu.OCRMenu.on_should_auto_navigate_to_next_page(menu, view)
+
+    cached_pages.pop(4)
+    view.is_empty = lambda: True
+    assert not ocr_menu.OCRMenu.on_should_auto_navigate_to_next_page(menu, view)
+
+
+def test_canceling_ocr_options_keeps_automatic_ocr_state():
+    current_engine = object()
+    stored_options = object()
+    cached_pages = {1: "recognized"}
+    menu = SimpleNamespace(
+        service=SimpleNamespace(
+            current_ocr_engine=current_engine,
+            stored_options=stored_options,
+            saved_scanned_pages=cached_pages,
+        ),
+        _get_ocr_options_from_dlg=lambda **_kwargs: (object(), None),
+        _cancel_automatic_ocr=lambda: pytest.fail("automatic OCR was canceled"),
+    )
+
+    result = ocr_menu.OCRMenu._get_ocr_options(menu, from_cache=False)
+
+    assert result is None
+    assert menu.service.current_ocr_engine is current_engine
+    assert menu.service.stored_options is stored_options
+    assert menu.service.saved_scanned_pages == {1: "recognized"}


### PR DESCRIPTION
## Link to issue number:

N/A

### Summary of the issue:

Continuous reading can reach an empty page before automatic OCR finishes, causing reading to stop or pages to be skipped. Some OCR dialogs can also reset the current book's OCR state when canceled.

### Description of how this pull request fixes the issue:

- Prefetches up to two following pages.
- Prevents automatic navigation until the next page is ready.
- Discards obsolete OCR results without moving focus.
- Preserves book OCR state when dialogs are canceled.
- Keeps Image To Text OCR state separate from the current book.

### Testing performed:

Manual testing.

### Known issues with pull request:

OCR operations already running in the engine cannot be interrupted; obsolete results are ignored.
