### PR TITLE
Fix EPUB TOC and internal links with differing path bases

### DIFF
--- a/bookworm/document/formats/epub.py
+++ b/bookworm/document/formats/epub.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import collections.abc
 import hashlib
 import os
+import posixpath
 import string
 from functools import cached_property, lru_cache
 from io import StringIO
@@ -252,16 +253,21 @@ class EpubDocument(SinglePageDocument):
         return len(href_parts) <= len(item_parts) and item_parts[-len(href_parts) :] == href_parts
 
     def resolve_link(self, link_range) -> LinkTarget:
-        href = urllib_parse.unquote(self.structure.link_targets[link_range])
+        raw_href = self.structure.link_targets[link_range]
+        href = urllib_parse.unquote(raw_href)
         if is_external_url(href):
             return LinkTarget(url=href, is_external=True)
+        resolved_href = self._resolve_epub_html_href(raw_href)
+        lookup_href = urllib_parse.unquote(resolved_href or raw_href)
         id_ranges = {
             urllib_parse.unquote(html_id): text_range
             for html_id, text_range in self.structure.html_id_ranges.items()
         }
-        if text_range := id_ranges.get(href):
+        if text_range := id_ranges.get(lookup_href):
             return LinkTarget(url=href, is_external=False, page=None, position=text_range)
-        href_with_boundary = f"/{href.removeprefix('./')}"
+        if resolved_href is not None:
+            return None
+        href_with_boundary = f"/{lookup_href.removeprefix('./')}"
         for html_id, text_range in id_ranges.items():
             if html_id.endswith(href_with_boundary):
                 return LinkTarget(url=href, is_external=False, page=None, position=text_range)
@@ -321,17 +327,49 @@ class EpubDocument(SinglePageDocument):
         return items
 
     def get_epub_html_item_by_href(self, href):
+        href = posixpath.normpath(href)
         if epub_item := self.epub.get_item_with_href(href):
             return epub_item
-        item_name = PurePosixPath(href).name
-        return more_itertools.first(
-            (
-                item
-                for item in self.epub_html_items
-                if PurePosixPath(item.file_name).name == item_name
-            ),
-            None,
-        )
+        href_parts = PurePosixPath(href).parts
+        while href_parts and href_parts[0] == "..":
+            href_parts = href_parts[1:]
+        relative_href = PurePosixPath(*href_parts).as_posix()
+        if relative_href != href and (epub_item := self.epub.get_item_with_href(relative_href)):
+            return epub_item
+        # ponytail: this linear manifest scan is tiny for normal EPUBs; index paths if it profiles hot.
+        suffix_matches = [
+            (self._path_suffix_match_length(item.file_name, relative_href), item)
+            for item in self.epub_html_items
+        ]
+        best_length = max((length for length, _item in suffix_matches), default=0)
+        best_matches = [item for length, item in suffix_matches if length == best_length]
+        if best_length and len(best_matches) == 1:
+            return best_matches[0]
+        return None
+
+    @staticmethod
+    def _path_suffix_match_length(first, second):
+        first_parts = PurePosixPath(posixpath.normpath(first)).parts
+        second_parts = PurePosixPath(posixpath.normpath(second)).parts
+        suffix_length = 0
+        for first_part, second_part in zip(reversed(first_parts), reversed(second_parts)):
+            if first_part != second_part:
+                break
+            suffix_length += 1
+        return suffix_length if suffix_length == min(len(first_parts), len(second_parts)) else 0
+
+    def _resolve_epub_html_href(self, href):
+        try:
+            parsed_href = urllib_parse.urlsplit(href)
+        except ValueError:
+            return None
+        if parsed_href.scheme or parsed_href.netloc or not parsed_href.path:
+            return None
+        path = urllib_parse.unquote(parsed_href.path)
+        if epub_item := self.get_epub_html_item_by_href(path):
+            fragment = parsed_href.fragment
+            return f"{epub_item.file_name}#{fragment}" if fragment else epub_item.file_name
+        return None
 
     def parse_epub(self):
         root = Section(
@@ -398,7 +436,7 @@ class EpubDocument(SinglePageDocument):
                     pager=SINGLE_PAGE_DOCUMENT_PAGER,
                     level=current_level,
                     parent=parent,
-                    data={"href": entry.href.lstrip("./")},
+                    data={"href": self._resolve_epub_html_href(entry.href) or entry.href},
                 )
                 yield sect
             else:
