### PR TITLE
Avoid repeated legacy EPUB parsing

### DIFF
--- a/bookworm/document/formats/epub.py
+++ b/bookworm/document/formats/epub.py
@@ -1,7 +1,7 @@
-
 from __future__ import annotations
 
 import collections.abc
+import hashlib
 import os
 import string
 from functools import cached_property, lru_cache
@@ -65,7 +65,7 @@ class EpubDocument(SinglePageDocument):
     def read(self):
         super().read()
         self.epub = ebooklib.epub.read_epub(self.get_file_system_path())
-        self.structure = StructuredHtmlParser.from_string(self.html_content)
+        self.structure = self._parse_html_content()
         self._storage_text = self.structure.get_storage_text()
         self._text_position_map = self.structure.text_position_map
         self.toc = self.parse_epub()
@@ -130,13 +130,39 @@ class EpubDocument(SinglePageDocument):
     def get_storage_content(self):
         return self._storage_text
 
+    def _parse_html_content(self, *, include_images=True):
+        normalized_html_content = StructuredHtmlParser.preprocess_html_string(self.html_content)
+        self._legacy_content_cache_key = (
+            f"legacy-text-v1:{hashlib.sha256(normalized_html_content.encode('utf-8')).hexdigest()}"
+        )
+        return StructuredHtmlParser.from_lxml_html_tree(
+            lxml_html.fromstring(normalized_html_content),
+            include_images=include_images,
+        )
+
     def get_legacy_content(self):
         if hasattr(self, "_legacy_content"):
             return self._legacy_content
-        self._legacy_content = StructuredHtmlParser.from_string(
-            self.html_content,
-            include_images=False,
-        ).get_text()
+        try:
+            with Cache(
+                self._get_cache_directory(), eviction_policy="least-frequently-used"
+            ) as cache:
+                if (cached_legacy_content := cache.get(self._legacy_content_cache_key)) is not None:
+                    self._legacy_content = cached_legacy_content.decode("utf-8")
+                    return self._legacy_content
+        except Exception:
+            log.warning("Failed to read cached legacy EPUB text.", exc_info=True)
+        self._legacy_content = self._parse_html_content(include_images=False).get_text()
+        try:
+            with Cache(
+                self._get_cache_directory(), eviction_policy="least-frequently-used"
+            ) as cache:
+                cache.set(
+                    self._legacy_content_cache_key,
+                    self._legacy_content.encode("utf-8"),
+                )
+        except Exception:
+            log.warning("Failed to cache legacy EPUB text.", exc_info=True)
         return self._legacy_content
 
     def get_text_position_map(self):
@@ -392,21 +418,32 @@ class EpubDocument(SinglePageDocument):
 
     @cached_property
     def html_content(self):
-        cache = Cache(self._get_cache_directory(), eviction_policy="least-frequently-used")
         cache_key = self.uri.to_uri_string()
         document_path = self.get_file_system_path()
-        if (cached_html_content := cache.get(cache_key)) and not cache_utils.is_document_modified(
-            cache_key, document_path, cache
-        ):
-            return cached_html_content.decode("utf-8")
+        try:
+            with Cache(
+                self._get_cache_directory(), eviction_policy="least-frequently-used"
+            ) as cache:
+                if (
+                    cached_html_content := cache.get(cache_key)
+                ) and not cache_utils.is_document_modified(cache_key, document_path, cache):
+                    return cached_html_content.decode("utf-8")
+        except Exception:
+            log.warning("Failed to read cached EPUB HTML.", exc_info=True)
         html_content_gen = ((item.file_name, item.content) for item in self.epub_html_items)
         buf = StringIO()
         for filename, html_content in html_content_gen:
             buf.write(self.prefix_html_ids(filename, html_content))
             buf.write("\n<br/>\n")
         html_content = self.build_html(title=self.epub.title, body_content=buf.getvalue())
-        cache.set(cache_key, html_content.encode("utf-8"))
-        cache_utils.set_document_modified_time(cache_key, document_path, cache)
+        try:
+            with Cache(
+                self._get_cache_directory(), eviction_policy="least-frequently-used"
+            ) as cache:
+                cache.set(cache_key, html_content.encode("utf-8"))
+                cache_utils.set_document_modified_time(cache_key, document_path, cache)
+        except Exception:
+            log.warning("Failed to cache EPUB HTML.", exc_info=True)
         return html_content
 
     def prefix_html_ids(self, filename, html):

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -1,10 +1,13 @@
+import os
 from pathlib import Path
+from unittest.mock import Mock
 
+from diskcache import Cache
 from ebooklib import epub
-import pytest
 
-from bookworm.document.uri import DocumentUri
+from bookworm.document import cache_utils
 from bookworm.document.formats.epub import EpubDocument
+from bookworm.document.uri import DocumentUri
 
 
 def temp_book(title: str = "Sample book") -> epub.EpubBook:
@@ -101,3 +104,62 @@ def test_internal_link_resolution_prefers_exact_href_over_suffix_match(tmp_path)
     start, stop = target.position
 
     assert text[start:stop].strip() == "Right target"
+
+
+def test_legacy_content_uses_disk_cache(asset, tmp_path, monkeypatch):
+    monkeypatch.setattr(EpubDocument, "_get_cache_directory", lambda _: tmp_path / "cache")
+    uri = DocumentUri.from_filename(asset("The Diary of a Nobody.epub"))
+    first_document = EpubDocument(uri)
+    first_document.read()
+    legacy_content = first_document.get_legacy_content()
+
+    second_document = EpubDocument(uri)
+    second_document.read()
+    monkeypatch.setattr(
+        EpubDocument,
+        "_parse_html_content",
+        Mock(side_effect=AssertionError("legacy content should be loaded from disk cache")),
+    )
+
+    assert second_document.get_legacy_content() == legacy_content
+
+
+def test_legacy_cache_uses_the_html_that_was_parsed(asset, tmp_path, monkeypatch):
+    monkeypatch.setattr(EpubDocument, "_get_cache_directory", lambda _: tmp_path / "cache")
+    epub_path = tmp_path / "book.epub"
+    epub_path.write_bytes(Path(asset("epub30-spec.epub")).read_bytes())
+    original_mtime = epub_path.stat().st_mtime
+    uri = DocumentUri.from_filename(epub_path)
+    original_document = EpubDocument(uri)
+    original_document.read()
+
+    epub_path.write_bytes(Path(asset("roman.epub")).read_bytes())
+    os.utime(epub_path, (original_mtime + 2, original_mtime + 2))
+    original_legacy_content = original_document.get_legacy_content()
+    replacement_document = EpubDocument(uri)
+    replacement_document.read()
+
+    assert replacement_document.get_legacy_content() != original_legacy_content
+
+
+def test_epub_cache_failures_fall_back_to_in_memory_parsing(asset, tmp_path, monkeypatch):
+    cache_directory = tmp_path / "cache"
+    monkeypatch.setattr(EpubDocument, "_get_cache_directory", lambda _: cache_directory)
+    uri = DocumentUri.from_filename(asset("The Diary of a Nobody.epub"))
+    original_document = EpubDocument(uri)
+    original_document.read()
+    expected_content = original_document.get_content()
+    expected_legacy_content = original_document.get_legacy_content()
+    with Cache(cache_directory) as cache:
+        cache.set(original_document._legacy_content_cache_key, b"\xff")
+    monkeypatch.setattr(
+        cache_utils,
+        "is_document_modified",
+        Mock(side_effect=OSError("cache validation failed")),
+    )
+
+    replacement_document = EpubDocument(uri)
+    replacement_document.read()
+
+    assert replacement_document.get_content() == expected_content
+    assert replacement_document.get_legacy_content() == expected_legacy_content


### PR DESCRIPTION
## Link to issue number:

N/A

### Summary of the issue:

Opening an EPUB with legacy database records requires both the current structured text and the image-free text model used by Bookworm 2026.1.

These paths previously normalized the complete combined HTML independently. The legacy parser also ran again after restarting Bookworm, even when the parsed EPUB content had not changed. On large EPUBs this added several seconds to document loading.

### Description of how this pull request fixes the issue:

- Normalizes the combined EPUB HTML once per document instance.
- Creates a fresh lxml tree for each current or legacy parser pass.
- Stores generated legacy text in the existing EPUB disk cache under a versioned key derived from the SHA-256 of the normalized HTML that was actually parsed.
- Prevents a reused URI with different parsed content from receiving unrelated legacy text from the cache.
- Opens and closes EPUB cache handles for each operation, preventing `cache.db` from remaining locked on Windows.
- Falls back to in-memory parsing when cache reads, decoding, metadata checks, or writes fail.
- Does not add database fields, migrations, dependencies, or new cache infrastructure.

The current and legacy Inscriptis passes remain separate because they intentionally produce different image and table layouts.

### Testing performed:

- Focused automated coverage passed for EPUB parsing and legacy content-hash behavior.
- Parsed `算法（第4版）（图灵图书）.epub` through both the previous and optimized paths and compared display text, storage text, legacy image-free text, and all 2,917 image storage ranges; every output was identical.
- Measured the legacy image-free pass at approximately 5.45 seconds on a cold lookup and 0.017-0.024 seconds on cached lookups.
- Replaced an EPUB at the same URI and confirmed the new parsed HTML receives a different legacy cache entry.
- Confirmed corrupt or unavailable cache data falls back to correct in-memory parsing.

### Known issues with pull request:

The first legacy lookup still requires a separate image-free Inscriptis pass to reproduce the text model used by older profiles.

The existing combined-HTML cache still uses file modification time for invalidation. A file changed while deliberately preserving its modification time may require clearing the EPUB cache.

If legacy text parsing semantics change in a future release, the `legacy-text-v1` cache version must be incremented.