### PR TITLE
Avoid quadratic image range mapping during EPUB hashing

### DIFF
--- a/bookworm/structured_text/structured_html_parser.py
+++ b/bookworm/structured_text/structured_html_parser.py
@@ -370,11 +370,19 @@ class StructuredHtmlParser(Inscriptis):
         )
 
     def iter_image_storage_ranges(self):
-        for image_info in self._get_visible_image_elements():
-            yield image_info, self.display_to_storage_range(
-                image_info.text_range.start,
-                image_info.text_range.stop,
+        storage_ranges = {
+            (replacement.display_start, replacement.display_stop): TextRange(
+                replacement.storage_start,
+                replacement.storage_stop,
             )
+            for replacement in self._text_position_map.replacements
+        }
+        for image_info in self._get_visible_image_elements():
+            display_range = image_info.text_range.astuple()
+            storage_range = storage_ranges.get(display_range)
+            if storage_range is None:
+                storage_range = self.display_to_storage_range(*display_range)
+            yield image_info, storage_range
 
     @staticmethod
     def _get_image_label(image):

--- a/tests/test_embedded_images.py
+++ b/tests/test_embedded_images.py
@@ -244,6 +244,32 @@ def test_structured_html_parser_uses_stable_storage_placeholders():
         ).astuple() == (start, stop)
 
 
+def test_image_storage_ranges_do_not_depend_on_image_order(monkeypatch):
+    parser = StructuredHtmlParser.from_string(
+        """
+        <html><body>
+            <img src="images/first.png" alt="First image">
+            <img src="images/second.png" alt="Second image">
+        </body></html>
+        """
+    )
+    expected = {
+        image_info.src: parser.display_to_storage_range(*image_info.text_range)
+        for image_info in parser._get_visible_image_elements()
+    }
+    parser._image_elements.reverse()
+    monkeypatch.setattr(
+        StructuredHtmlParser,
+        "display_to_storage_range",
+        lambda *_args, **_kwargs: pytest.fail("exact image ranges should not require a scan"),
+    )
+
+    assert {
+        image_info.src: storage_range
+        for image_info, storage_range in parser.iter_image_storage_ranges()
+    } == expected
+
+
 def test_structured_html_parser_keeps_range_stops_before_following_images():
     parser = StructuredHtmlParser.from_string(
         """


### PR DESCRIPTION
## Link to issue number:

N/A

### Summary of the issue:

EPUB content hashing converts every embedded image display range to its storage range.

Each conversion previously scanned the complete list of text replacements. Documents containing many images therefore performed quadratic work. The affected EPUB contains 2,917 image elements.

### Description of how this pull request fixes the issue:

`iter_image_storage_ranges()` now builds a display-range-to-storage-range lookup from the replacements already generated by `TextPositionMap`.

Each image is resolved by its exact display range. The existing general mapping method remains as a fallback for unexpected or malformed ranges.

This reduces the normal image range mapping path from O(n²) to O(n) without relying on image and replacement list ordering.

### Testing performed:

- Ran 80 relevant automated regression tests covering embedded images and content hashing.
- Reversed the internal order of two images and confirmed both images still received the correct storage ranges without using the general scanning fallback.
- Compared all 2,917 image storage ranges generated for `算法（第4版）（图灵图书）.epub`; every range was identical before and after the change.
- Compared the final EPUB content hashes and confirmed they were identical.
- Measured content-hash generation at 7.434 seconds before the change and 0.444 seconds after the change, an improvement of approximately 16.7×.

### Known issues with pull request:

None known. Unexpected image ranges retain the previous general mapping behavior as a compatibility fallback.