@@ -408,7 +446,7 @@ class EpubDocument(SinglePageDocument):
                     level=current_level,
                     pager=SINGLE_PAGE_DOCUMENT_PAGER,
                     parent=parent,
-                    data={"href": epub_sect.href.lstrip("./")},
+                    data={"href": self._resolve_epub_html_href(epub_sect.href) or epub_sect.href},
                 )
                 yield sect
                 yield from self.add_toc_entry(

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -74,13 +74,26 @@ def test_internal_link_resolution_prefers_exact_href_over_suffix_match(tmp_path)
     )
     link_chapter = epub_chapter(
         "link.xhtml",
-        '<p><a href="chap.xhtml#same">Go exact target</a></p>',
+        '<p><a href="chap.xhtml#same">Go exact target</a></p>'
+        '<p><a href="OEBPS/chap.xhtml#same">Go normalized target</a></p>'
+        '<p><a href="BOOK/chapter.xhtml#same">Missing fragment</a></p>',
     )
     right_target = epub_chapter(
         "chap.xhtml",
         '<h1 id="same">Right target</h1><p>Right body</p>',
     )
-    for item in (wrong_target, link_chapter, right_target):
+    missing_fragment_target = epub_chapter("chapter.xhtml", "<h1>Root target</h1>")
+    wrong_fragment_target = epub_chapter(
+        "vol/chapter.xhtml",
+        '<h1 id="same">Wrong fragment target</h1>',
+    )
+    for item in (
+        wrong_target,
+        link_chapter,
+        right_target,
+        missing_fragment_target,
+        wrong_fragment_target,
+    ):
         book.add_item(item)
     book.add_item(epub.EpubNcx())
     book.add_item(epub.EpubNav())
@@ -88,22 +101,96 @@ def test_internal_link_resolution_prefers_exact_href_over_suffix_match(tmp_path)
         epub.Link("link.xhtml", "Link", "link"),
         epub.Link("chap.xhtml#same", "Right", "right"),
     )
-    book.spine = ["nav", wrong_target, link_chapter, right_target]
+    book.spine = [
+        "nav",
+        wrong_target,
+        link_chapter,
+        right_target,
+        missing_fragment_target,
+        wrong_fragment_target,
+    ]
     epub_path = tmp_path / "suffix_match.epub"
     epub.write_epub(epub_path, book, {})
     document = EpubDocument(DocumentUri.from_filename(epub_path))
     document.read()
     text = document.get_content()
-    link_range = next(
+    for href, label in (
+        ("chap.xhtml#same", "Go exact target"),
+        ("OEBPS/chap.xhtml#same", "Go normalized target"),
+    ):
+        link_range = next(
+            text_range
+            for text_range, target_href in document.structure.link_targets.items()
+            if target_href == href and text[text_range[0] : text_range[1]] == label
+        )
+        target = document.resolve_link(link_range)
+        start, stop = target.position
+
+        assert target.url == href
+        assert text[start:stop].strip() == "Right target"
+
+    missing_fragment_range = next(
         text_range
-        for text_range, href in document.structure.link_targets.items()
-        if href == "chap.xhtml#same" and text[text_range[0] : text_range[1]] == "Go exact target"
+        for text_range, target_href in document.structure.link_targets.items()
+        if target_href == "BOOK/chapter.xhtml#same"
     )
+    assert document.resolve_link(missing_fragment_range) is None
 
-    target = document.resolve_link(link_range)
-    start, stop = target.position
 
-    assert text[start:stop].strip() == "Right target"
+def test_toc_resolution_matches_unique_manifest_path_suffix(tmp_path, monkeypatch):
+    book = epub.EpubBook()
+    book.set_title("nested navigation")
+    book.set_language("en")
+    chapter = epub_chapter(
+        "Text/chapter.xhtml",
+        '<h1 id="part">Target heading</h1><p>Target body</p>',
+    )
+    basename_collision = epub_chapter(
+        "chapter.xhtml",
+        '<h1 id="part">Wrong heading</h1>',
+    )
+    book.add_item(basename_collision)
+    book.add_item(chapter)
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.toc = (epub.Link("Text/chapter.xhtml#part", "Target", "target"),)
+    book.spine = ["nav", basename_collision, chapter]
+    epub_path = tmp_path / "nested_navigation.epub"
+    epub.write_epub(epub_path, book, {})
+    monkeypatch.setattr(EpubDocument, "_get_cache_directory", lambda _: tmp_path / "cache")
+    document = EpubDocument(DocumentUri.from_filename(epub_path))
+    document.read()
+    document.epub.toc = (epub.Link("../BOOK/Text/chapter.xhtml#part", "Target", "target"),)
+
+    section = next(document.parse_epub().iter_children())
+
+    assert document.get_content()[section.text_range.as_slice()].strip() == "Target heading"
+
+
+def test_epub_html_href_suffix_match_must_be_unique():
+    book = epub.EpubBook()
+    first = epub_chapter("vol1/chapter.xhtml", "<p>First</p>")
+    second = epub_chapter("vol2/chapter.xhtml", "<p>Second</p>")
+    book.add_item(first)
+    book.add_item(second)
+    document = EpubDocument(None)
+    document.epub = book
+    document.__dict__["epub_html_items"] = (first, second)
+
+    assert (
+        document._resolve_epub_html_href("../BOOK/vol2/chapter.xhtml?cache=1#part%201")
+        == "vol2/chapter.xhtml#part%201"
+    )
+    assert document._resolve_epub_html_href("chapter.xhtml#part") is None
+    assert document._resolve_epub_html_href("https://example.com/chapter.xhtml") is None
+    assert document._resolve_epub_html_href("https://[invalid/chapter.xhtml") is None
+
+    root = epub_chapter("chapter.xhtml", "<p>Root</p>")
+    book.add_item(root)
+    document.__dict__["epub_html_items"] = (root, first, second)
+    assert (
+        document._resolve_epub_html_href("../vol2/chapter.xhtml#part") == "vol2/chapter.xhtml#part"
+    )
 
 
 def test_legacy_content_uses_disk_cache(asset, tmp_path, monkeypatch):


### PR DESCRIPTION
## Link to issue number:

N/A — reported with a local EPUB.

### Summary of the issue:

Some EPUBs keep their navigation files at the archive root while the package and chapters are stored in a subdirectory. EbookLib may then expose navigation paths such as `OEBPS/002.xhtml` or `../OEBPS/002.xhtml`, while Bookworm indexes the same chapter as `002.xhtml`.

Literal path matching caused TOC entries to return to the beginning and prevented in-document links from opening with Ctrl+Enter.

### Description of how this pull request fixes the issue:

Resolve EPUB navigation paths against the loaded HTML manifest. Exact paths take priority, followed by a unique most-specific path suffix match.

Ambiguous matches are not guessed, and anchor lookup remains scoped to the selected document to prevent cross-document redirects.

### Testing performed:

Manual testing:

- Opened the reported EPUB in Bookworm.
- Verified navigation through the Bookworm TOC.
- Verified in-document TOC links using Ctrl+Enter.

Unit testing:

- Added coverage for exact paths, parent-relative paths, duplicate basenames, ambiguous matches, and missing fragments.
- All 232 tests pass.

### Known issues with pull request:

Full `xml:base` and URI-base resolution is outside the scope of this change. Ambiguous targets intentionally remain unresolved.
